### PR TITLE
Build our own Prow component images

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -40,9 +40,17 @@ git_repository(
     tag = "v0.5.1",
 )
 
+
 load("@io_bazel_rules_docker//docker:docker.bzl", "docker_repositories", "docker_pull")
 
 docker_repositories()
+
+load(
+    "@io_bazel_rules_docker//go:image.bzl",
+    _go_repositories = "repositories",
+)
+
+_go_repositories()
 
 git_repository(
     name = "io_bazel_rules_k8s",

--- a/hack/print-workspace-status.sh
+++ b/hack/print-workspace-status.sh
@@ -21,10 +21,8 @@ set -o pipefail
 git_commit="$(git describe --tags --always --dirty)"
 build_date="$(date -u '+%Y%m%d')"
 docker_tag="v${build_date}-${git_commit}"
-# TODO(fejta): retire STABLE_PROW_REPO
 cat <<EOF
-STABLE_DOCKER_REPO ${DOCKER_REPO_OVERRIDE:-gcr.io/k8s-testimages}
-STABLE_PROW_REPO ${PROW_REPO_OVERRIDE:-gcr.io/k8s-prow}
+STABLE_DOCKER_REPO ${DOCKER_REPO_OVERRIDE:-eu.gcr.io/jetstack-build-infra}
 STABLE_PROW_CONTEXT build-infra
 STABLE_BUILD_CONTEXT libvirt
 STABLE_BUILD_GIT_COMMIT ${git_commit}

--- a/prow/README.md
+++ b/prow/README.md
@@ -4,32 +4,38 @@ This directory contains manifests used for the deployment of the Prow cluster.
 
 ## Updating Prow
 
-If you make any changes to the manifests here, you will need to **manually**
-run Bazel to apply these to production.
+The core Prow components are automatically built from our own fork of the test-infra
+repository, and applied to our production build cluster.
 
-We do *not* currently automate the roll-out of the manifests in this repository.
+In order to upgrade Prow to a new version, you will first need to change the
+[WORKSPACE](../WORKSPACE) file in the root of this repository to reference
+the desired revision.
 
-You can 'apply' the latest changes in this repository using:
+For example, you should change the `commit` here appropriately:
+
+```
+git_repository(
+    name = "test_infra",
+    commit = "a8cee5a60a2d9476341cf843867221a8bd18a3e8",
+    remote = "https://github.com/kubernetes/test-infra.git",
+)
+```
+
+Once this is done, you can use Bazel to build, push and deploy the relevant new
+images:
 
 ```
 $ bazel run //prow/cluster:production.apply
 ```
 
-In order to find connections details for the 'build-infra' and 'libvirt' clusters,
+We do *not* currently automate the roll-out of the manifests in this repository.
+This means that someone with privileged access must run the `production.apply`
+job.
+
+In order to find connection details for the 'build-infra' and 'libvirt' clusters,
 you will need to ensure you have two contexts already correctly configured.
 Namely, `build-infra` and `libvirt`. Bazel will use the contexts with these names
 to apply changes to Prow.
 
 You can see where these context names are hardcoded in the [hack/print-workspace-status.sh](hack/print-workspace-status.sh)
 file.
-
-## TODO
-
-Instead of explicitly specifying image tags in the deployment manifests, we can
-instead automatically build and push docker images based on the chosen revision
-of jetstack/test-infra we have defined in the WORKSPACE file.
-
-This will make it easier to update Prow, and also mean we can easily control what
-version of test-infra is deployed to our production cluster.
-
-We can use [rules_k8s](https://github.com/bazelbuild/rules_k8s) for this.

--- a/prow/cluster/BUILD.bazel
+++ b/prow/cluster/BUILD.bazel
@@ -5,27 +5,71 @@ load("//prow:prow.bzl", "release", "component", "MULTI_KIND", "BUILD_CONTEXT")
 
 release(
     "production",
-    component("branchprotector", "cronjob"),
-    component("deck", "service", "deployment", "rbac"),
+    component("branchprotector", "cronjob",
+        images = {
+            "eu.gcr.io/jetstack-build-infra/prow-branchprotector:latest": "//prow/images:branchprotector",
+        },
+    ),
+    component("deck", "service", "deployment", "rbac",
+        images = {
+            "eu.gcr.io/jetstack-build-infra/prow-deck:latest": "//prow/images:deck",
+        },
+    ),
     component("gce-ssd-retain", "storageclass"),
-    component("ghproxy", "service", "deployment"),
-    component("hook", "service", "deployment", "rbac"),
-    component("horologium", "deployment", "rbac"),
+    component("ghproxy", "service", "deployment",
+        images = {
+            "eu.gcr.io/jetstack-build-infra/prow-ghproxy:latest": "//prow/images:ghproxy",
+        },
+    ),
+    component("hook", "service", "deployment", "rbac",
+        images = {
+            "eu.gcr.io/jetstack-build-infra/prow-hook:latest": "//prow/images:hook",
+        },
+    ),
+    component("horologium", "deployment", "rbac",
+        images = {
+            "eu.gcr.io/jetstack-build-infra/prow-horologium:latest": "//prow/images:horologium",
+        },
+    ),
     component("lego", "deployment"),
     component(
         "mem-limit-range",
         "limitrange",
         context = BUILD_CONTEXT,
     ),
-    component("plank", "deployment", "rbac"),
+    component("plank", "deployment", "rbac",
+        images = {
+            "eu.gcr.io/jetstack-build-infra/prow-plank:latest": "//prow/images:plank",
+        },
+    ),
     component("prowjob", "customresourcedefinition"),
     component("pushgateway", "deployment"),
-    component("sinker", "deployment", "rbac"),
-    component("splice", "deployment"),
-    component("tide", "service", "deployment", "rbac"),
+    component("sinker", "deployment", "rbac",
+        images = {
+            "eu.gcr.io/jetstack-build-infra/prow-sinker:latest": "//prow/images:sinker",
+        },
+    ),
+    component("splice", "deployment",
+        images = {
+            "eu.gcr.io/jetstack-build-infra/prow-splice:latest": "//prow/images:splice",
+        },
+    ),
+    component("tide", "service", "deployment", "rbac",
+        images = {
+            "eu.gcr.io/jetstack-build-infra/prow-tide:latest": "//prow/images:tide",
+        },
+    ),
     component("tls-ing", "ingress"),
-    component("tot", "service", "deployment"),
-    component("needs-rebase", "deployment", "service"),
+    component("tot", "service", "deployment",
+            images = {
+            "eu.gcr.io/jetstack-build-infra/prow-tot:latest": "//prow/images:tot",
+        },
+    ),
+    component("needs-rebase", "deployment", "service",
+        images = {
+            "eu.gcr.io/jetstack-build-infra/prow-needs-rebase:latest": "//prow/images:needs-rebase",
+        },
+    ),
 )
 
 filegroup(

--- a/prow/cluster/branchprotector_cronjob.yaml
+++ b/prow/cluster/branchprotector_cronjob.yaml
@@ -14,7 +14,7 @@ spec:
         spec:
           containers:
           - name: branchprotector
-            image: gcr.io/k8s-prow/branchprotector:v20180827-b14cf3e25
+            image: eu.gcr.io/jetstack-build-infra/prow-branchprotector:latest
             args:
             - --config-path=/etc/config/config.yaml
             - --job-config-path=/etc/job-config

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -34,7 +34,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20180827-b14cf3e25
+        image: eu.gcr.io/jetstack-build-infra/prow-deck:latest
         imagePullPolicy: Always
         ports:
           - name: http

--- a/prow/cluster/ghproxy_deployment.yaml
+++ b/prow/cluster/ghproxy_deployment.yaml
@@ -48,7 +48,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-testimages/ghproxy:latest
+        image: eu.gcr.io/jetstack-build-infra/prow-ghproxy:latest
         imagePullPolicy: Always
         args:
         - --cache-dir=/cache

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -34,9 +34,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        # Using a custom image that include the DCO sign-off checker plugin
-        # until https://github.com/kubernetes/test-infra/pull/9197 merges.
-        image: eu.gcr.io/jetstack-build-infra/hook:20180829-a6ba34-dco
+        image: eu.gcr.io/jetstack-build-infra/prow-hook:latest
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/horologium_deployment.yaml
+++ b/prow/cluster/horologium_deployment.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20180827-b14cf3e25
+        image: eu.gcr.io/jetstack-build-infra/prow-horologium:latest
         args:
         - --job-config-path=/etc/job-config
         volumeMounts:

--- a/prow/cluster/needs-rebase_deployment.yaml
+++ b/prow/cluster/needs-rebase_deployment.yaml
@@ -28,7 +28,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase
-        image: gcr.io/k8s-prow/needs-rebase:v20180827-b14cf3e25
+        image: eu.gcr.io/jetstack-build-infra/prow-needs-rebase:latest
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: "plank" # Uncomment for use with RBAC
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:v20180827-b14cf3e25
+        image: eu.gcr.io/jetstack-build-infra/prow-plank:latest
         args:
         - --tot-url=http://tot
         - --dry-run=false

--- a/prow/cluster/sinker_deployment.yaml
+++ b/prow/cluster/sinker_deployment.yaml
@@ -17,7 +17,7 @@ spec:
         args:
         - --build-cluster=/etc/cluster/cluster
         - --job-config-path=/etc/job-config
-        image: gcr.io/k8s-prow/sinker:v20180827-b14cf3e25
+        image: eu.gcr.io/jetstack-build-infra/prow-sinker:latest
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/cluster/splice_deployment.yaml
+++ b/prow/cluster/splice_deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: splice
-        image: gcr.io/k8s-prow/splice:v20180827-b14cf3e25
+        image: eu.gcr.io/jetstack-build-infra/prow-splice:latest
         args:
         - --job-config-path=/etc/job-config
         volumeMounts:

--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: "tide" # Uncomment for use with RBAC
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20180827-b14cf3e25
+        image: eu.gcr.io/jetstack-build-infra/prow-tide:latest
         args:
         - --dry-run=false
         - --github-endpoint=http://ghproxy

--- a/prow/cluster/tot_deployment.yaml
+++ b/prow/cluster/tot_deployment.yaml
@@ -40,7 +40,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: tot
-        image: gcr.io/k8s-prow/tot:v20180827-b14cf3e25
+        image: eu.gcr.io/jetstack-build-infra/prow-tot:latest
         imagePullPolicy: Always
         args:
         - -storage=/store/tot.json

--- a/prow/images/BUILD.bazel
+++ b/prow/images/BUILD.bazel
@@ -1,0 +1,67 @@
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+
+go_image(
+    name = "branchprotector",
+    binary = "@test_infra//prow/cmd/branchprotector",
+    visibility = ["//prow:__subpackages__"],
+)
+
+go_image(
+    name = "deck",
+    binary = "@test_infra//prow/cmd/deck",
+    visibility = ["//prow:__subpackages__"],
+)
+
+go_image(
+    name = "ghproxy",
+    binary = "@test_infra//ghproxy",
+    visibility = ["//prow:__subpackages__"],
+)
+
+go_image(
+    name = "hook",
+    binary = "@test_infra//prow/cmd/hook",
+    visibility = ["//prow:__subpackages__"],
+)
+
+go_image(
+    name = "horologium",
+    binary = "@test_infra//prow/cmd/horologium",
+    visibility = ["//prow:__subpackages__"],
+)
+
+go_image(
+    name = "plank",
+    binary = "@test_infra//prow/cmd/plank",
+    visibility = ["//prow:__subpackages__"],
+)
+
+go_image(
+    name = "sinker",
+    binary = "@test_infra//prow/cmd/sinker",
+    visibility = ["//prow:__subpackages__"],
+)
+
+go_image(
+    name = "splice",
+    binary = "@test_infra//prow/cmd/splice",
+    visibility = ["//prow:__subpackages__"],
+)
+
+go_image(
+    name = "tide",
+    binary = "@test_infra//prow/cmd/tide",
+    visibility = ["//prow:__subpackages__"],
+)
+
+go_image(
+    name = "tot",
+    binary = "@test_infra//prow/cmd/tot",
+    visibility = ["//prow:__subpackages__"],
+)
+
+go_image(
+    name = "needs-rebase",
+    binary = "@test_infra//prow/external-plugins/needs-rebase",
+    visibility = ["//prow:__subpackages__"],
+)


### PR DESCRIPTION
This switches us to build our own Prow component images from the test-infra repo named in our WORKSPACE file.

This means that bumping Prow will simply require updating the reference in our Bazel workspace - Bazel will then take care of building, pushing and deploying these new images.

I've updated the README accordingly with this info.