### PR TITLE
Add slim bazelbuild image

### DIFF
--- a/images/bazelbuild/Dockerfile
+++ b/images/bazelbuild/Dockerfile
@@ -1,0 +1,38 @@
+# Copyright 2018 The Jetstack contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Includes bazel only
+FROM ubuntu:16.04
+LABEL maintainer="james@jetstack.io"
+
+# add env we can debug with the image name:tag
+ARG IMAGE_ARG
+ENV IMAGE=${IMAGE_ARG}
+
+ARG BAZEL_VERSION
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    pkg-config \
+    zip \
+    g++ \
+    zlib1g-dev \
+    unzip \
+    python
+
+RUN INSTALLER="bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"; \
+    DOWNLOAD_URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/${INSTALLER}"; \
+    wget -q "${DOWNLOAD_URL}" && \
+    chmod +x "${INSTALLER}" && "./${INSTALLER}" && rm "${INSTALLER}"
+
+WORKDIR /workspace

--- a/images/bazelbuild/Makefile
+++ b/images/bazelbuild/Makefile
@@ -1,0 +1,45 @@
+# Copyright 2018 The Jetstack contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+IMG = gcr.io/jetstack-build-infra-images/bazelbuild
+TAG := $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
+
+LATEST_BAZEL_VERSION=0.16.1
+BAZEL_VERSIONS=$(LATEST_BAZEL_VERSION)
+
+all: build
+
+do_build = \
+	docker build --pull --build-arg BAZEL_VERSION=$(VERSION) --build-arg IMAGE_ARG=$(IMG):$(TAG)-$(VERSION) -t $(IMG):$(TAG)-$(VERSION) .;\
+	docker tag $(IMG):$(TAG)-$(VERSION) $(IMG):latest-$(VERSION);\
+	echo Built $(IMG):$(TAG)-$(VERSION) and tagged with latest-$(VERSION);\
+	[ "$(VERSION)" == "$(LATEST_BAZEL_VERSION)" ] &&\
+	docker tag $(IMG):$(TAG)-$(VERSION) $(IMG):latest-latest &&\
+	echo tagged $(IMG) with latest-latest tag;
+
+do_push = \
+	docker push $(IMG):$(TAG)-$(VERSION);\
+	docker push $(IMG):latest-$(VERSION);\
+	echo Pushed $(IMG) with $(TAG)-$(VERSION) and latest-$(VERSION) tags;\
+	[ "$(VERSION)" == "$(LATEST_BAZEL_VERSION)" ] &&\
+	docker push $(IMG):latest-latest &&\
+	echo Pushed $(IMG) with latest-latest tag;
+
+build:
+	@$(foreach VERSION,$(BAZEL_VERSIONS),$(do_build))
+
+push: build
+	@$(foreach VERSION,$(BAZEL_VERSIONS),$(do_push))
+
+.PHONY: all build push

--- a/images/bazelbuild/README.md
+++ b/images/bazelbuild/README.md
@@ -1,0 +1,5 @@
+# bazelbuild
+
+A slim image containing *only* Bazel.
+
+This image can be used as a basis for any pure-bazel project.


### PR DESCRIPTION
Adds a bazelbuild image to be used by 'decorated' build jobs.

This image will not work without decoration, as the image does not contain gcloud nor runner script.

This image will be used for testing the `jetstack/testing` repo itself, and in future for cert-manager too.
