### PR TITLE
Update jobs to reference old images

### DIFF
--- a/config/jobs/cert-manager/cert-manager-optional.yaml
+++ b/config/jobs/cert-manager/cert-manager-optional.yaml
@@ -30,7 +30,7 @@ presubmits:
         key: dedicated
         operator: Equal
       containers:
-      - image: gcr.io/jetstack-build-infra/cert-manager-minikube-in-go-v1.7.15:0.14
+      - image: gcr.io/jetstack-build-infra/minikube-in-go-v1.7.15:0.14
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -63,7 +63,7 @@ presubmits:
         key: dedicated
         operator: Equal
       containers:
-      - image: gcr.io/jetstack-build-infra/cert-manager-minikube-in-go-v1.8.10:0.14
+      - image: gcr.io/jetstack-build-infra/minikube-in-go-v1.8.10:0.14
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"

--- a/config/jobs/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager-periodics.yaml
@@ -23,7 +23,7 @@ periodics:
       key: dedicated
       operator: Equal
     containers:
-    - image: gcr.io/jetstack-build-infra/cert-manager-minikube-in-go-v1.7.15:0.14
+    - image: gcr.io/jetstack-build-infra/minikube-in-go-v1.7.15:0.14
       args:
       - "--repo=github.com/jetstack/cert-manager=master"
       - "--root=/go/src"
@@ -51,7 +51,7 @@ periodics:
       key: dedicated
       operator: Equal
     containers:
-    - image: gcr.io/jetstack-build-infra/cert-manager-minikube-in-go-v1.8.10:0.14
+    - image: gcr.io/jetstack-build-infra/minikube-in-go-v1.8.10:0.14
       args:
       - "--repo=github.com/jetstack/cert-manager=master"
       - "--root=/go/src"

--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -71,7 +71,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/jetstack-build-infra/cert-mmanager-gcloud-in-go:0.12
+      - image: gcr.io/jetstack-build-infra/gcloud-in-go:0.12
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -109,7 +109,7 @@ presubmits:
         key: dedicated
         operator: Equal
       containers:
-      - image: gcr.io/jetstack-build-infra/cert-manager-minikube-in-go-v1.9.6:0.14
+      - image: gcr.io/jetstack-build-infra/minikube-in-go-v1.9.6:0.14
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"

--- a/config/jobs/navigator/navigator-presubmits.yaml
+++ b/config/jobs/navigator/navigator-presubmits.yaml
@@ -1,0 +1,280 @@
+# minikube size job templates
+.minikube_medium: &minikube_medium
+  resources:
+    requests:
+      cpu: 3800m
+      memory: 12Gi
+
+presubmits:
+  jetstack/navigator:
+  - name: pull-navigator-bazel-verify
+    agent: kubernetes
+    context: pull-navigator-bazel-verify
+    always_run: false
+    rerun_command: "/test pull-navigator-bazel-verify"
+    trigger: "(?m)^/test pull-navigator-bazel-verify,?(\\s+|$)"
+    labels:
+      preset-service-account: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/jetstack-build-infra/bazelbuild:v20180321-d7679e93b-0.11.1
+        imagePullPolicy: IfNotPresent
+        args:
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+        - "--upload=gs://jetstack-logs/pr-logs"
+        - "--scenario=kubernetes_bazel"
+        - "--" # end bootstrap args, scenario args below
+        - --test=//cmd/... //pkg/... //internal/... //plugin/...
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "2Gi"
+
+  - name: pull-navigator-e2e-v1-9
+    context: pull-navigator-e2e-v1-9
+    always_run: false
+    trigger: "(?m)^/test( bazel-e2e( v?1.9)?|)( \\[.+\\])?$"
+    rerun_command: "/test bazel-e2e v1.9"
+    skip_report: false
+    max_concurrency: 4
+    agent: kubernetes
+    labels:
+      preset-service-account: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      libvirt-socket: "true"
+      minikube-support: "true"
+      minikube-medium: "true"
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/libvirt: ""
+      # Note: this is not supported yet by prow PodSpec, taint temporary removed
+      tolerations:
+      - effect: NoSchedule
+        key: dedicated
+        operator: Equal
+      containers:
+      - image: gcr.io/jetstack-build-infra/minikube-in-go-v1.9.6:0.12
+        args:
+        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src"
+        - "--upload=gs://jetstack-logs/pr-logs"
+        - "--clean"
+        - "--job=$(JOB_NAME)"
+        - "--scenario=minikube"
+        - "--"
+        - make
+        - e2e-test
+        <<: *minikube_medium
+        securityContext:
+          privileged: true
+
+  - name: navigator-quick-verify
+    always_run: true
+    skip_report: false
+    context: navigator-quick-verify
+    max_concurrency: 2
+    agent: kubernetes
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/jetstack-build-infra/gcloud-in-go:0.10
+        args:
+        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src"
+        - "--upload=gs://jetstack-logs/pr-logs"
+        - "--clean"
+        resources:
+          requests:
+            cpu: 1
+            memory: 1Gi
+    trigger: "(?m)^/test( all| verify| quick verify),?(\\s+|$)"
+    rerun_command: "/test verify"
+
+  - name: navigator-e2e-v1-7
+    context: navigator-e2e-v1-7
+    always_run: true
+    trigger: "(?m)^/test( all| e2e( v?1.7)?|)( \\[.+\\])?$"
+    rerun_command: "/test e2e v1.7"
+    skip_report: false
+    max_concurrency: 4
+    agent: kubernetes
+    labels:
+      preset-service-account: "true"
+      libvirt-socket: "true"
+      minikube-support: "true"
+      minikube-medium: "true"
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/libvirt: ""
+      # Note: this is not supported yet by prow PodSpec, taint temporary removed
+      tolerations:
+      - effect: NoSchedule
+        key: dedicated
+        operator: Equal
+      containers:
+      - image: gcr.io/jetstack-build-infra/minikube-in-go-v1.7.15:0.12
+        args:
+        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src"
+        - "--upload=gs://jetstack-logs/pr-logs"
+        - "--clean"
+        <<: *minikube_medium
+        securityContext:
+          privileged: true
+
+  - name: navigator-e2e-v1-8
+    context: navigator-e2e-v1-8
+    always_run: true
+    trigger: "(?m)^/test( all| e2e( v?1.8)?|)( \\[.+\\])?$"
+    rerun_command: "/test e2e v1.8"
+    skip_report: false
+    max_concurrency: 4
+    agent: kubernetes
+    labels:
+      preset-service-account: "true"
+      libvirt-socket: "true"
+      minikube-support: "true"
+      minikube-medium: "true"
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/libvirt: ""
+      # Note: this is not supported yet by prow PodSpec, taint temporary removed
+      tolerations:
+      - effect: NoSchedule
+        key: dedicated
+        operator: Equal
+      containers:
+      - image: gcr.io/jetstack-build-infra/minikube-in-go-v1.8.10:0.12
+        args:
+        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src"
+        - "--upload=gs://jetstack-logs/pr-logs"
+        - "--clean"
+        <<: *minikube_medium
+        securityContext:
+          privileged: true
+
+  - name: navigator-e2e-v1-9
+    context: navigator-e2e-v1-9
+    always_run: true
+    trigger: "(?m)^/test( all| e2e( v?1.9)?|)( \\[.+\\])?$"
+    rerun_command: "/test e2e v1.9"
+    skip_report: false
+    max_concurrency: 4
+    agent: kubernetes
+    labels:
+      preset-service-account: "true"
+      libvirt-socket: "true"
+      minikube-support: "true"
+      minikube-medium: "true"
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/libvirt: ""
+      # Note: this is not supported yet by prow PodSpec, taint temporary removed
+      tolerations:
+      - effect: NoSchedule
+        key: dedicated
+        operator: Equal
+      containers:
+      - image: gcr.io/jetstack-build-infra/minikube-in-go-v1.9.6:0.12
+        args:
+        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src"
+        - "--upload=gs://jetstack-logs/pr-logs"
+        - "--clean"
+        <<: *minikube_medium
+        securityContext:
+          privileged: true
+
+  - name: navigator-e2e-v1-10
+    context: navigator-e2e-v1-10
+    always_run: false
+    trigger: "(?m)^/test( all| e2e( v?1.10)?|)( \\[.+\\])?$"
+    rerun_command: "/test e2e v1.10"
+    skip_report: false
+    max_concurrency: 4
+    agent: kubernetes
+    labels:
+      preset-service-account: "true"
+      libvirt-socket: "true"
+      minikube-support: "true"
+      minikube-medium: "true"
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/libvirt: ""
+      # Note: this is not supported yet by prow PodSpec, taint temporary removed
+      tolerations:
+      - effect: NoSchedule
+        key: dedicated
+        operator: Equal
+      containers:
+      - image: gcr.io/jetstack-build-infra/minikube-in-go-v1.10.0:0.12
+        args:
+        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src"
+        - "--upload=gs://jetstack-logs/pr-logs"
+        - "--clean"
+        <<: *minikube_medium
+        securityContext:
+          privileged: true
+
+  - name: navigator-kubetest-e2e
+    agent: kubernetes
+    context: pull-navigator-kubetest
+    rerun_command: "/test kubetest-e2e"
+    trigger: "(?m)^/test kubetest-e2e,?(\\s+|$)"
+    always_run: false
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/bootstrap:v20180122-6fd3aef1a
+        args:
+        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src"
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://jetstack-logs/pr-logs"
+        - "--timeout=90"
+        env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: "true"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        volumeMounts:
+        # - name: cache-ssd
+        #   mountPath: /root/.cache
+        # - name: docker-graph
+        #   mountPath: /docker-graph
+        - name: var-lib-docker
+          mountPath: /var/lib/docker
+        # TODO: not sure if we can run parallel builds
+        # ports:
+        # - containerPort: 9999
+        #   hostPort: 9999
+        resources:
+          requests:
+            cpu: 3800m
+            memory: "12Gi"
+      volumes:
+      # TODO: re-enable cache volumes
+      # - name: cache-ssd
+      #   hostPath:
+      #     path: /mnt/disks/ssd0
+      # - name: docker-graph
+      #   hostPath:
+      #     path: /mnt/disks/ssd0/docker-graph
+      - name: var-lib-docker
+        emptyDir: {}
+

--- a/config/jobs/tarmak/extras-presubmits.yaml
+++ b/config/jobs/tarmak/extras-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/jetstack-build-infra/gcloud-in-go:0.15
+      - image: gcr.io/jetstack-build-infra/gcloud-in-go:0.10
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -35,7 +35,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/jetstack-build-infra/gcloud-in-go:0.15
+      - image: gcr.io/jetstack-build-infra/gcloud-in-go:0.10
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -59,7 +59,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/jetstack-build-infra/gcloud-in-go:0.15
+      - image: gcr.io/jetstack-build-infra/gcloud-in-go:0.10
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -83,7 +83,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/jetstack-build-infra/gcloud-in-go:0.15
+      - image: gcr.io/jetstack-build-infra/gcloud-in-go:0.10
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"

--- a/config/jobs/tarmak/tarmak-postsubmits.yaml
+++ b/config/jobs/tarmak/tarmak-postsubmits.yaml
@@ -15,7 +15,7 @@ postsubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/jetstack-build-infra/sphinx-docs:0.2
+      - image: gcr.io/jetstack-build-infra/sphinx-docs:0.1
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/workspace"

--- a/config/jobs/tarmak/tarmak-presubmits.yaml
+++ b/config/jobs/tarmak/tarmak-presubmits.yaml
@@ -9,7 +9,7 @@
     preset-service-account: "true"
   spec:
     containers:
-    - image: gcr.io/jetstack-build-infra/tarmak-ruby:2.4.0
+    - image: gcr.io/jetstack-build-infra/ruby:2.4.0
       args:
       - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
       - "--root=/workspace"
@@ -51,7 +51,7 @@
       key: dedicated
       operator: Equal
     containers:
-    - image: gcr.io/jetstack-build-infra/tarmak-ruby:2.4.0
+    - image: gcr.io/jetstack-build-infra/ruby:2.4.0
       args:
       - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
       - "--root=/workspace"
@@ -401,7 +401,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/jetstack-build-infra/gcloud-in-go:0.15
+      - image: gcr.io/jetstack-build-infra/gcloud-in-go:0.7
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -424,7 +424,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/jetstack-build-infra/sphinx-docs:0.2
+      - image: gcr.io/jetstack-build-infra/sphinx-docs:0.1
         args:
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/workspace"

--- a/config/jobs/testing/testing-periodics.yaml
+++ b/config/jobs/testing/testing-periodics.yaml
@@ -1,0 +1,137 @@
+periodics:
+
+- name: periodic-testing-retester
+  interval: 20m  # Retest at most 1 PR per 20m, which should not DOS the queue.
+  agent: kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/commenter:v20170808-abf66782
+      args:
+      - |-
+        --query=is:pr
+        -label:do-not-merge
+        -label:do-not-merge/blocked-paths
+        -label:do-not-merge/cherry-pick-not-approved
+        -label:do-not-merge/hold
+        -label:do-not-merge/release-note-label-needed
+        -label:do-not-merge/work-in-progress
+        label:lgtm
+        label:approved
+        status:failure
+        -label:needs-rebase
+        -label:needs-ok-to-test
+        -label:"cncf-cla: no"
+        repo:jetstack/navigator
+        repo:jetstack/cert-manager
+      - --token=/etc/token/bot-github-token
+      - |-
+        --comment=/retest
+        This bot automatically retries jobs that failed/flaked on approved PRs (send feedback to [jetstack](https://github.com/jetstack)).
+        Review the [full test history](https://jetstack-build-infra.appspot.com/pr/{{.Number}}) for this PR.
+        Silence the bot with an `/lgtm cancel` comment for consistent failures.
+      - --template
+      - --ceiling=1
+      - --confirm
+      - --updated=30m
+      volumeMounts:
+      - name: token
+        mountPath: /etc/token
+    volumes:
+    - name: token
+      secret:
+        secretName: retest-bot-token
+
+- name: periodic-testing-close
+  interval: 1h
+  agent: kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/commenter:v20170808-abf66782
+      args:
+      - |-
+        --query=repo:jetstack/cert-manager
+        -label:lifecycle/frozen
+        label:lifecycle/rotten
+      - --updated=720h
+      - --token=/etc/token/bot-github-token
+      - |-
+        --comment=Rotten issues close after 30d of inactivity.
+        Reopen the issue with `/reopen`.
+        Mark the issue as fresh with `/remove-lifecycle rotten`.
+        Send feedback to [jetstack](https://github.com/jetstack).
+        /close
+      - --template
+      - --ceiling=10
+      - --confirm
+      volumeMounts:
+      - name: token
+        mountPath: /etc/token
+    volumes:
+    - name: token
+      secret:
+        secretName: retest-bot-token
+
+- name: periodic-testing-rotten
+  interval: 1h
+  agent: kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/commenter:v20170808-abf66782
+      args:
+      - |-
+        --query=repo:jetstack/cert-manager
+        -label:lifecycle/frozen
+        label:lifecycle/stale
+        -label:lifecycle/rotten
+      - --updated=720h
+      - --token=/etc/token/bot-github-token
+      - |-
+        --comment=Stale issues rot after 30d of inactivity.
+        Mark the issue as fresh with `/remove-lifecycle rotten`.
+        Rotten issues close after an additional 30d of inactivity.
+        If this issue is safe to close now please do so with `/close`.
+        Send feedback to [jetstack](https://github.com/jetstack).
+        /lifecycle rotten
+        /remove-lifecycle stale
+      - --template
+      - --ceiling=10
+      - --confirm
+      volumeMounts:
+      - name: token
+        mountPath: /etc/token
+    volumes:
+    - name: token
+      secret:
+        secretName: retest-bot-token
+
+- name: periodic-testing-stale
+  interval: 1h
+  agent: kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/commenter:v20170808-abf66782
+      args:
+      - |-
+        --query=repo:jetstack/cert-manager
+        -label:lifecycle/frozen
+        -label:lifecycle/stale
+        -label:lifecycle/rotten
+      - --updated=2160h
+      - --token=/etc/token/bot-github-token
+      - |-
+        --comment=Issues go stale after 90d of inactivity.
+        Mark the issue as fresh with `/remove-lifecycle stale`.
+        Stale issues rot after an additional 30d of inactivity and eventually close.
+        If this issue is safe to close now please do so with `/close`.
+        Send feedback to [jetstack](https://github.com/jetstack).
+        /lifecycle stale
+      - --template
+      - --ceiling=10
+      - --confirm
+      volumeMounts:
+      - name: token
+        mountPath: /etc/token
+    volumes:
+    - name: token
+      secret:
+        secretName: retest-bot-token


### PR DESCRIPTION
As part of the migration, I am initially going to just get this repo authoritative for Prow config.

The job config for bootstrap scripts will *for the time being* be loaded from the old jetstack/test-infra repo.

This should minimise disruption.

Once moved across, we can begin to update base images for all repos to reference this repository instead.