### PR TITLE
Build kind from kubernetes-sigs/kind

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -44,6 +44,12 @@ git_repository(
 )
 
 git_repository(
+    name = "kind",
+    commit = "35d67a6310dd76e7737c44ebb6164fc757e1f919",
+    remote = "https://github.com/kubernetes-sigs/kind.git",
+)
+
+git_repository(
     name = "io_kubernetes_build",
     commit = "84d52408a061e87d45aebf5a0867246bdf66d180",
     remote = "https://github.com/kubernetes/repo-infra.git",

--- a/images/cert-manager/e2e/BUILD.bazel
+++ b/images/cert-manager/e2e/BUILD.bazel
@@ -41,7 +41,7 @@ container_image(
 
 go_binary(
     name = "kind",
-    embed = ["@test_infra//kind:go_default_library"],
+    embed = ["@kind//:go_default_library"],
     goarch = "amd64",
     goos = "linux",
     pure = "on",


### PR DESCRIPTION
kind has moved out of test-infra, so we need to do this before we bump the test-infra fork any further.