### PR TITLE
Update katacoda-lint image with python3-yaml package

### DIFF
--- a/images/katacoda-lint/Dockerfile
+++ b/images/katacoda-lint/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get -y update \
    gnupg \
    jq \
    python3 \
+   python3-yaml \
    util-linux \
    uuid-runtime \
 && curl -fsSL https://deb.nodesource.com/setup_8.x | bash - \


### PR DESCRIPTION
Add python3-yaml for extracting Docker images from kubernetes manifest files as part of https://github.com/jetstack/katacoda-scenarios/pull/58