### PR TITLE
Bump Bazel to 0.18.0 in cert-manager tests

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -114,7 +114,10 @@ load("//def:container.bzl", "container_dockerfile")
 container_dockerfile(
     name = "bazelbuild",
     build_matrix = {
-        "BAZEL_VERSION": ["0.16.1"],
+        "BAZEL_VERSION": [
+            "0.16.1",
+            "0.18.0",
+        ],
     },
     dockerfile = "//images/bazelbuild:Dockerfile",
 )

--- a/config/jobs/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager-periodics.yaml
@@ -101,7 +101,7 @@ periodics:
     cert-manager-cloudflare-svc-acct: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/cert-manager-e2e:v20180918-cbbd73b-0.16.1
+    - image: eu.gcr.io/jetstack-build-infra-images/cert-manager-e2e:v20181022-34682de-0.18.0
       args:
       - runner
       - hack/ci/run-e2e-kind.sh

--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -40,7 +40,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/cert-manager-e2e:v20180918-cbbd73b-0.16.1
+      - image: eu.gcr.io/jetstack-build-infra-images/cert-manager-e2e:v20181022-34682de-0.18.0
         args:
         - runner
         - make
@@ -71,7 +71,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/cert-manager-e2e:v20180918-cbbd73b-0.16.1
+      - image: eu.gcr.io/jetstack-build-infra-images/cert-manager-e2e:v20181022-34682de-0.18.0
         args:
         - runner
         - make
@@ -99,7 +99,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/cert-manager-e2e:v20180918-cbbd73b-0.16.1
+      - image: eu.gcr.io/jetstack-build-infra-images/cert-manager-e2e:v20181022-34682de-0.18.0
         args:
         - runner
         - make
@@ -124,7 +124,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/cert-manager-e2e:v20180918-cbbd73b-0.16.1
+      - image: eu.gcr.io/jetstack-build-infra-images/cert-manager-e2e:v20181022-34682de-0.18.0
         args:
         - runner
         - make
@@ -149,7 +149,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/cert-manager-e2e:v20180918-cbbd73b-0.16.1
+      - image: eu.gcr.io/jetstack-build-infra-images/cert-manager-e2e:v20181022-34682de-0.18.0
         args:
         - runner
         - make
@@ -174,7 +174,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/cert-manager-e2e:v20180918-cbbd73b-0.16.1
+      - image: eu.gcr.io/jetstack-build-infra-images/cert-manager-e2e:v20181022-34682de-0.18.0
         args:
         - runner
         - make
@@ -204,7 +204,7 @@ presubmits:
       cert-manager-cloudflare-svc-acct: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/cert-manager-e2e:v20180918-cbbd73b-0.16.1
+      - image: eu.gcr.io/jetstack-build-infra-images/cert-manager-e2e:v20181022-34682de-0.18.0
         args:
         - runner
         - hack/ci/run-e2e-kind.sh

--- a/images/bazelbuild/BUILD.bazel
+++ b/images/bazelbuild/BUILD.bazel
@@ -16,8 +16,26 @@ filegroup(
 )
 
 container_image(
-    name = "image",
+    name = "image-0.16.1",
     base = "@bazelbuild//image.0.16.1",
+    files = [
+        ":create_bazel_cache_rcs.sh",
+        ":runner",
+        "//hack:coalesce.py",
+        "//images:barnacle",
+    ],
+    symlinks = {
+        "/usr/local/bin/barnacle": "/barnacle",
+        "/usr/local/bin/runner": "/runner",
+        "/usr/local/bin/coalesce.py": "/coalesce.py",
+        "/usr/local/bin/create_bazel_cache_rcs.sh": "/create_bazel_cache_rcs.sh",
+    },
+    visibility = ["//visibility:public"],
+)
+
+container_image(
+    name = "image-0.18.0",
+    base = "@bazelbuild//image.0.18.0",
     files = [
         ":create_bazel_cache_rcs.sh",
         ":runner",
@@ -36,7 +54,8 @@ container_image(
 container_bundle(
     name = "bazelbuild",
     images = {
-        "{STABLE_IMAGE_DOCKER_REPO}/bazelbuild:{STABLE_IMAGE_DOCKER_TAG}-0.16.1": ":image",
+        "{STABLE_IMAGE_DOCKER_REPO}/bazelbuild:{STABLE_IMAGE_DOCKER_TAG}-0.16.1": ":image-0.16.1",
+        "{STABLE_IMAGE_DOCKER_REPO}/bazelbuild:{STABLE_IMAGE_DOCKER_TAG}-0.18.0": ":image-0.18.0",
     },
     stamp = True,
 )

--- a/images/cert-manager/e2e/BUILD.bazel
+++ b/images/cert-manager/e2e/BUILD.bazel
@@ -19,24 +19,13 @@ filegroup(
 container_image(
     name = "image",
     # we can reuse the bazelbuild base image
-    base = "//images/bazelbuild:image",
-    env = {
-        "PATH": "/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-    },
+    base = "//images/bazelbuild:image-0.18.0",
     files = [
         ":kind",
-        "@dep_linux//file",
-        "@helm_linux//:helm",
     ],
     symlinks = {
-        "/usr/local/bin/helm": "/helm",
-        "/usr/local/bin/dep": "/dep-linux-amd64",
         "/usr/local/bin/kind": "/kind",
-        "/usr/local/go": "/go",
     },
-    tars = [
-        "@golang//file",
-    ],
 )
 
 go_binary(
@@ -50,7 +39,7 @@ go_binary(
 container_bundle(
     name = "e2e",
     images = {
-        "{STABLE_IMAGE_DOCKER_REPO}/cert-manager-e2e:{STABLE_IMAGE_DOCKER_TAG}-0.16.1": ":image",
+        "{STABLE_IMAGE_DOCKER_REPO}/cert-manager-e2e:{STABLE_IMAGE_DOCKER_TAG}-0.18.0": ":image",
     },
     stamp = True,
 )


### PR DESCRIPTION
This requires https://github.com/jetstack/cert-manager/pull/983 to pass, and is required for https://github.com/jetstack/cert-manager/pull/982