### PR TITLE
Revert "cert-manager: set skip_report: false on v1.12 job"

### DIFF
--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -238,7 +238,8 @@ presubmits:
     rerun_command: "/test e2e v1.11"
 
   - name: pull-cert-manager-e2e-v1-12
-    skip_report: false
+    # Set skip_report to true until we've validated the e2e passes
+    skip_report: true
     context: pull-cert-manager-e2e-v1-12
     # Match everything except PRs that only touch docs/
     always_run: false


### PR DESCRIPTION
This has been causing flakes - need to investigate what might be up with 1.12: https://github.com/jetstack/cert-manager/pull/976