### PR TITLE
Bazel bump

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -117,6 +117,7 @@ container_dockerfile(
         "BAZEL_VERSION": [
             "0.16.1",
             "0.18.0",
+            "0.21.0",
         ],
     },
     dockerfile = "//images/bazelbuild:Dockerfile",

--- a/images/bazelbuild/BUILD.bazel
+++ b/images/bazelbuild/BUILD.bazel
@@ -51,11 +51,30 @@ container_image(
     visibility = ["//visibility:public"],
 )
 
+container_image(
+    name = "image-0.21.0",
+    base = "@bazelbuild//image.0.21.0",
+    files = [
+        ":create_bazel_cache_rcs.sh",
+        ":runner",
+        "//hack:coalesce.py",
+        "//images:barnacle",
+    ],
+    symlinks = {
+        "/usr/local/bin/barnacle": "/barnacle",
+        "/usr/local/bin/runner": "/runner",
+        "/usr/local/bin/coalesce.py": "/coalesce.py",
+        "/usr/local/bin/create_bazel_cache_rcs.sh": "/create_bazel_cache_rcs.sh",
+    },
+    visibility = ["//visibility:public"],
+)
+
 container_bundle(
     name = "bazelbuild",
     images = {
         "{STABLE_IMAGE_DOCKER_REPO}/bazelbuild:{STABLE_IMAGE_DOCKER_TAG}-0.16.1": ":image-0.16.1",
         "{STABLE_IMAGE_DOCKER_REPO}/bazelbuild:{STABLE_IMAGE_DOCKER_TAG}-0.18.0": ":image-0.18.0",
+        "{STABLE_IMAGE_DOCKER_REPO}/bazelbuild:{STABLE_IMAGE_DOCKER_TAG}-0.21.0": ":image-0.21.0",
     },
     stamp = True,
 )


### PR DESCRIPTION
This PR adds a v0.21.0 bazelbuild image.

We also need to create a similar build of the cert-manager e2e image too.