### PR TITLE
Add a bazel test //... presumbit job

### DIFF
--- a/config/jobs/katacoda-scenarios/katacoda-scenarios-presubmits.yaml
+++ b/config/jobs/katacoda-scenarios/katacoda-scenarios-presubmits.yaml
@@ -24,3 +24,33 @@ presubmits:
             memory: 1Gi
     trigger: "(?m)^/test verify,?(\\s+|$)"
     rerun_command: "/test verify"
+  - name: pull-katacoda-scenarios-bazel
+    always_run: true
+    context: pull-katacoda-scenarios-bazel
+    max_concurrency: 2
+    agent: kubernetes
+    decorate: true
+    branches:
+    - master
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:v20181107-8aac55d-0.18.0
+        args:
+        - runner
+        - bazel
+        - test
+        - //...
+        resources:
+          requests:
+            cpu: 2
+            memory: 4Gi
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+    trigger: "(?m)^/test verify,?(\\s+|$)"
+    rerun_command: "/test verify"


### PR DESCRIPTION
* Run `bazel test //...` to run golang tests in the katacoda-scenarios repo
* Goes with https://github.com/jetstack/katacoda-scenarios/pull/123
* Enables Docker-in-Docker because some of the functional tests launch docker containers with temporary SSH daemons.