### PR TITLE
More Fixes for katacoda-scenarios bazel test config

### DIFF
--- a/config/jobs/katacoda-scenarios/katacoda-scenarios-presubmits.yaml
+++ b/config/jobs/katacoda-scenarios/katacoda-scenarios-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
     decoration_config:
       ssh_key_secrets:
       - jetstack-pulling-bot
+    clone_uri: "git@github.com:jetstack/katacoda-scenarios.git"
     branches:
     - master
     labels:


### PR DESCRIPTION
Fixes for https://github.com/jetstack/testing/pull/132

 * Use git+ssh URl for pulling private repo