### PR TITLE
Add KIND_TARGET env vars to cert-manager presubmits

### DIFF
--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -143,8 +143,12 @@ presubmits:
             cpu: 2
             memory: 6Gi
         env:
+        # TODO: remove this after https://github.com/jetstack/cert-manager/pull/1215 merges
         - name: KIND_IMAGE
           value: eu.gcr.io/jetstack-build-infra-images/kind:1.11.4-1
+        # The Bazel target used to build the kind cluster
+        - name: KIND_TARGET
+          value: //test/e2e:e2e-1.11
         securityContext:
           privileged: true
           capabilities:
@@ -196,8 +200,12 @@ presubmits:
             cpu: 2
             memory: 6Gi
         env:
+        # TODO: remove this after https://github.com/jetstack/cert-manager/pull/1215 merges
         - name: KIND_IMAGE
           value: eu.gcr.io/jetstack-build-infra-images/kind:1.12.2-1
+        # The Bazel target used to build the kind cluster
+        - name: KIND_TARGET
+          value: //test/e2e:e2e-1.12
         securityContext:
           privileged: true
           capabilities:


### PR DESCRIPTION
This will allow https://github.com/jetstack/cert-manager/pull/1215 to run tests against Kubernetes 1.12 clusters