### PR TITLE
Replace target_url with pr_status_base_url

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -175,7 +175,7 @@ presets:
     value: /etc/bazel-cache-credentials/credentials.json
 
 tide:
-  target_url: https://prow.build-infra.jetstack.net/tide.html
+  pr_status_base_url: https://prow.build-infra.jetstack.net/pr
   squash_label: tide/squash
   queries:
   - repos:


### PR DESCRIPTION
This fixes links on the tide status context, and directs users to the more-helpful PR status page (as k/k does)

/cc @kragniz 
