### PR TITLE
Adds kube-oidc-proxy e2e test for Kubernetes v1.14

### DIFF
--- a/config/jobs/kube-oidc-proxy/kube-oidc-proxy-presubmits.yaml
+++ b/config/jobs/kube-oidc-proxy/kube-oidc-proxy-presubmits.yaml
@@ -183,3 +183,54 @@ presubmits:
           type: Directory
     trigger: "(?m)^/test( e2e( v?1.13)?|)( \\[.+\\])?$"
     rerun_command: "/test e2e v1.13"
+
+  # kind based kube-oidc-proxy e2e job
+  - name: pull-kube-oidc-proxy-e2e-v1-14
+    context: pull-kube-oidc-proxy-e2e-v1-14
+    # Match everything except PRs that only touch docs/
+    always_run: true
+    optional: true
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    decoration_config:
+      ssh_key_secrets:
+      - jetstack-pulling-bot
+    clone_uri: "git@github.com:jetstack/kube-oidc-proxy.git"
+    branches:
+    - master
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:v20190320-1080345
+        workingDir: /go/src/github.com/jetstack/kube-oidc-proxy
+        args:
+        - hack/docker-start-wrapper.sh
+        - make
+        - e2e-1.14
+        resources:
+          requests:
+            cpu: 2
+            memory: 6Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+    trigger: "(?m)^/test( e2e( v?1.14)?|)( \\[.+\\])?$"
+    rerun_command: "/test e2e v1.14"

--- a/config/jobs/kube-oidc-proxy/kube-oidc-proxy-presubmits.yaml
+++ b/config/jobs/kube-oidc-proxy/kube-oidc-proxy-presubmits.yaml
@@ -137,7 +137,7 @@ presubmits:
   - name: pull-kube-oidc-proxy-e2e-v1-13
     context: pull-kube-oidc-proxy-e2e-v1-13
     # Match everything except PRs that only touch docs/
-    always_run: true
+    always_run: false
     optional: true
     max_concurrency: 4
     agent: kubernetes


### PR DESCRIPTION
Signed-off-by: JoshVanL <vleeuwenjoshua@gmail.com>
/cc @simonswine 
/cc @munnerz 

Think we should keep 1.11 for the time being.. EKS is still lagging for example :roll_eyes: 