### PR TITLE
Automate bumping ProwJob configs when new images are pushed

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -19,6 +19,7 @@ filegroup(
         "//images/bazelbuild:all-srcs",
         "//images/builder:all-srcs",
         "//prow:all-srcs",
+        "//tools/image-bumper:all-srcs",
     ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -102,3 +102,9 @@ go_repository(
     vcs = "git",
     importpath = "gopkg.in/yaml.v2",
 )
+
+git_repository(
+    name = "test_infra",
+    commit = "4d31f63924b8eb14211f19a2722125b8fa0040c9",
+    remote = "https://github.com/kubernetes/test-infra.git",
+)

--- a/config/jobs/testing/testing-trusted.yaml
+++ b/config/jobs/testing/testing-trusted.yaml
@@ -1,6 +1,32 @@
 presets:
 
 - labels:
+    preset-deployer-github-token: "true"
+  env:
+  - name: GITHUB_USER
+    value: jetstack-bot
+  - name: GITHUB_TOKEN_FILE
+    value: /etc/github/token
+  volumeMounts:
+  - name: github-token
+    mountPath: /etc/github
+  volumes:
+  - name: github-token
+    secret:
+      secretName: bot-github-token
+
+- labels:
+    preset-deployer-ssh-key: "true"
+  volumeMounts:
+  - name: ssh
+    mountPath: /root/.ssh
+  volumes:
+  - name: ssh
+    secret:
+      secretName: jetstack-bot-ssh-keys
+      defaultMode: 0400
+
+- labels:
     preset-deployer-service-account: "true"
   env:
   - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -45,9 +71,11 @@ postsubmits:
       preset-bazel-scratch-dir: "true"
       preset-image-deploy: "true"
       preset-deployer-service-account: "true"
+      preset-deployer-github-token: "true"
+      preset-deployer-ssh-key: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20190408-4d1853d-0.24.1
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20190409-ac1a0f9-0.24.1
         args:
         # Wrap the release script with the runner so we can use docker-in-docker
         - runner
@@ -74,9 +102,11 @@ postsubmits:
       preset-bazel-scratch-dir: "true"
       preset-image-deploy: "true"
       preset-deployer-service-account: "true"
+      preset-deployer-github-token: "true"
+      preset-deployer-ssh-key: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20190408-4d1853d-0.24.1
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20190409-ac1a0f9-0.24.1
         args:
         # Wrap the release script with the runner so we can use docker-in-docker
         - runner
@@ -103,6 +133,8 @@ postsubmits:
       preset-bazel-scratch-dir: "true"
       preset-image-deploy: "true"
       preset-deployer-service-account: "true"
+      preset-deployer-github-token: "true"
+      preset-deployer-ssh-key: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20190408-4d1853d-0.24.1
@@ -132,6 +164,8 @@ postsubmits:
       preset-bazel-scratch-dir: "true"
       preset-image-deploy: "true"
       preset-deployer-service-account: "true"
+      preset-deployer-github-token: "true"
+      preset-deployer-ssh-key: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20190408-4d1853d-0.24.1
@@ -161,6 +195,8 @@ postsubmits:
       preset-bazel-scratch-dir: "true"
       preset-image-deploy: "true"
       preset-deployer-service-account: "true"
+      preset-deployer-github-token: "true"
+      preset-deployer-ssh-key: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20190408-4d1853d-0.24.1
@@ -190,6 +226,8 @@ postsubmits:
       preset-bazel-scratch-dir: "true"
       preset-image-deploy: "true"
       preset-deployer-service-account: "true"
+      preset-deployer-github-token: "true"
+      preset-deployer-ssh-key: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20190408-4d1853d-0.24.1

--- a/images/builder/ci-runner.sh
+++ b/images/builder/ci-runner.sh
@@ -61,7 +61,6 @@ find "${WORKSPACE}/config/jobs" -type f -name '*.yaml' | \
     --image-regex "${PUSHED_IMAGE}"
 
 ensure-config() {
-  git config user.name &>/dev/null && git config user.email &>/dev/null && return 0
   local username="jetstack-bot"
   local email="jetstack-bot@users.noreply.github.com"
   echo "git config user.name=$username user.email=$email..." >&2

--- a/images/builder/ci-runner.sh
+++ b/images/builder/ci-runner.sh
@@ -34,8 +34,54 @@ echo "Generating docker credentials..."
 gcloud auth configure-docker --quiet
 
 echo "Executing builder..."
-bazel run \
+PUSHED_IMAGE=$(bazel run \
     //images/builder -- \
-    --build-dir "${WORKSPACE}"/"${BUILD_DIR}" "$@"
+    --build-dir "${WORKSPACE}"/"${BUILD_DIR}" "$@")
 
 echo "Build complete!"
+
+if [ -z "${PUSHED_IMAGE}" ]; then
+    echo "No image pushed to registry"
+    exit 0
+fi
+
+echo "Pushed image ${PUSHED_IMAGE}"
+echo
+
+user="${GITHUB_USER:-}"
+token="${GITHUB_TOKEN_FILE:-}"
+if [ -z "${user}" ] || [ -z "${token}" ]; then
+    echo "Skipping patching job configs"
+    exit 0
+fi
+
+echo "Patching YAML files for new image"
+find "${WORKSPACE}/config/jobs" -type f -name '*.yaml' | \
+    xargs bazel run //tools/image-bumper -- \
+    --image-regex "${PUSHED_IMAGE}"
+
+ensure-config() {
+  git config user.name &>/dev/null && git config user.email &>/dev/null && return 0
+  local username="jetstack-bot"
+  local email="jetstack-bot@users.noreply.github.com"
+  echo "git config user.name=$username user.email=$email..." >&2
+  git config user.name "$username"
+  git config user.email "$email"
+}
+ensure-config "$@"
+
+image_name=$(basename "${PUSHED_IMAGE}")
+title="Automatic bump of ${image_name} jobs"
+git add -A
+git commit -m "${title}"
+git push -f "git@github.com:${user}/testing.git" HEAD:autobump-"${image_name}"
+
+bazel run @test_infra//robots/pr-creator -- \
+    --github-token-path="${token}" \
+    --org jetstack --repo testing --branch master \
+    --title="${title}" --match-title="Bump ${image_name} jobs" \
+    --body="Automatically bumped jobs that referenced image ${PUSHED_IMAGE}" \
+    --source="${user}":autobump-"${image_name}" \
+    --confirm
+
+echo "Complete!"

--- a/tools/image-bumper/BUILD.bazel
+++ b/tools/image-bumper/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "github.com/example/project/tools/image-bumper",
+    visibility = ["//visibility:private"],
+)
+
+go_binary(
+    name = "image-bumper",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/tools/image-bumper/main.go
+++ b/tools/image-bumper/main.go
@@ -1,0 +1,212 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var (
+	imageRegexp = regexp.MustCompile(`\b(eu\.gcr\.io)/([a-z][a-z0-9-]{5,29}/[a-zA-Z0-9][a-zA-Z0-9_.-]+):([a-zA-Z0-9_.-]+)\b`)
+	tagRegexp   = regexp.MustCompile(`(v?\d{8}-(?:v\d(?:[.-]\d+)*-g)?[0-9a-f]{6,10}|latest)(-.+)?`)
+	tagCache    = make(map[string]string)
+)
+
+const (
+	imageHostPart  = 1
+	imageImagePart = 2
+	imageTagPart   = 3
+	tagVersionPart = 1
+	tagExtraPart   = 2
+)
+
+type manifest map[string]struct {
+	TimeCreatedMs string   `json:"timeCreatedMs"`
+	Tags          []string `json:"tag"`
+}
+
+func findLatestTag(imageHost, imageName, currentTag string) (string, error) {
+	k := imageHost + "/" + imageName + ":" + currentTag
+	if result, ok := tagCache[k]; ok {
+		return result, nil
+	}
+
+	currentTagParts := tagRegexp.FindStringSubmatch(currentTag)
+	if currentTagParts == nil {
+		return "", fmt.Errorf("couldn't figure out the current tag in %q", currentTag)
+	}
+	if currentTagParts[tagVersionPart] == "latest" {
+		return currentTag, nil
+	}
+
+	resp, err := http.Get("https://" + imageHost + "/v2/" + imageName + "/tags/list")
+	if err != nil {
+		return "", fmt.Errorf("couldn't fetch tag list: %v", err)
+	}
+
+	result := struct {
+		Manifest manifest `json:"manifest"`
+	}{}
+
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("couldn't parse tag information from registry: %v", err)
+	}
+
+	latestTag, err := pickBestTag(currentTagParts, result.Manifest)
+	if err != nil {
+		return "", err
+	}
+
+	tagCache[k] = latestTag
+
+	return latestTag, nil
+}
+
+func pickBestTag(currentTagParts []string, manifest manifest) (string, error) {
+	// The approach is to find the most recently created image that has the same suffix as the
+	// current tag. However, if we find one called "latest" (with appropriate suffix), we assume
+	// that's the latest regardless of when it was created.
+	var latestTime int64
+	latestTag := ""
+	for _, v := range manifest {
+		bestVariant := ""
+		override := false
+		for _, t := range v.Tags {
+			log.Printf("testing tag %s", t)
+			parts := tagRegexp.FindStringSubmatch(t)
+			if parts == nil {
+				continue
+			}
+			if parts[tagExtraPart] != currentTagParts[tagExtraPart] {
+				continue
+			}
+			if parts[tagVersionPart] == "latest" {
+				override = true
+				continue
+			}
+			if bestVariant == "" || len(t) < len(bestVariant) {
+				bestVariant = t
+			}
+		}
+		if bestVariant == "" {
+			continue
+		}
+		t, err := strconv.ParseInt(v.TimeCreatedMs, 10, 64)
+		if err != nil {
+			return "", fmt.Errorf("couldn't parse timestamp %q: %v", v.TimeCreatedMs, err)
+		}
+		if override || t > latestTime {
+			latestTime = t
+			latestTag = bestVariant
+			if override {
+				break
+			}
+		}
+	}
+
+	if latestTag == "" {
+		return "", fmt.Errorf("failed to find a good tag")
+	}
+
+	return latestTag, nil
+}
+
+func updateFile(path string, imageFilter *regexp.Regexp) error {
+	content, err := ioutil.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %v", path, err)
+	}
+
+	indexes := imageRegexp.FindAllSubmatchIndex(content, -1)
+	// Not finding any images is not an error.
+	if indexes == nil {
+		return nil
+	}
+
+	newContent := make([]byte, 0, len(content))
+	lastIndex := 0
+	for _, m := range indexes {
+		newContent = append(newContent, content[lastIndex:m[imageTagPart*2]]...)
+		host := string(content[m[imageHostPart*2]:m[imageHostPart*2+1]])
+		image := string(content[m[imageImagePart*2]:m[imageImagePart*2+1]])
+		tag := string(content[m[imageTagPart*2]:m[imageTagPart*2+1]])
+		lastIndex = m[1]
+
+		if tag == "" || (imageFilter != nil && !imageFilter.MatchString(host+"/"+image+":"+tag)) {
+			newContent = append(newContent, content[m[imageTagPart*2]:m[1]]...)
+			continue
+		}
+		log.Printf("calling findLatestTag %q %q %q", host, image, tag)
+		latest, err := findLatestTag(host, image, tag)
+		if err != nil {
+			log.Printf("Failed to update %s/%s:%s: %v.\n", host, image, tag, err)
+			newContent = append(newContent, content[m[imageTagPart*2]:m[1]]...)
+			continue
+		}
+		newContent = append(newContent, []byte(latest)...)
+	}
+	newContent = append(newContent, content[lastIndex:]...)
+	if err := ioutil.WriteFile(path, newContent, 0644); err != nil {
+		return fmt.Errorf("failed to write %s: %v", path, err)
+	}
+	return nil
+}
+
+type options struct {
+	imageRegex string
+	files      []string
+}
+
+func parseOptions() options {
+	var o options
+	flag.StringVar(&o.imageRegex, "image-regex", "", "Only touch images matching this regex")
+	flag.Parse()
+	o.files = flag.Args()
+	return o
+}
+
+func main() {
+	o := parseOptions()
+	var imageRegex *regexp.Regexp
+	if o.imageRegex != "" {
+		var err error
+		imageRegex, err = regexp.Compile(o.imageRegex)
+		if err != nil {
+			log.Fatalf("Failed to parse image-regex: %v\n", err)
+		}
+	}
+	for _, f := range o.files {
+		if err := updateFile(f, imageRegex); err != nil {
+			log.Printf("Failed to update %s: %v", f, err)
+		}
+	}
+	log.Println("Done.")
+	for before, after := range tagCache {
+		if strings.Split(before, ":")[1] == after {
+			continue
+		}
+		log.Printf("%s -> %s\n", before, after)
+	}
+}

--- a/tools/image-bumper/main.go
+++ b/tools/image-bumper/main.go
@@ -1,3 +1,5 @@
+// +skip_license_check
+
 /*
 Copyright 2019 The Kubernetes Authors.
 


### PR DESCRIPTION
Extend our existing ci-runner script to also handle creating PRs that bump image tags used in our ProwJobs when new images are published.

This is based off the image bumper in https://github.com/kubernetes/test-infra/pull/12119

Once that PR merges, we'll be able to remove the `tools/image-bumper` directory altogether and build directly from test-infra 😄 

/cc @simonswine 