### PR TITLE
Add experimental bazelbuild image

### DIFF
--- a/images/bazelbuild/Dockerfile
+++ b/images/bazelbuild/Dockerfile
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 # Includes bazel, docker-in-docker and gcloud
-FROM debian:stretch
+ARG DEBIAN_VERSION=stretch
+FROM debian:"${DEBIAN_VERSION}"
 LABEL maintainer="james@jetstack.io"
 
 #
@@ -46,10 +47,10 @@ RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID"
 # the pod logs, so we just comment out the call to it... :shrug:
 # TODO(benthelder): update docker version. This is pinned because of
 # https://github.com/kubernetes/test-infra/issues/6187
+ARG DOCKER_VERSION="17.09.1~ce-0~debian"
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends docker-ce=17.09.1~ce-0~debian && \
+    apt-get install -y --no-install-recommends docker-ce="${DOCKER_VERSION}" && \
     sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker
-
 
 # Move Docker's storage location
 RUN echo 'DOCKER_OPTS="${DOCKER_OPTS} --data-root=/docker-graph"' | \

--- a/images/bazelbuild/build.yaml
+++ b/images/bazelbuild/build.yaml
@@ -3,6 +3,11 @@ name: bazelbuild # Name of the image to be built
 # Variants allow multiple images to be built in a single build step, with
 # different build arguments for each build.
 variants:
+  experimental:
+    arguments:
+      BAZEL_VERSION: 0.24.1
+      DEBIAN_VERSION: stretch
+      DOCKER_VERSION: 5:18.09.4~3-0~debian-stretch
   "0.24.1":
     # Specify build arguments for this variant
     arguments:

--- a/images/builder/README.md
+++ b/images/builder/README.md
@@ -27,7 +27,7 @@ images:
 To build an image locally, from the root of this repository run:
 
 ```bash
-$ bazel run //images/builder -- images/bazelbuild
+$ bazel run //images/builder -- --build-dir=$(pwd)/images/bazelbuild
 ```
 
 ### Additional options
@@ -46,6 +46,7 @@ them available for templating in the `images` section of the `build.yaml` file.
 | _REGISTRY   | The image registry (specified as --registry)         | eu.gcr.io/jetstack-build-infra-images |
 | _DATE_STAMP | The current date stamp, useful for use in image tags | 20190407                              |
 | _GIT_REF    | The current git reference of the repository          | 2ba5d19                               |
+| _VARIANT    | The name of the variant being built, if any          | experimental                          |
 +-------------+------------------------------------------------------+---------------------------------------+
 
 Additionally, all global and variant-specific options will be provided to the


### PR DESCRIPTION
The intention is that this image tag can act as a staging ground for new bazel releases. I'm going to add a new cert-manager presubmit job so that we can catch build failures with new bazel versions early.

Signed-off-by: James Munnelly <james@munnelly.eu>