### PR TITLE
Require more CPUs and memory for cert-manager e2e

### DIFF
--- a/config/jobs/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager-periodics.yaml
@@ -74,8 +74,8 @@ periodics:
       - hack/ci/run-e2e-kind.sh
       resources:
         requests:
-          cpu: 2
-          memory: 6Gi
+          cpu: 4
+          memory: 8Gi
       env:
       # TODO: remove this after https://github.com/jetstack/cert-manager/pull/1215 merges
       - name: KIND_IMAGE
@@ -125,8 +125,8 @@ periodics:
       - hack/ci/run-e2e-kind.sh
       resources:
         requests:
-          cpu: 2
-          memory: 6Gi
+          cpu: 4
+          memory: 8Gi
       env:
       # TODO: remove this after https://github.com/jetstack/cert-manager/pull/1215 merges
       - name: KIND_IMAGE
@@ -176,8 +176,8 @@ periodics:
       - hack/ci/run-e2e-kind.sh
       resources:
         requests:
-          cpu: 2
-          memory: 6Gi
+          cpu: 4
+          memory: 8Gi
       env:
       # TODO: remove this after https://github.com/jetstack/cert-manager/pull/1215 merges
       - name: KIND_IMAGE

--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -185,8 +185,8 @@ presubmits:
         - hack/ci/run-e2e-kind.sh
         resources:
           requests:
-            cpu: 2
-            memory: 6Gi
+            cpu: 4
+            memory: 8Gi
         env:
         # TODO: remove this after https://github.com/jetstack/cert-manager/pull/1215 merges
         - name: KIND_IMAGE
@@ -241,8 +241,8 @@ presubmits:
         - hack/ci/run-e2e-kind.sh
         resources:
           requests:
-            cpu: 2
-            memory: 6Gi
+            cpu: 4
+            memory: 8Gi
         env:
         # TODO: remove this after https://github.com/jetstack/cert-manager/pull/1215 merges
         - name: KIND_IMAGE
@@ -296,8 +296,8 @@ presubmits:
         - hack/ci/run-e2e-kind.sh
         resources:
           requests:
-            cpu: 2
-            memory: 6Gi
+            cpu: 4
+            memory: 8Gi
         env:
         # TODO: remove this after https://github.com/jetstack/cert-manager/pull/1215 merges
         - name: KIND_IMAGE

--- a/config/jobs/cert-manager/releases/cert-manager-release-0.8.yaml
+++ b/config/jobs/cert-manager/releases/cert-manager-release-0.8.yaml
@@ -114,8 +114,8 @@ presubmits:
         - hack/ci/run-e2e-kind.sh
         resources:
           requests:
-            cpu: 2
-            memory: 6Gi
+            cpu: 4
+            memory: 8Gi
         env:
         # TODO: remove this after https://github.com/jetstack/cert-manager/pull/1215 merges
         - name: KIND_IMAGE
@@ -170,8 +170,8 @@ presubmits:
         - hack/ci/run-e2e-kind.sh
         resources:
           requests:
-            cpu: 2
-            memory: 6Gi
+            cpu: 4
+            memory: 8Gi
         env:
         # TODO: remove this after https://github.com/jetstack/cert-manager/pull/1215 merges
         - name: KIND_IMAGE
@@ -225,8 +225,8 @@ presubmits:
         - hack/ci/run-e2e-kind.sh
         resources:
           requests:
-            cpu: 2
-            memory: 6Gi
+            cpu: 4
+            memory: 8Gi
         env:
         # TODO: remove this after https://github.com/jetstack/cert-manager/pull/1215 merges
         - name: KIND_IMAGE

--- a/config/jobs/cert-manager/venafi-presubmits.yaml
+++ b/config/jobs/cert-manager/venafi-presubmits.yaml
@@ -17,8 +17,8 @@ presubmits:
         - ./start-demo.sh
         resources:
           requests:
-            cpu: 2
-            memory: 6Gi
+            cpu: 4
+            memory: 8Gi
         securityContext:
           privileged: true
           capabilities:


### PR DESCRIPTION
Some jobs have been failing due to resource starvation on nodes. Let's bump these values to make them a bit more realistic 😄