### PR TITLE
Fix scraping for plank

### DIFF
--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -46,6 +46,9 @@ spec:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --skip-report=true
+        ports:
+          - name: http
+            containerPort: 9090
         volumeMounts:
         - mountPath: /etc/cluster
           name: cluster


### PR DESCRIPTION
Prometheus annotations also need matching ports declaration in the
container

Signed-off-by: Christian Simon <simon@swine.de>

/assign @munnerz 