### PR TITLE
Rollback cert-manager previous release job to bazel 0.24.1

### DIFF
--- a/config/jobs/cert-manager/cert-manager-postsubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-postsubmits.yaml
@@ -104,7 +104,7 @@ postsubmits:
       preset-deployer-github-token: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20190925-a5657ed-0.27.1
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20190925-a5657ed-0.24.1
         args:
         # Wrap the release script with the runner so we can use docker-in-docker
         - runner


### PR DESCRIPTION
This job appears to be stuck - we had this problem in the past with newer Bazel versions on ~release-0.10, and it required Bazel fixes to resolve.

All other release-0.10 jobs use Bazel 0.24.1, and this is an outlier. Roll it back so we can get v0.10.1 out 😄 