### PR TITLE
Use bazelbuild 1.0.0 images in cert-manager

### DIFF
--- a/config/jobs/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager-periodics.yaml
@@ -15,7 +15,7 @@ periodics:
     preset-bazel-scratch-dir: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20191016-5d3fe7c-0.29.1
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20191016-5d3fe7c-1.0.0
       args:
       - runner
       - bazel
@@ -78,7 +78,7 @@ periodics:
     preset-venafi-tpp-credentials: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20191016-5d3fe7c-0.29.1
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20191016-5d3fe7c-1.0.0
       args:
       - runner
       - hack/ci/run-e2e-kind.sh
@@ -132,7 +132,7 @@ periodics:
     preset-venafi-tpp-credentials: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20191016-5d3fe7c-0.29.1
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20191016-5d3fe7c-1.0.0
       args:
       - runner
       - hack/ci/run-e2e-kind.sh
@@ -186,7 +186,7 @@ periodics:
     preset-venafi-tpp-credentials: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20191016-5d3fe7c-0.29.1
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20191016-5d3fe7c-1.0.0
       args:
       - runner
       - hack/ci/run-e2e-kind.sh
@@ -240,7 +240,7 @@ periodics:
     preset-venafi-tpp-credentials: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20191016-5d3fe7c-0.29.1
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20191016-5d3fe7c-1.0.0
       args:
       - runner
       - hack/ci/run-e2e-kind.sh
@@ -294,7 +294,7 @@ periodics:
     preset-venafi-tpp-credentials: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20191016-5d3fe7c-0.29.1
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20191016-5d3fe7c-1.0.0
       args:
       - runner
       - hack/ci/run-e2e-kind.sh
@@ -348,7 +348,7 @@ periodics:
     preset-venafi-tpp-credentials: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20191016-5d3fe7c-0.29.1
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20191016-5d3fe7c-1.0.0
       args:
       - runner
       - hack/ci/run-e2e-kind.sh

--- a/config/jobs/cert-manager/cert-manager-postsubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-postsubmits.yaml
@@ -48,7 +48,7 @@ postsubmits:
       preset-deployer-github-token: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20191016-5d3fe7c-0.29.1
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20191016-5d3fe7c-1.0.0
         args:
         # Wrap the release script with the runner so we can use docker-in-docker
         - runner
@@ -157,7 +157,7 @@ postsubmits:
       preset-cert-manager-publish-bot-credentials: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20191016-5d3fe7c-0.29.1
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20191016-5d3fe7c-1.0.0
         args:
         # Wrap the release script with the runner so we can use docker-in-docker
         - runner

--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -60,7 +60,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20191016-5d3fe7c-0.29.1
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20191016-5d3fe7c-1.0.0
         args:
         - runner
         - bazel
@@ -123,7 +123,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20191016-5d3fe7c-0.29.1
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20191016-5d3fe7c-1.0.0
         args:
         # Wrap the release script with the runner so we can use docker-in-docker
         - runner
@@ -162,7 +162,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20191016-5d3fe7c-0.29.1
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20191016-5d3fe7c-1.0.0
         args:
         - runner
         - make
@@ -194,7 +194,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20191016-5d3fe7c-0.29.1
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20191016-5d3fe7c-1.0.0
         args:
         - runner
         - make
@@ -230,7 +230,7 @@ presubmits:
       preset-venafi-tpp-credentials: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20191016-5d3fe7c-0.29.1
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20191016-5d3fe7c-1.0.0
         args:
         - runner
         - hack/ci/run-e2e-kind.sh
@@ -286,7 +286,7 @@ presubmits:
       preset-venafi-tpp-credentials: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20191016-5d3fe7c-0.29.1
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20191016-5d3fe7c-1.0.0
         args:
         - runner
         - hack/ci/run-e2e-kind.sh
@@ -342,7 +342,7 @@ presubmits:
       preset-venafi-tpp-credentials: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20191016-5d3fe7c-0.29.1
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20191016-5d3fe7c-1.0.0
         args:
         - runner
         - hack/ci/run-e2e-kind.sh
@@ -398,7 +398,7 @@ presubmits:
       preset-venafi-tpp-credentials: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20191016-5d3fe7c-0.29.1
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20191016-5d3fe7c-1.0.0
         args:
         - runner
         - hack/ci/run-e2e-kind.sh
@@ -453,7 +453,7 @@ presubmits:
       preset-venafi-tpp-credentials: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20191016-5d3fe7c-0.29.1
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20191016-5d3fe7c-1.0.0
         args:
         - runner
         - hack/ci/run-e2e-kind.sh
@@ -509,7 +509,7 @@ presubmits:
       preset-venafi-tpp-credentials: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20191016-5d3fe7c-0.29.1
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20191016-5d3fe7c-1.0.0
         args:
         - runner
         - hack/ci/run-e2e-kind.sh


### PR DESCRIPTION
This also bumps us to an image with a new docker version, as well as with the 'experimental' docker flag set 😄 