### PR TITLE
Add presubmit for preflight

### DIFF
--- a/config/jobs/preflight/OWNERS
+++ b/config/jobs/preflight/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- munnerz
+- j-fuentes
+reviewers:
+- munnerz
+- j-fuentes
+labels:
+- area/preflight

--- a/config/jobs/preflight/preflight-presubmits.yaml
+++ b/config/jobs/preflight/preflight-presubmits.yaml
@@ -1,0 +1,23 @@
+presubmits:
+  jetstack/preflight:
+
+  - name: pull-preflight-unit
+    cluster: gke
+    agent: kubernetes
+    decorate: true
+    always_run: true
+    max_concurrency: 8
+    spec:
+      containers:
+      - image: golang:1.12.7
+        args:
+        - make
+        - test
+        resources:
+          requests:
+            cpu: 500m
+            memory: 200Mi
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"


### PR DESCRIPTION
This adds a presubmit job for jetstack/preflight.

This one just runs the unit tests. If it works, I will continue adding more checks.