### PR TITLE
Bump golang version to 1.13.4 for preflight jobs

### DIFF
--- a/config/jobs/preflight/preflight-presubmits.yaml
+++ b/config/jobs/preflight/preflight-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
     max_concurrency: 8
     spec:
       containers:
-      - image: golang:1.12.7
+      - image: golang:1.13.4
         args:
         - make
         - test


### PR DESCRIPTION
Signed-off-by: Jose Fuentes <jsfuentescastillo@gmail.com>