### PR TITLE
Add cert-manager release-0.12 periodic job

### DIFF
--- a/config/jobs/cert-manager/releases/cert-manager-release-periodics.yaml
+++ b/config/jobs/cert-manager/releases/cert-manager-release-periodics.yaml
@@ -1,0 +1,54 @@
+periodics:
+
+- name: ci-cert-manager-release-next
+  interval: 2h
+  cluster: gke
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: jetstack
+    repo: cert-manager
+    base_ref: release-0.12
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-cloudflare-credentials: "true"
+    preset-venafi-tpp-credentials: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20191016-eff358a-1.0.0
+      args:
+      - runner
+      - hack/ci/run-e2e-kind.sh
+      resources:
+        requests:
+          cpu: 6
+          memory: 12Gi
+      env:
+      - name: K8S_VERSION
+        value: "1.16"
+      securityContext:
+        privileged: true
+        capabilities:
+          add: ["SYS_ADMIN"]
+      volumeMounts:
+      - mountPath: /lib/modules
+        name: modules
+        readOnly: true
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    volumes:
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+    dnsConfig:
+      options:
+        - name: ndots
+          value: "1"


### PR DESCRIPTION
We can use this job to give a signal on the upcoming release. We may consider adding a `-latest` variant here too in future (for the latest stable version)