### PR TITLE
Change kube-oidc-proxy e2e tests to use new ginko format

### DIFF
--- a/config/jobs/kube-oidc-proxy/kube-oidc-proxy-presubmits.yaml
+++ b/config/jobs/kube-oidc-proxy/kube-oidc-proxy-presubmits.yaml
@@ -59,7 +59,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:v20190320-1080345
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20191205-e920769-1.13.4
         args:
         - make
         - e2e
@@ -106,7 +106,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:v20190320-1080345
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20191205-e920769-1.13.4
         args:
         - make
         - e2e
@@ -153,7 +153,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:v20190320-1080345
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20191205-e920769-1.13.4
         args:
         - make
         - e2e
@@ -200,7 +200,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:v20190320-1080345
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20191205-e920769-1.13.4
         args:
         - make
         - e2e
@@ -247,7 +247,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:v20190320-1080345
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20191205-e920769-1.13.4
         args:
         - make
         - e2e
@@ -294,7 +294,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:v20190320-1080345
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20191205-e920769-1.13.4
         args:
         - make
         - e2e

--- a/config/jobs/kube-oidc-proxy/kube-oidc-proxy-presubmits.yaml
+++ b/config/jobs/kube-oidc-proxy/kube-oidc-proxy-presubmits.yaml
@@ -12,7 +12,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: golang:1.13.4
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20191205-e920769-1.13.4
         args:
         - make
         - all
@@ -32,7 +32,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: golang:1.13.4
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20191205-e920769-1.13.4
         args:
         - make
         - -C
@@ -61,6 +61,7 @@ presubmits:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20191205-e920769-1.13.4
         args:
+        - runner
         - make
         - e2e
         env:
@@ -108,6 +109,7 @@ presubmits:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20191205-e920769-1.13.4
         args:
+        - runner
         - make
         - e2e
         env:
@@ -155,6 +157,7 @@ presubmits:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20191205-e920769-1.13.4
         args:
+        - runner
         - make
         - e2e
         env:
@@ -202,6 +205,7 @@ presubmits:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20191205-e920769-1.13.4
         args:
+        - runner
         - make
         - e2e
         env:
@@ -249,6 +253,7 @@ presubmits:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20191205-e920769-1.13.4
         args:
+        - runner
         - make
         - e2e
         env:
@@ -296,6 +301,7 @@ presubmits:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20191205-e920769-1.13.4
         args:
+        - runner
         - make
         - e2e
         env:

--- a/config/jobs/kube-oidc-proxy/kube-oidc-proxy-presubmits.yaml
+++ b/config/jobs/kube-oidc-proxy/kube-oidc-proxy-presubmits.yaml
@@ -12,7 +12,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: golang:1.12.1
+      - image: golang:1.13.4
         args:
         - make
         - all
@@ -32,7 +32,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: golang:1.12.1
+      - image: golang:1.13.4
         args:
         - make
         - -C
@@ -61,9 +61,11 @@ presubmits:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:v20190320-1080345
         args:
-        - hack/docker-start-wrapper.sh
         - make
-        - e2e-1.11
+        - e2e
+        env:
+        - name: KUBE_OIDC_PROXY_K8S_VERSION
+          value: "1.11.10"
         resources:
           requests:
             cpu: 6
@@ -106,9 +108,11 @@ presubmits:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:v20190320-1080345
         args:
-        - hack/docker-start-wrapper.sh
         - make
-        - e2e-1.12
+        - e2e
+        env:
+        - name: KUBE_OIDC_PROXY_K8S_VERSION
+          value: "1.12.8"
         resources:
           requests:
             cpu: 6
@@ -151,9 +155,11 @@ presubmits:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:v20190320-1080345
         args:
-        - hack/docker-start-wrapper.sh
         - make
-        - e2e-1.13
+        - e2e
+        env:
+        - name: KUBE_OIDC_PROXY_K8S_VERSION
+          value: "1.13.7"
         resources:
           requests:
             cpu: 6
@@ -196,9 +202,11 @@ presubmits:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:v20190320-1080345
         args:
-        - hack/docker-start-wrapper.sh
         - make
-        - e2e-1.14
+        - e2e
+        env:
+        - name: KUBE_OIDC_PROXY_K8S_VERSION
+          value: "1.14.3"
         resources:
           requests:
             cpu: 6
@@ -241,9 +249,58 @@ presubmits:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:v20190320-1080345
         args:
-        - hack/docker-start-wrapper.sh
         - make
-        - e2e-1.15
+        - e2e
+        env:
+        - name: KUBE_OIDC_PROXY_K8S_VERSION
+          value: "1.15.0"
+        resources:
+          requests:
+            cpu: 6
+            memory: 12Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+
+  # kind based kube-oidc-proxy e2e job
+  - name: pull-kube-oidc-proxy-e2e-v1-16
+    context: pull-kube-oidc-proxy-e2e-v1-16
+    # Match everything except PRs that only touch docs/
+    always_run: true
+    cluster: gke
+    optional: false
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    branches:
+    - master
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:v20190320-1080345
+        args:
+        - make
+        - e2e
+        env:
+        - name: KUBE_OIDC_PROXY_K8S_VERSION
+          value: "1.16.1"
         resources:
           requests:
             cpu: 6


### PR DESCRIPTION
Signed-off-by: JoshVanL <vleeuwenjoshua@gmail.com>

/assign @munnerz 
/cc @simonswine 

Waiting for https://github.com/jetstack/testing/pull/305 to merge