### PR TITLE
Run verify-release.sh instead of verify script

### DIFF
--- a/config/jobs/cert-manager/website/cert-manager-website-presubmits.yaml
+++ b/config/jobs/cert-manager/website/cert-manager-website-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
       containers:
       - image: node:13.0.1
         args:
-        - ./scripts/verify
+        - ./scripts/verify-release
         resources:
           requests:
             cpu: 1


### PR DESCRIPTION
This resolves an issue when verifying website links

Signed-off-by: James Munnelly <james@munnelly.eu>