### PR TITLE
Use golang-nodejs image for cert-manager/website

### DIFF
--- a/config/jobs/cert-manager/website/cert-manager-website-presubmits.yaml
+++ b/config/jobs/cert-manager/website/cert-manager-website-presubmits.yaml
@@ -14,7 +14,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: node:13.0.1
+      - image: "eu.gcr.io/jetstack-build-infra-images/golang-nodejs:20191129-c49853e-1.13.4"
         args:
         - ./scripts/verify-release
         resources:


### PR DESCRIPTION
Signed-off-by: James Munnelly <james@munnelly.eu>