### PR TITLE
Preped runner to preflight ci args so it runs docker daemon

### DIFF
--- a/config/jobs/preflight/preflight-postsubmits.yaml
+++ b/config/jobs/preflight/preflight-postsubmits.yaml
@@ -32,6 +32,7 @@ postsubmits:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:v20190320-1080345
         args:
+        - runner
         - make
         - ci-publish
         resources:
@@ -77,6 +78,7 @@ postsubmits:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:v20190320-1080345
         args:
+        - runner
         - make
         - ci-build
         resources:


### PR DESCRIPTION
`runner` is a wrapper that starts docker daemon before calling the command in the rest of the arguments.

Signed-off-by: Jose Fuentes <jsfuentescastillo@gmail.com>