### PR TITLE
Fix BASE_IMAGE golang-dind

### DIFF
--- a/images/golang-dind/build.yaml
+++ b/images/golang-dind/build.yaml
@@ -3,7 +3,7 @@ name: golang-dind # Name of the image to be built
 variants:
   "1.13.4":
     arguments:
-      BASE_IMAGE: "${_REGISTRY}/bazelbuild:20191016-eff358a-1.0.0"
+      BASE_IMAGE: "eu.gcr.io/jetstack-build-infra-images/bazelbuild:20191016-eff358a-1.0.0"
       GO_VERSION: "1.13.4"
 
 # Image names to be tagged and pushed


### PR DESCRIPTION
Templating is not supported for docker build arguments and this was causing the image to fail at build time (see [build log](https://00e9e64bac7c6e21d1fe579a4f6dbe402a8a057465afc24abb-apidata.googleusercontent.com/download/storage/v1/b/jetstack-logs/o/logs%2Fpost-testing-push-golang-dind%2F1194538282982051840%2Fbuild-log.txt?qk=AD5uMEteM_VWqfL6fjH66Ym-wQxeh_ZNyLjR4iaXqqxQjmVwJswA87TIgcARTT1A7-QZBq2TfXaVTjH99UTUaKpWj7GTkxMN8TC7bLToAzfnqMR_jtKZ4gtAPnIMxczop-1UPcNFDK4cKFzY1TE4uLD6IOmOwo_76RrhtsYVPTlSNTgEUjhYg6Njv9mvoEvMJy_7ZUa0-weHYV_ijw2X_ojlAJ1Dto0cym4px-LCbpCncbQxn6LbmGNA3QNGQX9yea5UuqJ_Y7405XxHhRQdZ29ZED4iHnYXKlF41OYy68VHB5aW0ORl-MLZLD4swFV5rpEpY6MggyAVhzfAH24WQOKkUNWCn0LOwDU3cpO70j3SeyHHWkYQiBAyeHkw2Bd3yAyQ5GoWMWNexbO7RFVZKmE0yNJTLn3Tc59g1AitNUFDMhw-474N3inXjP-0BXQ4B1HuiVpqIV9ptU2AVJN_-7gvURUwZIuIskv2lVOCBGYSn9M5JT8ahrWQfyhLGPw4YYLGgis7XXQAiI6_OHELkVZAdU6mSCjpxabaMev0btUOcmUDP05NLADZgtzgsAo7MWONmEks3ThHCon58Gw31xw2mvdOSEQ24uRyb5oZfD41nRH62E6iJHDEV3gXu-GdkONJL5PCvyPOmTLApqFpa6Mcd2Ve6IKkDBlHg-1qLUWi2xn5rlJ289U1ejF6fRIiMdzclUGW7lXqgTI3gG2xSF9CXHdbUlatQAuQf3FiIQowKJ9BGve6MMGTpGWWyJC7_R5MxZbR95P96LhD2f7pJ1Vrg3leq7ZOHS9afAxP9sQSTvlgpc6L6L7C6RrX4bU90KcSEiLT2JXhO_3nMVj8-BYOrTIVu1YBAZuPmjdeLM0a_MR2SNjW13TAee2OsiNn5PRo2S3ohj3K)).

Signed-off-by: Jose Fuentes <jsfuentescastillo@gmail.com>