### PR TITLE
Bump golang-dind image for preflight postsubmits

### DIFF
--- a/config/jobs/preflight/preflight-postsubmits.yaml
+++ b/config/jobs/preflight/preflight-postsubmits.yaml
@@ -30,7 +30,7 @@ postsubmits:
       preset-deployer-github-token: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:v20190320-1080345
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20191205-e920769-1.13.4
         args:
         - runner
         - make
@@ -76,7 +76,7 @@ postsubmits:
       preset-deployer-github-token: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:v20190320-1080345
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20191205-e920769-1.13.4
         args:
         - runner
         - make


### PR DESCRIPTION
Use latest version of `golang-dind` image. This is the [build log of the new image](https://00e9e64bace520e26df9f2a9f8fcb902272e045ced1013bcec-apidata.googleusercontent.com/download/storage/v1/b/jetstack-logs/o/logs%2Fpost-testing-push-golang-dind%2F1202637688440623104%2Fbuild-log.txt?qk=AD5uMEt_7Qd_vmk9Jlb19QPUtR9uvVZnmRQPkizxkX6jS8JfP7I9n52CRnFuhGMQW30MarYtyoy6_T3L1LEsGB1lIhxUlfBHk0d5L9SzzoNN0nxvWlJN8hqE249wTMj6CN4hdetNvMIBAzYfALCEp_CSBkGrmZPm_6wlomZRO396wc7J0pagQvJ4WW58ech0jCa58J6aUH6hkDnNxr3r3Cq7OjClihOXrQkSipz45waqvxWDlxg9lsTrHO8w9GbgQMO1jJEuJVe63Kj0VDiVPnFk1gtV4qyA7HRZbg0e-Wb9gBpj-8aW_xqXQIvg9fFcvh5jnslmPq3DOXQ0tUMYRGEiecnlU9285DrFf6wPQT33_P9GUF09G1CRl7tOMLf8sPE1zNXZ8W538akdbmZH9AiTn-iLGXtapgJXHm3FGEJO-8Ln6o4ilYNrDAsKccsoCyrUR4ZMsMROLCwIYPma0Mx05wEZIS-ogPUt0sdX7zElEs9N324gQ3TEHMj49ahiDiSbOksYdMWnCdmSp9a6B4UdNcVPmF1fdnbTD8KPvMOPGkgsTzIrfQvgfzRKeYhkgPkSe8a6DbqzKuYW93Peo5561xb16lmw6C2c5sALZZOD1Wamn8ENQliioe2VnaEakZ6PGKojJJfdlVakMHAUSnfqcmdNuqXY788_qVbH9QV409QEAwLL-H2Ma5ALkhGl-xrg1GezNWsBRCzsLPsd-8sgdfgkgypn_Lvv7Q2AraHO_DDNJukqiaZgKZny0lvNTfH-j74lz1PlOIuUjqJC0xjEN1plcMC3vF3Q5caD0rU2nJl0os_WtPqvTMDqZ5NrIb0qOlCWjpNXwKBFh8P-s7YtlXxLAlNwplgvay04R9ytTZJp5mhf7C0).

Signed-off-by: Jose Fuentes <jsfuentescastillo@gmail.com>