### PR TITLE
Change Preflight approvers and reviewers

### DIFF
--- a/config/jobs/preflight/OWNERS
+++ b/config/jobs/preflight/OWNERS
@@ -1,8 +1,8 @@
 approvers:
-- munnerz
+- charlieegan3
 - j-fuentes
 reviewers:
-- munnerz
+- charlieegan3
 - j-fuentes
 labels:
 - area/preflight


### PR DESCRIPTION
I have noticed @munnerz is appearing all the time as a reviewer, and I don't think we should be contaminating his inbox with things he is not directly involved in :).

Signed-off-by: Jose Fuentes <jsfuentescastillo@gmail.com>