### PR TITLE
Upgrade cert-manager to use Bazel 2.0.0

### DIFF
--- a/config/jobs/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager-periodics.yaml
@@ -15,7 +15,7 @@ periodics:
     preset-bazel-scratch-dir: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200121-1a8954b-1.0.0
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200121-1a8954b-2.0.0
       args:
       - runner
       - bazel
@@ -78,7 +78,7 @@ periodics:
     preset-venafi-tpp-credentials: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200121-1a8954b-1.0.0
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200121-1a8954b-2.0.0
       args:
       - runner
       - hack/ci/run-e2e-kind.sh
@@ -132,7 +132,7 @@ periodics:
     preset-venafi-tpp-credentials: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200121-1a8954b-1.0.0
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200121-1a8954b-2.0.0
       args:
       - runner
       - hack/ci/run-e2e-kind.sh
@@ -186,7 +186,7 @@ periodics:
     preset-venafi-tpp-credentials: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200121-1a8954b-1.0.0
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200121-1a8954b-2.0.0
       args:
       - runner
       - hack/ci/run-e2e-kind.sh
@@ -240,7 +240,7 @@ periodics:
     preset-venafi-tpp-credentials: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200121-1a8954b-1.0.0
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200121-1a8954b-2.0.0
       args:
       - runner
       - hack/ci/run-e2e-kind.sh
@@ -294,7 +294,7 @@ periodics:
     preset-venafi-tpp-credentials: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200121-1a8954b-1.0.0
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200121-1a8954b-2.0.0
       args:
       - runner
       - hack/ci/run-e2e-kind.sh

--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -67,7 +67,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200121-1a8954b-1.0.0
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200121-1a8954b-2.0.0
         args:
         - runner
         - bazel
@@ -132,7 +132,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200121-1a8954b-1.0.0
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200121-1a8954b-2.0.0
         args:
         # Wrap the release script with the runner so we can use docker-in-docker
         - runner
@@ -172,7 +172,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200121-1a8954b-1.0.0
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200121-1a8954b-2.0.0
         args:
         - runner
         - make
@@ -205,7 +205,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200121-1a8954b-1.0.0
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200121-1a8954b-2.0.0
         args:
         - runner
         - make
@@ -241,7 +241,7 @@ presubmits:
       preset-retry-flakey-tests: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200121-1a8954b-1.0.0
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200121-1a8954b-2.0.0
         args:
         - runner
         - hack/ci/run-e2e-kind.sh
@@ -297,7 +297,7 @@ presubmits:
       preset-retry-flakey-tests: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200121-1a8954b-1.0.0
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200121-1a8954b-2.0.0
         args:
         - runner
         - hack/ci/run-e2e-kind.sh
@@ -353,7 +353,7 @@ presubmits:
       preset-retry-flakey-tests: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200121-1a8954b-1.0.0
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200121-1a8954b-2.0.0
         args:
         - runner
         - hack/ci/run-e2e-kind.sh
@@ -408,7 +408,7 @@ presubmits:
       preset-retry-flakey-tests: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200121-1a8954b-1.0.0
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200121-1a8954b-2.0.0
         args:
         - runner
         - hack/ci/run-e2e-kind.sh
@@ -464,7 +464,7 @@ presubmits:
       preset-retry-flakey-tests: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200121-1a8954b-1.0.0
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200121-1a8954b-2.0.0
         args:
         - runner
         - hack/ci/run-e2e-kind.sh

--- a/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
+++ b/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
@@ -18,7 +18,7 @@ periodics:
     preset-venafi-tpp-credentials: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200121-1a8954b-1.0.0
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200121-1a8954b-2.0.0
       args:
       - runner
       - hack/ci/run-e2e-kind.sh


### PR DESCRIPTION
The test job that actually uses this image has been passing for a while now: https://prow.build-infra.jetstack.net/view/gcs/jetstack-logs/logs/ci-cert-manager-bazel-experimental/1235477345142312960

(minor the verify-links test..)

We can remove verify-links anyway now since docs have moved out of the main repo

/assign @meyskens 