### PR TITLE
Add Kubernetes 1.11 and 1.17 e2e jobs

### DIFF
--- a/config/jobs/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager-periodics.yaml
@@ -60,6 +60,59 @@ periodics:
           value: "1"
 
 # kind based cert-manager e2e job
+- name: ci-cert-manager-e2e-v1-11
+  interval: 4h
+  cluster: gke
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: jetstack
+    repo: cert-manager
+    base_ref: master
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-cloudflare-credentials: "true"
+    preset-venafi-tpp-credentials: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200305-35c2a27-2.2.0
+      args:
+      - runner
+      - hack/ci/run-e2e-kind.sh
+      resources:
+        requests:
+          cpu: 6
+          memory: 12Gi
+      env:
+      - name: K8S_VERSION
+        value: "1.11"
+      securityContext:
+        privileged: true
+        capabilities:
+          add: ["SYS_ADMIN"]
+      volumeMounts:
+      - mountPath: /lib/modules
+        name: modules
+        readOnly: true
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    volumes:
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+
 - name: ci-cert-manager-e2e-v1-12
   interval: 4h
   cluster: gke
@@ -328,3 +381,56 @@ periodics:
       options:
         - name: ndots
           value: "1"
+
+- name: ci-cert-manager-e2e-v1-17
+  interval: 4h
+  cluster: gke
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: jetstack
+    repo: cert-manager
+    base_ref: master
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-cloudflare-credentials: "true"
+    preset-venafi-tpp-credentials: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200305-35c2a27-2.2.0
+      args:
+      - runner
+      - hack/ci/run-e2e-kind.sh
+      resources:
+        requests:
+          cpu: 6
+          memory: 12Gi
+      env:
+      - name: K8S_VERSION
+        value: "1.17"
+      securityContext:
+        privileged: true
+        capabilities:
+          add: ["SYS_ADMIN"]
+      volumeMounts:
+      - mountPath: /lib/modules
+        name: modules
+        readOnly: true
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    volumes:
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"

--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -114,44 +114,6 @@ presubmits:
           - name: ndots
             value: "1"
 
-  # Job that runs the release tooling *without* actually publishing the built
-  # assets. This gives us visibility on whether the release tool works.
-  - name: pull-cert-manager-release-smoke
-    always_run: false
-    cluster: gke
-    context: pull-cert-manager-release-smoke
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    branches:
-    - master
-    - release-0.14
-    labels:
-      preset-service-account: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200305-35c2a27-2.2.0
-        args:
-        # Wrap the release script with the runner so we can use docker-in-docker
-        - runner
-        - bazel
-        - run
-        - //hack/release
-        - --
-        - --images
-        - --chart
-        - --manifests
-        resources:
-          requests:
-            cpu: 2
-            memory: 4Gi
-      dnsConfig:
-        options:
-          - name: ndots
-            value: "1"
-
   # Helm chart verification currently requires Docker.
   # We maintain a standalone presubmit for running this.
   # See https://github.com/helm/chart-testing/issues/53
@@ -220,6 +182,62 @@ presubmits:
             value: "1"
 
   # kind based cert-manager e2e job
+  - name: pull-cert-manager-e2e-v1-11
+    cluster: gke
+    context: pull-cert-manager-e2e-v1-11
+    always_run: false
+    optional: true
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    branches:
+    - master
+    - release-0.14
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-cloudflare-credentials: "true"
+      preset-venafi-tpp-credentials: "true"
+      preset-retry-flakey-tests: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200305-35c2a27-2.2.0
+        args:
+        - runner
+        - hack/ci/run-e2e-kind.sh
+        resources:
+          requests:
+            cpu: 6
+            memory: 12Gi
+        env:
+        - name: K8S_VERSION
+          value: "1.11"
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+
   - name: pull-cert-manager-e2e-v1-12
     cluster: gke
     context: pull-cert-manager-e2e-v1-12
@@ -498,3 +516,59 @@ presubmits:
         options:
           - name: ndots
             value: "1"
+
+  - name: pull-cert-manager-e2e-v1-17
+    cluster: gke
+    context: pull-cert-manager-e2e-v1-17
+    always_run: true
+    optional: true
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    branches:
+    - master
+    - release-0.14
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-cloudflare-credentials: "true"
+      preset-venafi-tpp-credentials: "true"
+      preset-retry-flakey-tests: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200305-35c2a27-2.2.0
+        args:
+        - runner
+        - hack/ci/run-e2e-kind.sh
+        resources:
+          requests:
+            cpu: 6
+            memory: 12Gi
+        env:
+        - name: K8S_VERSION
+          value: "1.17"
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"


### PR DESCRIPTION
Let's see if we can get 1.11 to pass now that we're also aiming to support OpenShift 3 😄 

I've also marked the 1.17 presubmit as `always_run` but with `optional: true` - this will mean that all PRs will have results for this job, but won't require it to pass in order to merge. In a few days, we can disable the v1.15 job by default and mark the v1.17 job as required with minimal disruption to existing PRs 😄 
