### PR TITLE
Add 'testing' retest-bot periodics to janitors dashboard

### DIFF
--- a/config/jobs/testing/testing-periodics.yaml
+++ b/config/jobs/testing/testing-periodics.yaml
@@ -4,7 +4,9 @@ periodics:
   interval: 20m  # Retest at most 1 PR per 20m, which should not DOS the queue.
   agent: kubernetes
   annotations:
-    testgrid-create-test-group: 'false'
+    testgrid-dashboards: jetstack-testing-janitors
+    testgrid-alert-email: james+alerts@munnelly.eu
+    description: Periodically comments /retest against approved and lgtm'd PRs that are failing
   spec:
     containers:
     - image: gcr.io/k8s-testimages/commenter:v20170808-abf66782
@@ -47,7 +49,9 @@ periodics:
   interval: 1h
   agent: kubernetes
   annotations:
-    testgrid-create-test-group: 'false'
+    testgrid-dashboards: jetstack-testing-janitors
+    testgrid-alert-email: james+alerts@munnelly.eu
+    description: Closes PRs and issues that are marked 'rotten' and have been inactive for 30d
   spec:
     containers:
     - image: gcr.io/k8s-testimages/commenter:v20170808-abf66782
@@ -79,7 +83,9 @@ periodics:
   interval: 1h
   agent: kubernetes
   annotations:
-    testgrid-create-test-group: 'false'
+    testgrid-dashboards: jetstack-testing-janitors
+    testgrid-alert-email: james+alerts@munnelly.eu
+    description: Marks PRs and issues that are marked 'stale' and have been inactive for 30d as 'rotten'
   spec:
     containers:
     - image: gcr.io/k8s-testimages/commenter:v20170808-abf66782
@@ -114,7 +120,9 @@ periodics:
   interval: 1h
   agent: kubernetes
   annotations:
-    testgrid-create-test-group: 'false'
+    testgrid-dashboards: jetstack-testing-janitors
+    testgrid-alert-email: james+alerts@munnelly.eu
+    description: Marks PRs and issues that have been inactive for 30d as 'stale'
   spec:
     containers:
     - image: gcr.io/k8s-testimages/commenter:v20170808-abf66782


### PR DESCRIPTION
Do not merge this until #347 has merged, so we can test out the postsubmit job it adds!
