### PR TITLE
Updates kube-oidc-proxy node image versions and now default 1.17/1.18

### DIFF
--- a/config/jobs/kube-oidc-proxy/kube-oidc-proxy-presubmits.yaml
+++ b/config/jobs/kube-oidc-proxy/kube-oidc-proxy-presubmits.yaml
@@ -114,7 +114,7 @@ presubmits:
         - e2e
         env:
         - name: KUBE_OIDC_PROXY_K8S_VERSION
-          value: "1.12.8"
+          value: "1.12.10"
         resources:
           requests:
             cpu: 6
@@ -162,7 +162,7 @@ presubmits:
         - e2e
         env:
         - name: KUBE_OIDC_PROXY_K8S_VERSION
-          value: "1.13.7"
+          value: "1.13.10"
         resources:
           requests:
             cpu: 6
@@ -210,7 +210,7 @@ presubmits:
         - e2e
         env:
         - name: KUBE_OIDC_PROXY_K8S_VERSION
-          value: "1.14.3"
+          value: "1.14.10"
         resources:
           requests:
             cpu: 6
@@ -239,9 +239,9 @@ presubmits:
   - name: pull-kube-oidc-proxy-e2e-v1-15
     context: pull-kube-oidc-proxy-e2e-v1-15
     # Match everything except PRs that only touch docs/
-    always_run: true
+    always_run: false
     cluster: gke
-    optional: false
+    optional: true
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -258,7 +258,7 @@ presubmits:
         - e2e
         env:
         - name: KUBE_OIDC_PROXY_K8S_VERSION
-          value: "1.15.0"
+          value: "1.15.7"
         resources:
           requests:
             cpu: 6
@@ -287,6 +287,54 @@ presubmits:
   - name: pull-kube-oidc-proxy-e2e-v1-16
     context: pull-kube-oidc-proxy-e2e-v1-16
     # Match everything except PRs that only touch docs/
+    always_run: false
+    cluster: gke
+    optional: false
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    branches:
+    - master
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20191205-e920769-1.13.4
+        args:
+        - runner
+        - make
+        - e2e
+        env:
+        - name: KUBE_OIDC_PROXY_K8S_VERSION
+          value: "1.16.4"
+        resources:
+          requests:
+            cpu: 6
+            memory: 12Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+
+  # kind based kube-oidc-proxy e2e job
+  - name: pull-kube-oidc-proxy-e2e-v1-17
+    context: pull-kube-oidc-proxy-e2e-v1-17
+    # Match everything except PRs that only touch docs/
     always_run: true
     cluster: gke
     optional: false
@@ -306,7 +354,55 @@ presubmits:
         - e2e
         env:
         - name: KUBE_OIDC_PROXY_K8S_VERSION
-          value: "1.16.1"
+          value: "1.17.2"
+        resources:
+          requests:
+            cpu: 6
+            memory: 12Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+
+  # kind based kube-oidc-proxy e2e job
+  - name: pull-kube-oidc-proxy-e2e-v1-18
+    context: pull-kube-oidc-proxy-e2e-v1-18
+    # Match everything except PRs that only touch docs/
+    always_run: true
+    cluster: gke
+    optional: false
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    branches:
+    - master
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20191205-e920769-1.13.4
+        args:
+        - runner
+        - make
+        - e2e
+        env:
+        - name: KUBE_OIDC_PROXY_K8S_VERSION
+          value: "1.18.0"
         resources:
           requests:
             cpu: 6

--- a/config/jobs/kube-oidc-proxy/kube-oidc-proxy-presubmits.yaml
+++ b/config/jobs/kube-oidc-proxy/kube-oidc-proxy-presubmits.yaml
@@ -46,7 +46,6 @@ presubmits:
   # kind based kube-oidc-proxy e2e job
   - name: pull-kube-oidc-proxy-e2e-v1-11
     context: pull-kube-oidc-proxy-e2e-v1-11
-    # Match everything except PRs that only touch docs/
     always_run: false
     cluster: gke
     optional: true
@@ -94,7 +93,6 @@ presubmits:
   # kind based kube-oidc-proxy e2e job
   - name: pull-kube-oidc-proxy-e2e-v1-12
     context: pull-kube-oidc-proxy-e2e-v1-12
-    # Match everything except PRs that only touch docs/
     always_run: false
     cluster: gke
     optional: true
@@ -142,7 +140,6 @@ presubmits:
   # kind based kube-oidc-proxy e2e job
   - name: pull-kube-oidc-proxy-e2e-v1-13
     context: pull-kube-oidc-proxy-e2e-v1-13
-    # Match everything except PRs that only touch docs/
     always_run: false
     cluster: gke
     optional: true
@@ -190,7 +187,6 @@ presubmits:
   # kind based kube-oidc-proxy e2e job
   - name: pull-kube-oidc-proxy-e2e-v1-14
     context: pull-kube-oidc-proxy-e2e-v1-14
-    # Match everything except PRs that only touch docs/
     always_run: false
     cluster: gke
     optional: true
@@ -238,7 +234,6 @@ presubmits:
   # kind based kube-oidc-proxy e2e job
   - name: pull-kube-oidc-proxy-e2e-v1-15
     context: pull-kube-oidc-proxy-e2e-v1-15
-    # Match everything except PRs that only touch docs/
     always_run: false
     cluster: gke
     optional: true
@@ -286,7 +281,6 @@ presubmits:
   # kind based kube-oidc-proxy e2e job
   - name: pull-kube-oidc-proxy-e2e-v1-16
     context: pull-kube-oidc-proxy-e2e-v1-16
-    # Match everything except PRs that only touch docs/
     always_run: false
     cluster: gke
     optional: false
@@ -334,10 +328,9 @@ presubmits:
   # kind based kube-oidc-proxy e2e job
   - name: pull-kube-oidc-proxy-e2e-v1-17
     context: pull-kube-oidc-proxy-e2e-v1-17
-    # Match everything except PRs that only touch docs/
-    always_run: true
+    always_run: false
     cluster: gke
-    optional: false
+    optional: true
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -382,7 +375,6 @@ presubmits:
   # kind based kube-oidc-proxy e2e job
   - name: pull-kube-oidc-proxy-e2e-v1-18
     context: pull-kube-oidc-proxy-e2e-v1-18
-    # Match everything except PRs that only touch docs/
     always_run: true
     cluster: gke
     optional: false


### PR DESCRIPTION
Signed-off-by: JoshVanL <vleeuwenjoshua@gmail.com>

/assign @munnerz 