### PR TITLE
Add periodic to test on openshift 3.11

### DIFF
--- a/config/jobs/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager-periodics.yaml
@@ -536,3 +536,65 @@ periodics:
       options:
       - name: ndots
         value: "1"
+
+- name: pull-cert-manager-e2e-openshift-v3-11
+  interval: 2h
+  cluster: gke
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: jetstack
+    repo: cert-manager
+    base_ref: master
+  annotations:
+    testgrid-create-test-group: 'true'
+    testgrid-dashboards: jetstack-cert-manager-master
+    testgrid-alert-email: james+alerts@munnelly.eu
+    description: Runs the end-to-end test suite against a OpenShift v3.11 cluster
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-cloudflare-credentials: "true"
+    preset-venafi-tpp-credentials: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200407-37ac701-2.2.0
+      args:
+      - runner
+      - devel/ci-run-e2e.sh
+      resources:
+        requests:
+          cpu: 6
+          memory: 12Gi
+      env:
+      - name: OPENSHIFT_VERSION
+        value: "3.11"
+      - name: IS_OPENSHIFT
+        value: "true"
+      - name: EXTRA_DOCKER_OPTS
+        value: "--insecure-registry=172.30.0.0/16"
+      securityContext:
+        privileged: true
+        capabilities:
+          add: ["SYS_ADMIN"]
+      volumeMounts:
+      - mountPath: /lib/modules
+        name: modules
+        readOnly: true
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    volumes:
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+    dnsConfig:
+      options:
+        - name: ndots
+          value: "1"


### PR DESCRIPTION
/hold

This PR runs the OpenShift e2e test just like the other Kubernetes versions.
This PR depends on https://github.com/jetstack/cert-manager/pull/2788