### PR TITLE
Fix ci-cert-manager-next-openshift-v3-11 test

### DIFF
--- a/config/jobs/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager-periodics.yaml
@@ -621,7 +621,7 @@ periodics:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200428-6b034c1-2.2.0
       args:
       - runner
-      - devel/ci/ci-run-e2e.sh
+      - devel/ci-run-e2e.sh
       resources:
         requests:
           cpu: 6

--- a/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
+++ b/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
@@ -623,7 +623,7 @@ periodics:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200428-6b034c1-2.2.0
       args:
       - runner
-      - devel/ci/ci-run-e2e.sh
+      - devel/ci-run-e2e.sh
       resources:
         requests:
           cpu: 6


### PR DESCRIPTION
the path was incorrect causing the periodic tests to always fail