### PR TITLE
Default config changes for Jetstack

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -215,18 +215,33 @@ tide:
   # Default tide config for all repos in the Jetstack org except cert-manager
   - orgs:
     - jetstack
-    - cert-manager
     excludedRepos:
     - jetstack/cert-manager
     - jetstack/tarmak
     - jetstack/cert-manager-csi
     labels:
     - lgtm
+    - approved
     missingLabels:
     - do-not-merge
     - do-not-merge/blocked-paths
     - do-not-merge/cherry-pick-not-approved
     - do-not-merge/hold
+    - do-not-merge/work-in-progress
+    - needs-rebase
+  # Default tide config for all repos in the cert-manager org
+  - orgs:
+    - cert-manager
+    labels:
+    - lgtm
+    - approved
+    - "dco-signoff: yes"
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/blocked-paths
+    - do-not-merge/cherry-pick-not-approved
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
     - do-not-merge/work-in-progress
     - needs-rebase
   # Repositories that enable the release-notes plugin (except cert-manager)

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -251,6 +251,7 @@ tide:
     - jetstack/preflight
     - jetstack/kube-oidc-proxy
     - jetstack/version-checker
+    - jetstack/testing
     labels:
     - lgtm
     - approved

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -221,7 +221,6 @@ tide:
     - jetstack/cert-manager-csi
     labels:
     - lgtm
-    - approved
     missingLabels:
     - do-not-merge
     - do-not-merge/blocked-paths

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -249,6 +249,8 @@ tide:
     - jetstack/tarmak
     - jetstack/cert-manager-csi
     - jetstack/preflight
+    - jetstack/kube-oidc-proxy
+    - jetstack/version-checker
     labels:
     - lgtm
     - approved

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -222,20 +222,18 @@ tide:
     - jetstack/cert-manager-csi
     labels:
     - lgtm
-    - approved
-    - "dco-signoff: yes"
     missingLabels:
     - do-not-merge
     - do-not-merge/blocked-paths
     - do-not-merge/cherry-pick-not-approved
     - do-not-merge/hold
-    - do-not-merge/invalid-owners-file
     - do-not-merge/work-in-progress
     - needs-rebase
   # Repositories that enable the release-notes plugin (except cert-manager)
   - repos:
     - jetstack/tarmak
     - jetstack/cert-manager-csi
+    - jetstack/preflight
     labels:
     - lgtm
     - approved

--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -133,10 +133,8 @@ require_matching_label:
 plugins:
 
   jetstack:
-  - approve
   - assign
   - blockade
-  - blunderbuss
   - cherry-pick-unapproved
   - dco
   - golint
@@ -150,7 +148,6 @@ plugins:
   - milestonestatus
   - milestoneapplier
   - override
-  - owners-label
   - require-matching-label
   - shrug
   - size
@@ -188,33 +185,54 @@ plugins:
   - yuks
 
   jetstack/cert-manager:
+  - approve
+  - blunderbuss
+  - owners-label
   - release-note
   - verify-owners
 
   jetstack/cert-manager-csi:
+  - approve
+  - blunderbuss
+  - owners-label
   - release-note
   - verify-owners
 
   jetstack/tarmak:
+  - approve
+  - blunderbuss
+  - owners-label
   - release-note
   - verify-owners
 
   jetstack/kube-oidc-proxy:
+  - approve
+  - blunderbuss
+  - owners-label
   - release-note
   - verify-owners
 
   jetstack/preflight:
+  - approve
+  - blunderbuss
+  - owners-label
   - release-note
   - verify-owners
 
   jetstack/version-checker:
+  - approve
+  - blunderbuss
+  - owners-label
   - release-note
   - verify-owners
 
   jetstack/testing:
+  - approve
+  - blunderbuss
   - config-updater
-  - verify-owners
+  - owners-label
   - release-note
+  - verify-owners
 
   munnerz/venafi-cm-demo:
   - trigger

--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -156,7 +156,6 @@ plugins:
   - size
   - skip
   - trigger
-  - verify-owners
   - wip
   - yuks
 
@@ -190,15 +189,32 @@ plugins:
 
   jetstack/cert-manager:
   - release-note
+  - verify-owners
 
   jetstack/cert-manager-csi:
   - release-note
+  - verify-owners
 
   jetstack/tarmak:
   - release-note
+  - verify-owners
+
+  jetstack/kube-oidc-proxy:
+  - release-note
+  - verify-owners
+
+  jetstack/preflight:
+  - release-note
+  - verify-owners
+
+  jetstack/version-checker:
+  - release-note
+  - verify-owners
 
   jetstack/testing:
   - config-updater
+  - verify-owners
+  - release-note
 
   munnerz/venafi-cm-demo:
   - trigger


### PR DESCRIPTION
We're starting to roll out the adoption of Github and some of our repositories don't require Prow at Jetstack.

We want to make this optional and not required for every new and existing repository apart from those that require it today i.e. cert-manager, preflight, kube-oidc-proxy, etc.

I wasn't able to find much documentation for the changes I wanted to create but I'm hoping this should be OK going forward.