### PR TITLE
Make cert-manager tests run against 1.20

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -55,7 +55,7 @@ branch-protection:
             - pull-cert-manager-bazel
             - pull-cert-manager-deps
             - pull-cert-manager-chart
-            - pull-cert-manager-e2e-v1-19
+            - pull-cert-manager-e2e-v1-20
         cert-manager-csi:
           protect: true
           required_status_checks:

--- a/config/jobs/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager-periodics.yaml
@@ -304,3 +304,62 @@ periodics:
       options:
       - name: ndots
         value: "1"
+
+- name: ci-cert-manager-e2e-v1-20
+  interval: 2h
+  cluster: gke
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: jetstack
+    repo: cert-manager
+    base_ref: master
+  annotations:
+    testgrid-create-test-group: 'true'
+    testgrid-dashboards: jetstack-cert-manager-master
+    testgrid-alert-email: james+alerts@munnelly.eu,maartje.eyskens+alerts@jetstack.io
+    description: Runs the end-to-end test suite against a Kubernetes v1.20 cluster
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-cloudflare-credentials: "true"
+    preset-venafi-tpp-credentials: "true"
+    preset-venafi-cloud-credentials: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200428-6b034c1-2.2.0
+      args:
+      - runner
+      - hack/ci/run-e2e-kind.sh
+      resources:
+        requests:
+          cpu: 6
+          memory: 12Gi
+      env:
+      - name: K8S_VERSION
+        value: "1.20"
+      securityContext:
+        privileged: true
+        capabilities:
+          add: ["SYS_ADMIN"]
+      volumeMounts:
+      - mountPath: /lib/modules
+        name: modules
+        readOnly: true
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    volumes:
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"

--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -394,12 +394,11 @@ presubmits:
         options:
         - name: ndots
           value: "1"
-
   - name: pull-cert-manager-e2e-v1-19
     cluster: gke
     context: pull-cert-manager-e2e-v1-19
-    always_run: true
-    optional: false
+    always_run: false
+    optional: true
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -455,7 +454,66 @@ presubmits:
         options:
         - name: ndots
           value: "1"
-
+  - name: pull-cert-manager-e2e-v1-20
+    cluster: gke
+    context: pull-cert-manager-e2e-v1-20
+    always_run: true
+    optional: false
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    branches:
+    - master
+    - release-1.2
+    annotations:
+      testgrid-create-test-group: 'true'
+      testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
+      description: Runs the end-to-end test suite against a Kubernetes v1.20 cluster
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-cloudflare-credentials: "true"
+      preset-venafi-tpp-credentials: "true"
+      preset-venafi-cloud-credentials: "true"
+      preset-retry-flakey-tests: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200428-6b034c1-2.2.0
+        args:
+        - runner
+        - hack/ci/run-e2e-kind.sh
+        resources:
+          requests:
+            cpu: 6
+            memory: 12Gi
+        env:
+        - name: K8S_VERSION
+          value: "1.20"
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
   # e2e test job with experimental certificates controller enabled
   - name: pull-cert-manager-experimental-e2e-v1-17
     cluster: gke

--- a/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
+++ b/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
@@ -304,3 +304,62 @@ periodics:
       options:
       - name: ndots
         value: "1"
+
+- name: ci-cert-manager-next-e2e-v1-20
+  interval: 2h
+  cluster: gke
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: jetstack
+    repo: cert-manager
+    base_ref: release-1.2
+  annotations:
+    testgrid-create-test-group: 'true'
+    testgrid-dashboards: jetstack-cert-manager-next
+    testgrid-alert-email: james+alerts@munnelly.eu,maartje.eyskens+alerts@jetstack.io
+    description: Runs the end-to-end test suite against a Kubernetes v1.20 cluster
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-cloudflare-credentials: "true"
+    preset-venafi-tpp-credentials: "true"
+    preset-venafi-cloud-credentials: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200428-6b034c1-2.2.0
+      args:
+      - runner
+      - hack/ci/run-e2e-kind.sh
+      resources:
+        requests:
+          cpu: 6
+          memory: 12Gi
+      env:
+      - name: K8S_VERSION
+        value: "1.20"
+      securityContext:
+        privileged: true
+        capabilities:
+          add: ["SYS_ADMIN"]
+      volumeMounts:
+      - mountPath: /lib/modules
+        name: modules
+        readOnly: true
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    volumes:
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"


### PR DESCRIPTION
To me merged after https://github.com/jetstack/cert-manager/pull/3503

reviews already welcome

/cc @zee-ahmed 
/hold

```release-note
NONE
```