### PR TITLE
Temporarily skip Venafi TPP tests while the test server is offline

### DIFF
--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -18,29 +18,33 @@ presets:
         name: cloudflare-api-key
         key: domain
 
-- labels:
-    preset-venafi-tpp-credentials: "true"
-  env:
-  - name: VENAFI_TPP_URL
-    valueFrom:
-      secretKeyRef:
-        name: venafi-tpp
-        key: url
-  - name: VENAFI_TPP_ZONE
-    valueFrom:
-      secretKeyRef:
-        name: venafi-tpp
-        key: zone
-  - name: VENAFI_TPP_USERNAME
-    valueFrom:
-      secretKeyRef:
-        name: venafi-tpp
-        key: username
-  - name: VENAFI_TPP_PASSWORD
-    valueFrom:
-      secretKeyRef:
-        name: venafi-tpp
-        key: password
+# The Venafi TPP test server is currently offline.
+# Commenting out these pod presets when will cause the Venafi Issuer E2E tests
+# to be skipped.
+#
+# - labels:
+#     preset-venafi-tpp-credentials: "true"
+#   env:
+#   - name: VENAFI_TPP_URL
+#     valueFrom:
+#       secretKeyRef:
+#         name: venafi-tpp
+#         key: url
+#   - name: VENAFI_TPP_ZONE
+#     valueFrom:
+#       secretKeyRef:
+#         name: venafi-tpp
+#         key: zone
+#   - name: VENAFI_TPP_USERNAME
+#     valueFrom:
+#       secretKeyRef:
+#         name: venafi-tpp
+#         key: username
+#   - name: VENAFI_TPP_PASSWORD
+#     valueFrom:
+#       secretKeyRef:
+#         name: venafi-tpp
+#         key: password
 
 - labels:
     preset-venafi-cloud-credentials: "true"


### PR DESCRIPTION
I've commented out the Venafi TPP related Pod presets which should remove the `VENAFI_TPP_*`  env variables and cause the Venafi E2E tests to be skipped.

```release-note
NONE
```

