### PR TITLE
Reenable venafi e2e tests

### DIFF
--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -1,3 +1,6 @@
+# TODO: These Pod presets are used by all the cert-manager tests (not just those in this file).
+# Move the presets to a separate file to make it obvious that they are shared.
+# See https://github.com/jetstack/testing/issues/411
 presets:
 - labels:
     preset-cloudflare-credentials: "true"

--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -18,33 +18,29 @@ presets:
         name: cloudflare-api-key
         key: domain
 
-# The Venafi TPP test server is currently offline.
-# Commenting out these pod presets when will cause the Venafi Issuer E2E tests
-# to be skipped.
-#
-# - labels:
-#     preset-venafi-tpp-credentials: "true"
-#   env:
-#   - name: VENAFI_TPP_URL
-#     valueFrom:
-#       secretKeyRef:
-#         name: venafi-tpp
-#         key: url
-#   - name: VENAFI_TPP_ZONE
-#     valueFrom:
-#       secretKeyRef:
-#         name: venafi-tpp
-#         key: zone
-#   - name: VENAFI_TPP_USERNAME
-#     valueFrom:
-#       secretKeyRef:
-#         name: venafi-tpp
-#         key: username
-#   - name: VENAFI_TPP_PASSWORD
-#     valueFrom:
-#       secretKeyRef:
-#         name: venafi-tpp
-#         key: password
+- labels:
+    preset-venafi-tpp-credentials: "true"
+  env:
+  - name: VENAFI_TPP_URL
+    valueFrom:
+      secretKeyRef:
+        name: venafi-tpp
+        key: url
+  - name: VENAFI_TPP_ZONE
+    valueFrom:
+      secretKeyRef:
+        name: venafi-tpp
+        key: zone
+  - name: VENAFI_TPP_USERNAME
+    valueFrom:
+      secretKeyRef:
+        name: venafi-tpp
+        key: username
+  - name: VENAFI_TPP_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: venafi-tpp
+        key: password
 
 - labels:
     preset-venafi-cloud-credentials: "true"


### PR DESCRIPTION
Paul has fixed our Venafi test server so we can re-enable the Venafi E2E tests.


```release-note
NONE
```