### PR TITLE
Update istio-csr e2e pull CI to use golang-dind 1.15.7

### DIFF
--- a/config/jobs/istio-csr/istio-csr-presubmits.yaml
+++ b/config/jobs/istio-csr/istio-csr-presubmits.yaml
@@ -37,7 +37,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20200504-c7fefcd-1.13.4
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20210122-46f3dbf-1.15.7
         args:
         - runner
         - make


### PR DESCRIPTION
Signed-off-by: joshvanl <vleeuwenjoshua@gmail.com>

/assign @meyskens 