### PR TITLE
Exclude terraform repositories for tide

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -228,6 +228,10 @@ tide:
     - jetstack/tarmak
     - jetstack/cert-manager-csi
     - jetstack/preflight-platform
+    - jetstack/terraform-jetstack
+    - jetstack/terraform-flightdeck
+    - jetstack/terraform-sendgrid
+    - jetstack/terraform-auth0
     labels:
     - lgtm
     missingLabels:


### PR DESCRIPTION
Since we use Atlantis and our PR process is different for our Terraform repositories within Jetstack. We should exclude these repositories to disable tide. 

This will stop any changes being merged into master that haven't been applied within Terraform.