### PR TITLE
Use cert-manager-dev-alerts mailing list instead of a single email

### DIFF
--- a/config/jobs/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager-periodics.yaml
@@ -49,7 +49,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-master
-    testgrid-alert-email: james+alerts@munnelly.eu,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
     description: Runs 'bazel test //...' using the 'experimental' Bazel version
   spec:
     containers:
@@ -89,7 +89,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-master
-    testgrid-alert-email: james+alerts@munnelly.eu,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
     description: Runs the end-to-end test suite against a Kubernetes v1.16 cluster
   spec:
     containers:
@@ -140,7 +140,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-master
-    testgrid-alert-email: james+alerts@munnelly.eu,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
     description: Runs the end-to-end test suite against a Kubernetes v1.17 cluster
   labels:
     preset-service-account: "true"
@@ -199,7 +199,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-master
-    testgrid-alert-email: james+alerts@munnelly.eu,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
     description: Runs the end-to-end test suite against a Kubernetes v1.18 cluster
   labels:
     preset-service-account: "true"
@@ -258,7 +258,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-master
-    testgrid-alert-email: james+alerts@munnelly.eu,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
     description: Runs the end-to-end test suite against a Kubernetes v1.19 cluster
   labels:
     preset-service-account: "true"
@@ -317,7 +317,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-master
-    testgrid-alert-email: james+alerts@munnelly.eu,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
     description: Runs the end-to-end test suite against a Kubernetes v1.20 cluster
   labels:
     preset-service-account: "true"

--- a/config/jobs/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager-periodics.yaml
@@ -49,7 +49,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-master
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     description: Runs 'bazel test //...' using the 'experimental' Bazel version
   spec:
     containers:
@@ -89,7 +89,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-master
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     description: Runs the end-to-end test suite against a Kubernetes v1.16 cluster
   spec:
     containers:
@@ -140,7 +140,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-master
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     description: Runs the end-to-end test suite against a Kubernetes v1.17 cluster
   labels:
     preset-service-account: "true"
@@ -199,7 +199,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-master
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     description: Runs the end-to-end test suite against a Kubernetes v1.18 cluster
   labels:
     preset-service-account: "true"
@@ -258,7 +258,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-master
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     description: Runs the end-to-end test suite against a Kubernetes v1.19 cluster
   labels:
     preset-service-account: "true"
@@ -317,7 +317,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-master
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     description: Runs the end-to-end test suite against a Kubernetes v1.20 cluster
   labels:
     preset-service-account: "true"

--- a/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
+++ b/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
@@ -16,7 +16,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-next
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     description: Runs 'bazel test //...'
   spec:
     containers:
@@ -50,7 +50,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-next
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     description: Runs 'bazel test //...' using the 'experimental' Bazel version
   spec:
     containers:
@@ -89,7 +89,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-next
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     description: Runs the end-to-end test suite against a Kubernetes v1.16 cluster
   spec:
     containers:
@@ -140,7 +140,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-next
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     description: Runs the end-to-end test suite against a Kubernetes v1.17 cluster
   labels:
     preset-service-account: "true"
@@ -199,7 +199,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-next
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     description: Runs the end-to-end test suite against a Kubernetes v1.18 cluster
   labels:
     preset-service-account: "true"
@@ -258,7 +258,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-next
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     description: Runs the end-to-end test suite against a Kubernetes v1.19 cluster
   labels:
     preset-service-account: "true"
@@ -317,7 +317,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-next
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     description: Runs the end-to-end test suite against a Kubernetes v1.20 cluster
   labels:
     preset-service-account: "true"

--- a/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
+++ b/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
@@ -16,7 +16,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-next
-    testgrid-alert-email: james+alerts@munnelly.eu,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
     description: Runs 'bazel test //...'
   spec:
     containers:
@@ -50,7 +50,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-next
-    testgrid-alert-email: james+alerts@munnelly.eu,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
     description: Runs 'bazel test //...' using the 'experimental' Bazel version
   spec:
     containers:
@@ -89,7 +89,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-next
-    testgrid-alert-email: james+alerts@munnelly.eu,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
     description: Runs the end-to-end test suite against a Kubernetes v1.16 cluster
   spec:
     containers:
@@ -140,7 +140,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-next
-    testgrid-alert-email: james+alerts@munnelly.eu,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
     description: Runs the end-to-end test suite against a Kubernetes v1.17 cluster
   labels:
     preset-service-account: "true"
@@ -199,7 +199,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-next
-    testgrid-alert-email: james+alerts@munnelly.eu,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
     description: Runs the end-to-end test suite against a Kubernetes v1.18 cluster
   labels:
     preset-service-account: "true"
@@ -258,7 +258,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-next
-    testgrid-alert-email: james+alerts@munnelly.eu,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
     description: Runs the end-to-end test suite against a Kubernetes v1.19 cluster
   labels:
     preset-service-account: "true"
@@ -317,7 +317,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-next
-    testgrid-alert-email: james+alerts@munnelly.eu,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
     description: Runs the end-to-end test suite against a Kubernetes v1.20 cluster
   labels:
     preset-service-account: "true"

--- a/config/jobs/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
+++ b/config/jobs/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
@@ -16,7 +16,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     description: Runs 'bazel test //...'
   spec:
     containers:
@@ -50,7 +50,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     description: Runs 'bazel test //...' using the 'experimental' Bazel version
   spec:
     containers:
@@ -90,7 +90,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     description: Runs the end-to-end test suite against a Kubernetes v1.11 cluster
   spec:
     containers:
@@ -149,7 +149,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     description: Runs the end-to-end test suite against a Kubernetes v1.12 cluster
   spec:
     containers:
@@ -209,7 +209,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     description: Runs the end-to-end test suite against a Kubernetes v1.13 cluster
   spec:
     containers:
@@ -269,7 +269,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     description: Runs the end-to-end test suite against a Kubernetes v1.14 cluster
   spec:
     containers:
@@ -329,7 +329,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     description: Runs the end-to-end test suite against a Kubernetes v1.15 cluster
   spec:
     containers:
@@ -389,7 +389,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     description: Runs the end-to-end test suite against a Kubernetes v1.16 cluster
   spec:
     containers:
@@ -440,7 +440,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     description: Runs the end-to-end test suite against a Kubernetes v1.17 cluster
   labels:
     preset-service-account: "true"
@@ -499,7 +499,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     description: Runs the end-to-end test suite against a Kubernetes v1.18 cluster
   labels:
     preset-service-account: "true"
@@ -558,7 +558,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     description: Runs the end-to-end test suite against a Kubernetes v1.19 cluster
   labels:
     preset-service-account: "true"
@@ -618,7 +618,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-master
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     description: Runs the end-to-end test suite against an Openshift v3.11 cluster
   labels:
     preset-service-account: "true"

--- a/config/jobs/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
+++ b/config/jobs/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
@@ -16,7 +16,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: james+alerts@munnelly.eu,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
     description: Runs 'bazel test //...'
   spec:
     containers:
@@ -50,7 +50,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: james+alerts@munnelly.eu,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
     description: Runs 'bazel test //...' using the 'experimental' Bazel version
   spec:
     containers:
@@ -90,7 +90,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: james+alerts@munnelly.eu,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
     description: Runs the end-to-end test suite against a Kubernetes v1.11 cluster
   spec:
     containers:
@@ -149,7 +149,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: james+alerts@munnelly.eu,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
     description: Runs the end-to-end test suite against a Kubernetes v1.12 cluster
   spec:
     containers:
@@ -209,7 +209,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: james+alerts@munnelly.eu,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
     description: Runs the end-to-end test suite against a Kubernetes v1.13 cluster
   spec:
     containers:
@@ -269,7 +269,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: james+alerts@munnelly.eu,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
     description: Runs the end-to-end test suite against a Kubernetes v1.14 cluster
   spec:
     containers:
@@ -329,7 +329,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: james+alerts@munnelly.eu,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
     description: Runs the end-to-end test suite against a Kubernetes v1.15 cluster
   spec:
     containers:
@@ -389,7 +389,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: james+alerts@munnelly.eu,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
     description: Runs the end-to-end test suite against a Kubernetes v1.16 cluster
   spec:
     containers:
@@ -440,7 +440,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: james+alerts@munnelly.eu,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
     description: Runs the end-to-end test suite against a Kubernetes v1.17 cluster
   labels:
     preset-service-account: "true"
@@ -499,7 +499,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: james+alerts@munnelly.eu,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
     description: Runs the end-to-end test suite against a Kubernetes v1.18 cluster
   labels:
     preset-service-account: "true"
@@ -558,7 +558,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: james+alerts@munnelly.eu,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
     description: Runs the end-to-end test suite against a Kubernetes v1.19 cluster
   labels:
     preset-service-account: "true"
@@ -618,7 +618,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-master
-    testgrid-alert-email: james+alerts@munnelly.eu,maartje+alerts@eyskens.me
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com,maartje+alerts@eyskens.me
     description: Runs the end-to-end test suite against an Openshift v3.11 cluster
   labels:
     preset-service-account: "true"

--- a/config/jobs/cert-manager/website/cert-manager-website-periodics.yaml
+++ b/config/jobs/cert-manager/website/cert-manager-website-periodics.yaml
@@ -13,7 +13,7 @@ periodics:
     preset-service-account: "true"
   annotations:
     testgrid-dashboards: jetstack-cert-manager-website
-    testgrid-alert-email: james+alerts@munnelly.eu
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     description: Updates the algolia search index for the cert-manager website
   spec:
     containers:

--- a/config/jobs/testing/testing-periodics.yaml
+++ b/config/jobs/testing/testing-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
   decorate: true
   annotations:
     testgrid-dashboards: jetstack-testing-janitors
-    testgrid-alert-email: james+alerts@munnelly.eu
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     description: Periodically comments /retest against approved and lgtm'd PRs that are failing
   spec:
     containers:
@@ -55,7 +55,7 @@ periodics:
   decorate: true
   annotations:
     testgrid-dashboards: jetstack-testing-janitors
-    testgrid-alert-email: james+alerts@munnelly.eu
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     description: Closes PRs and issues that are marked 'rotten' and have been inactive for 30d
   spec:
     containers:
@@ -92,7 +92,7 @@ periodics:
   decorate: true
   annotations:
     testgrid-dashboards: jetstack-testing-janitors
-    testgrid-alert-email: james+alerts@munnelly.eu
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     description: Marks PRs and issues that are marked 'stale' and have been inactive for 30d as 'rotten'
   spec:
     containers:
@@ -132,7 +132,7 @@ periodics:
   decorate: true
   annotations:
     testgrid-dashboards: jetstack-testing-janitors
-    testgrid-alert-email: james+alerts@munnelly.eu
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     description: Marks PRs and issues that have been inactive for 30d as 'stale'
   spec:
     containers:

--- a/config/jobs/testing/testing-trusted.yaml
+++ b/config/jobs/testing/testing-trusted.yaml
@@ -71,7 +71,7 @@ postsubmits:
       preset-bazel-scratch-dir: "true"
     annotations:
       testgrid-dashboards: jetstack-testing-janitors
-      testgrid-alert-email: james+alerts@munnelly.eu
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     spec:
       containers:
       - image: gcr.io/k8s-prow/transfigure
@@ -103,7 +103,7 @@ postsubmits:
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-testing-janitors
-      testgrid-alert-email: james+alerts@munnelly.eu
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
       description: Build and push the 'bazelbuild' image
     spec:
       containers:
@@ -139,7 +139,7 @@ postsubmits:
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-testing-janitors
-      testgrid-alert-email: james+alerts@munnelly.eu
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
       description: Build and push the 'golang-dind' image
     spec:
       containers:
@@ -175,7 +175,7 @@ postsubmits:
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-testing-janitors
-      testgrid-alert-email: james+alerts@munnelly.eu
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
       description: Build and push the 'golang-nodejs' image
     spec:
       containers:
@@ -211,7 +211,7 @@ postsubmits:
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-testing-janitors
-      testgrid-alert-email: james+alerts@munnelly.eu
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
       description: Build and push the 'katacoda-lint' image
     spec:
       containers:
@@ -247,7 +247,7 @@ postsubmits:
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-testing-janitors
-      testgrid-alert-email: james+alerts@munnelly.eu
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
       description: Build and push the 'tarmak-ruby' image
     spec:
       containers:
@@ -283,7 +283,7 @@ postsubmits:
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-testing-janitors
-      testgrid-alert-email: james+alerts@munnelly.eu
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
       description: Build and push the 'tarmak-sphinx-docs' image
     spec:
       containers:
@@ -319,7 +319,7 @@ postsubmits:
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-testing-janitors
-      testgrid-alert-email: james+alerts@munnelly.eu
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
       description: Build and push the 'terraform-google-gke-cluster' image
     spec:
       containers:


### PR DESCRIPTION
As discussed with @munnerz today and with the team [during the standup](https://docs.google.com/document/d/1EohesIvuUqeELN-f7TzLilAYVRKIDPjrX4Sxyz-BD7k/edit#bookmark=id.i6zyn2oxxt1m) on Wed 27 Jan 2021, it might be worth creating cert-manager-dev-alerts@googlegroups.com that will allow anyone to subscribe to the test-grid notifications.

James Munnelly has created the group [cert-manager-dev-alerts](https://groups.google.com/g/cert-manager-dev-alerts).

From @james-w:
> We are also going to deploy an instance we manage ourselves rather than relying on that environment

Related PRs:
- https://github.com/jetstack/platform-board/issues/291 (group created)
- https://github.com/cert-manager/website/pull/419 (document the alerting mechanism)