### PR TITLE
Disable the Venafi Cloud E2E tests

### DIFF
--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -48,19 +48,26 @@ presets:
 #         name: venafi-tpp
 #         key: password
 
-- labels:
-    preset-venafi-cloud-credentials: "true"
-  env:
-  - name: VENAFI_CLOUD_ZONE
-    valueFrom:
-      secretKeyRef:
-        name: venafi-cloud
-        key: zone
-  - name: VENAFI_CLOUD_APITOKEN
-    valueFrom:
-      secretKeyRef:
-        name: venafi-cloud
-        key: apitoken
+# The Venafi Cloud API token has expired or has been revoked.
+# Jetstack Infra team are setting up a new user and API token but we're
+# temporarily disabling these tests so that we can get cert-manager PRs merged
+# Commenting out these pod presets when will cause the Venafi Cloud Issuer E2E tests
+# to be skipped. See:
+# * https://github.com/jetstack/cert-manager/issues/3555
+#
+# - labels:
+#     preset-venafi-cloud-credentials: "true"
+#   env:
+#   - name: VENAFI_CLOUD_ZONE
+#     valueFrom:
+#       secretKeyRef:
+#         name: venafi-cloud
+#         key: zone
+#   - name: VENAFI_CLOUD_APITOKEN
+#     valueFrom:
+#       secretKeyRef:
+#         name: venafi-cloud
+#         key: apitoken
 
 - labels:
     preset-retry-flakey-tests: "true"


### PR DESCRIPTION
See https://github.com/jetstack/cert-manager/issues/3555#issuecomment-772475332

```release-note
NONE
```