### PR TITLE
Add a manually triggered E2E test job for Venafi TPP

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,7 +1,7 @@
 plank:
   job_url_template: 'https://prow.build-infra.jetstack.net/view/gcs/jetstack-logs/{{if eq .Spec.Type "presubmit"}}pr-logs/pull{{else if eq .Spec.Type "batch"}}pr-logs/pull{{else}}logs{{end}}{{if .Spec.Refs}}{{if ne .Spec.Refs.Org ""}}/{{.Spec.Refs.Org}}_{{.Spec.Refs.Repo}}{{end}}{{end}}{{if eq .Spec.Type "presubmit"}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}{{else if eq .Spec.Type "batch"}}/batch{{end}}/{{.Spec.Job}}/{{.Status.BuildID}}/'
   report_templates: 
-    '*': '[Full PR test history](https://prow.build-infra.jetstack.net/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}). [Your PR dashboard](https://jetstack-build-infra.appspot.com/pr/{{with index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}). Please help us cut down on flakes by [linking to](https://git.k8s.io/community/contributors/devel/flaky-tests.md#filing-issues-for-flaky-tests) an [open issue](https://github.com/{{.Spec.Refs.Org}}/{{.Spec.Refs.Repo}}/issues?q=is:issue+is:open) when you hit one in your PR.'
+    '*': '[Full PR test history](https://prow.build-infra.jetstack.net/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}). [Your PR dashboard](https://jetstack-build-infra.appspot.com/pr/{{with index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}). Please help us cut down on flakes by [linking to](https://git.k8s.io/community/contributors/devel/sig-testing/flaky-tests.md#github-issues-for-known-flakes) an [open issue](https://github.com/{{.Spec.Refs.Org}}/{{.Spec.Refs.Repo}}/issues?q=is:issue+is:open) when you hit one in your PR.'
   job_url_prefix_config:
     '*': https://prow.build-infra.jetstack.net/view/gcs/
   pod_pending_timeout: 60m

--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -450,6 +450,73 @@ presubmits:
         options:
         - name: ndots
           value: "1"
+
+  # An E2E test job to allow us to manually trigger the Venafi TPP E2E tests
+  # with the following GitHub comment:
+  #
+  #  /test pull-cert-manager-e2e-v1-20-venafi-issuer-tpp
+  #
+  # See https://github.com/jetstack/cert-manager/issues/3555
+  #
+  - name: pull-cert-manager-e2e-v1-20-venafi-issuer-tpp
+    cluster: gke
+    context: pull-cert-manager-e2e-v1-20-venafi-issuer-tpp
+    always_run: false
+    optional: true
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    branches:
+    - master
+    - release-1.3
+    annotations:
+      description: Runs the E2E tests labelled [Feature:VenafiIssuer:TPP] against a Kubernetes v1.20 cluster
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-venafi-tpp-credentials: "true"
+      preset-retry-flakey-tests: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200428-6b034c1-2.2.0
+        args:
+        - runner
+        - devel/ci-run-e2e.sh
+        - -ginkgo.focus
+        - '\[Feature:VenafiIssuer:TPP\]'
+        resources:
+          requests:
+            cpu: 6
+            memory: 12Gi
+        env:
+        - name: K8S_VERSION
+          value: "1.20"
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+
   # e2e test job with experimental certificates controller enabled
   - name: pull-cert-manager-experimental-e2e-v1-17
     cluster: gke

--- a/config/jobs/cert-manager/config.yaml
+++ b/config/jobs/cert-manager/config.yaml
@@ -18,32 +18,29 @@ presets:
         name: cloudflare-api-key
         key: domain
 
-# The Venafi TPP test server is currently offline.
-# Commenting out these pod presets when will cause the Venafi Issuer E2E tests
-# to be skipped.
-# - labels:
-#     preset-venafi-tpp-credentials: "true"
-#   env:
-#   - name: VENAFI_TPP_URL
-#     valueFrom:
-#       secretKeyRef:
-#         name: venafi-tpp
-#         key: url
-#   - name: VENAFI_TPP_ZONE
-#     valueFrom:
-#       secretKeyRef:
-#         name: venafi-tpp
-#         key: zone
-#   - name: VENAFI_TPP_USERNAME
-#     valueFrom:
-#       secretKeyRef:
-#         name: venafi-tpp
-#         key: username
-#   - name: VENAFI_TPP_PASSWORD
-#     valueFrom:
-#       secretKeyRef:
-#         name: venafi-tpp
-#         key: password
+- labels:
+    preset-venafi-tpp-credentials: "true"
+  env:
+  - name: VENAFI_TPP_URL
+    valueFrom:
+      secretKeyRef:
+        name: venafi-tpp
+        key: url
+  - name: VENAFI_TPP_ZONE
+    valueFrom:
+      secretKeyRef:
+        name: venafi-tpp
+        key: zone
+  - name: VENAFI_TPP_USERNAME
+    valueFrom:
+      secretKeyRef:
+        name: venafi-tpp
+        key: username
+  - name: VENAFI_TPP_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: venafi-tpp
+        key: password
 
 - labels:
     preset-venafi-cloud-credentials: "true"


### PR DESCRIPTION
Followup to  https://github.com/jetstack/cert-manager/pull/3679 where I've configured Ginkgo to skip tests with the `[Feature:xx]` label.

Merge this one first so that I can test the job on https://github.com/jetstack/cert-manager/pull/3679

Part of: https://github.com/jetstack/cert-manager/issues/3555

```release-note
NONE
```