### PR TITLE
Adds args to build golang-dind image with go 1.16

### DIFF
--- a/images/golang-dind/build.yaml
+++ b/images/golang-dind/build.yaml
@@ -1,6 +1,10 @@
 name: golang-dind # Name of the image to be built
 
 variants:
+  "1.16":
+    arguments:
+      BASE_IMAGE: "eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200428-6b034c1-3.0.0"
+      GO_VERSION: "1.16"
   "1.15.7":
     arguments:
       BASE_IMAGE: "eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200428-6b034c1-3.0.0"


### PR DESCRIPTION
I am not 100% sure whether I actually need to build this image locally and push to GCR or whether there is some automation somewhere such that once this gets merged, it will build it and push it automatically 😄 