### PR TITLE
Use Bazel 3.7 for experimental Bazel builds

### DIFF
--- a/images/bazelbuild/build.yaml
+++ b/images/bazelbuild/build.yaml
@@ -5,7 +5,7 @@ name: bazelbuild # Name of the image to be built
 variants:
   experimental:
     arguments:
-      BAZEL_VERSION: "3.0.0"
+      BAZEL_VERSION: "3.7.2"
       DEBIAN_VERSION: buster
       DOCKER_VERSION: 5:19.03.3~3-0~debian-buster
 


### PR DESCRIPTION
We should upgrade version of Bazel that we are using in `cert-manager` CI tests (Currently v2.2.0 for [regular presubmit tests](https://github.com/jetstack/testing/blob/master/config/jobs/cert-manager/cert-manager-presubmits.yaml#L24)), so that we can upgrade some Bazel dependencies (i.e [go rules](https://github.com/bazelbuild/rules_go/releases/tag/v0.26.0))

I would like to build an experimental image to be then used in [bazel-experimental](https://github.com/jetstack/testing/blob/master/config/jobs/cert-manager/cert-manager-presubmits.yaml#L39) to see that nothing breaks, so we can then upgrade the regular bazel image to v3.7.2 also.

Signed-off-by: irbekrm <irbekrm@gmail.com>