### PR TITLE
Bump versions for bazelbuild images

### DIFF
--- a/images/bazelbuild/build.yaml
+++ b/images/bazelbuild/build.yaml
@@ -5,20 +5,20 @@ name: bazelbuild # Name of the image to be built
 variants:
   experimental:
     arguments:
-      BAZEL_VERSION: "3.7.2"
+      BAZEL_VERSION: "4.0.0"
       DEBIAN_VERSION: buster
       DOCKER_VERSION: 5:19.03.3~3-0~debian-buster
 
-  "3.0.0":
+  "4.0.0":
     arguments:
-      BAZEL_VERSION: "3.0.0"
+      BAZEL_VERSION: "4.0.0"
       DEBIAN_VERSION: buster
       DOCKER_VERSION: 5:19.03.3~3-0~debian-buster
 
-  "2.2.0":
+  "3.7.2":
     # Specify build arguments for this variant
     arguments:
-      BAZEL_VERSION: "2.2.0"
+      BAZEL_VERSION: "3.7.2"
       DEBIAN_VERSION: buster
       DOCKER_VERSION: 5:19.03.3~3-0~debian-buster
 


### PR DESCRIPTION
`cert-manager` experimental-bazel builds with Bazel v3.7.2 passed [i.e here](https://prow.k8s.io/view/gs/jetstack-logs/logs/ci-cert-manager-bazel-experimental/1374400310495154176), so I'm bumping versions again to build `bazelbuild` images only with Bazel v4.0.0 and v3.7.2
Once these images have been build, I will bump Bazel versions of regular and bazel-experimental CM CI tests accordingly.

Signed-off-by: irbekrm <irbekrm@gmail.com>