### PR TITLE
Bazel 3.7.2 -> 3.5.0

### DIFF
--- a/images/bazelbuild/build.yaml
+++ b/images/bazelbuild/build.yaml
@@ -15,10 +15,10 @@ variants:
       DEBIAN_VERSION: buster
       DOCKER_VERSION: 5:19.03.3~3-0~debian-buster
 
-  "3.7.2":
+  "3.5.0":
     # Specify build arguments for this variant
     arguments:
-      BAZEL_VERSION: "3.7.2"
+      BAZEL_VERSION: "3.5.0"
       DEBIAN_VERSION: buster
       DOCKER_VERSION: 5:19.03.3~3-0~debian-buster
 


### PR DESCRIPTION
I previously bumped Bazel version 2v.2.0 -> v3.7.2 everywhere which caused our release tool to fail as the latest official Bazel image is with v3.5.0 https://console.cloud.google.com/gcr/images/cloud-marketplace-containers/GLOBAL/google/bazel?gcrImageListsize=30

I would now like to build an image with v3.5.0 so that we can use the same version everywhere.
Signed-off-by: irbekrm <irbekrm@gmail.com>