### PR TITLE
Bumps versions of Bazel

### DIFF
--- a/images/golang-dind/build.yaml
+++ b/images/golang-dind/build.yaml
@@ -3,11 +3,11 @@ name: golang-dind # Name of the image to be built
 variants:
   "1.16":
     arguments:
-      BASE_IMAGE: "eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200428-6b034c1-3.0.0"
+      BASE_IMAGE: "eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210331-363c37a-3.5.0"
       GO_VERSION: "1.16"
   "1.15.7":
     arguments:
-      BASE_IMAGE: "eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200428-6b034c1-3.0.0"
+      BASE_IMAGE: "eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210331-363c37a-3.5.0"
       GO_VERSION: "1.15.7"
   "1.14.2":
     arguments:


### PR DESCRIPTION
Creates a `golang-dind` image with v3.5.0 of Bazel.

This will only create a new image.

I'd like this image to be able to run CI tests for our release tool with a newer version of [golang-dind image](https://github.com/jetstack/testing/blob/master/config/jobs/cert-manager/release/cert-manager-release-presubmits.yaml#L18)- right now they're failing because the version is too old (v2.2.0) 

```release-note
NONE
```

Signed-off-by: irbekrm <irbekrm@gmail.com>