### PR TITLE
bump bazel for cmrel presubmit image

### DIFF
--- a/config/jobs/cert-manager/release/cert-manager-release-presubmits.yaml
+++ b/config/jobs/cert-manager/release/cert-manager-release-presubmits.yaml
@@ -15,7 +15,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20210122-46f3dbf-1.14.2
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20210331-a8721c1-1.16
         args:
         - runner
         - ./test/presubmit.sh


### PR DESCRIPTION
This bumps version of image used to run presubmit tests for cert-manager release tool.

It uses an image with an updated version of Bazel (v2.2.0 -> v3.5.0) and Go (v1.14 -> v1.16).

Currently we have those presubmit test failing as they do a mock release of cert-manager whose Bazel setup doesn't work with v2.2.0 https://prow.build-infra.jetstack.net/view/gcs/jetstack-logs/pr-logs/pull/cert-manager_release/23/pull-cert-manager-release-verify/1377218476724195328

Signed-off-by: irbekrm <irbekrm@gmail.com>