### PR TITLE
Enables GCS reporter

### DIFF
--- a/prow/cluster/crier_deployment.yaml
+++ b/prow/cluster/crier_deployment.yaml
@@ -39,6 +39,7 @@ spec:
         - --job-config-path=/etc/job-config
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
+        - --kubernetes-blob-storage-workers=1
         volumeMounts:
         - name: config
           mountPath: /etc/config


### PR DESCRIPTION
See https://github.com/jetstack/cert-manager/issues/3827 for context.

Currently all our tests are marked as failing in Testgrid due to there being a new row that reports health of a ProwJob's pod and us not having a reporter that would report pod's health.
This PR attempts to enable [GCS Kubernetes plugin](https://github.com/kubernetes/test-infra/tree/b6180c95b3383919711cfc97436a2d082281d284/prow/crier/reporters/gcs/kubernetes) that would report pod's health.

As I understand the reporter would generate a `podinfo.json` file and upload it to [the GCS bucket we are already using](https://console.cloud.google.com/storage/browser/jetstack-logs/logs?authuser=1&project=jetstack-build-infra&pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22))&prefix=&forceOnObjectsSortingFiltering=false) using [the same creds](https://github.com/jetstack/testing/blob/master/config/config.yaml#L23).

I am not sure if there is some test env where I could try this first?
Also I guess there will be an extra step to get this config to be applied.

```release-note
Enable GCS plugin for crier
```

Signed-off-by: irbekrm <irbekrm@gmail.com>