### PR TITLE
Bump cert-manager version

### DIFF
--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.3
+    - release-1.4
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
@@ -46,7 +46,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.3
+    - release-1.4
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
@@ -84,7 +84,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.3
+    - release-1.4
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
@@ -122,7 +122,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.3
+    - release-1.4
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
@@ -158,7 +158,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.3
+    - release-1.4
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
@@ -219,7 +219,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.3
+    - release-1.4
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
@@ -280,7 +280,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.3
+    - release-1.4
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
@@ -340,7 +340,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.3
+    - release-1.4
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
@@ -400,7 +400,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.3
+    - release-1.4
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking

--- a/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
+++ b/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
@@ -8,7 +8,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.3
+    base_ref: release-1.4
   labels:
     preset-service-account: "true"
     preset-bazel-remote-cache-enabled: "true"
@@ -43,7 +43,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.3
+    base_ref: release-1.4
   labels:
     preset-service-account: "true"
     preset-bazel-scratch-dir: "true"
@@ -77,7 +77,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.3
+    base_ref: release-1.4
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
@@ -136,7 +136,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.3
+    base_ref: release-1.4
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-next
@@ -195,7 +195,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.3
+    base_ref: release-1.4
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-next
@@ -254,7 +254,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.3
+    base_ref: release-1.4
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-next
@@ -313,7 +313,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.3
+    base_ref: release-1.4
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-next

--- a/config/jobs/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
+++ b/config/jobs/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
@@ -8,7 +8,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.2
+    base_ref: release-1.3
   labels:
     preset-service-account: "true"
     preset-bazel-remote-cache-enabled: "true"
@@ -43,7 +43,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.2
+    base_ref: release-1.3
   labels:
     preset-service-account: "true"
     preset-bazel-scratch-dir: "true"
@@ -77,7 +77,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.2
+    base_ref: release-1.3
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
@@ -136,7 +136,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.2
+    base_ref: release-1.3
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
@@ -195,7 +195,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.2
+    base_ref: release-1.3
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
@@ -254,7 +254,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.2
+    base_ref: release-1.3
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous

--- a/config/jobs/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
+++ b/config/jobs/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
-    - release-1.2
+    - release-1.3
     annotations:
       testgrid-create-test-group: 'false'
     labels:
@@ -42,7 +42,7 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
-    - release-1.2
+    - release-1.3
     annotations:
       testgrid-create-test-group: 'false'
     labels:
@@ -77,7 +77,7 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
-    - release-1.2
+    - release-1.3
     annotations:
       testgrid-create-test-group: 'false'
     labels:
@@ -112,7 +112,7 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
-    - release-1.2
+    - release-1.3
     annotations:
       testgrid-create-test-group: 'false'
     labels:
@@ -144,7 +144,7 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
-    - release-1.2
+    - release-1.3
     annotations:
       testgrid-create-test-group: 'false'
     labels:
@@ -202,7 +202,7 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
-    - release-1.2
+    - release-1.3
     annotations:
       testgrid-create-test-group: 'false'
     labels:
@@ -260,7 +260,7 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
-    - release-1.2
+    - release-1.3
     annotations:
       testgrid-create-test-group: 'false'
     labels:

--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -88,7 +88,8 @@ repo_milestone:
 
 milestone_applier:
   jetstack/cert-manager:
-    master: v1.3
+    master: v1.4
+    release-1.3: v1.3
     release-1.2: v1.2
     release-1.1: v1.1
     release-1.0: v1.0
@@ -104,9 +105,10 @@ milestone_applier:
   cert-manager/website:
     # cert-manager/website uses master branch for 'current' version and the
     # release-next branch for the 'next' version
-    release-next: v1.3
-    master: v1.2
+    release-next: v1.4
+    master: v1.3
     # Older versions are archived into named release branches
+    release-1.2: v1.2
     release-1.1: v1.1
     release-1.0: v1.0
     release-0.16: v0.16


### PR DESCRIPTION
Updated current, release-previous and release-next jobs.

See https://github.com/jetstack/testing/pull/428 for an example of us doing this for the 1.2 release.

```release-note
NONE
```