### PR TITLE
Remove the reference to a non-existent config entry

### DIFF
--- a/config/jobs/cert-manager-csi/cert-manager-csi-presubmits.yaml
+++ b/config/jobs/cert-manager-csi/cert-manager-csi-presubmits.yaml
@@ -3,7 +3,6 @@ presubmits:
 
   - name: pull-cert-manager-csi-verify
     always_run: true
-    cluster: gke
     context: pull-cert-manager-csi-verify
     max_concurrency: 8
     agent: kubernetes
@@ -46,7 +45,6 @@ presubmits:
 
   # kind based cert-manager-csi e2e job for Kubernetes v1.16, cert-manager v1.12
   - name: pull-cert-manager-csi-e2e-v1-16
-    cluster: gke
     context: pull-cert-manager-csi-e2e-v1-16
     # Match everything except PRs that only touch docs/
     always_run: true

--- a/config/jobs/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager-periodics.yaml
@@ -2,7 +2,6 @@ periodics:
 
 - name: ci-cert-manager-bazel
   interval: 2h
-  cluster: gke
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -36,7 +35,6 @@ periodics:
 
 - name: ci-cert-manager-bazel-experimental
   interval: 2h
-  cluster: gke
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -71,7 +69,6 @@ periodics:
 # kind based cert-manager e2e job
 - name: ci-cert-manager-e2e-v1-16
   interval: 2h
-  cluster: gke
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -130,7 +127,6 @@ periodics:
 
 - name: ci-cert-manager-e2e-v1-17
   interval: 2h
-  cluster: gke
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -189,7 +185,6 @@ periodics:
 
 - name: ci-cert-manager-e2e-v1-18
   interval: 2h
-  cluster: gke
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -248,7 +243,6 @@ periodics:
 
 - name: ci-cert-manager-e2e-v1-19
   interval: 2h
-  cluster: gke
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -307,7 +301,6 @@ periodics:
 
 - name: ci-cert-manager-e2e-v1-20
   interval: 2h
-  cluster: gke
   agent: kubernetes
   decorate: true
   extra_refs:

--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -3,7 +3,6 @@ presubmits:
 
   - name: pull-cert-manager-bazel
     always_run: true
-    cluster: gke
     context: pull-cert-manager-bazel
     max_concurrency: 8
     agent: kubernetes
@@ -39,7 +38,6 @@ presubmits:
   - name: pull-cert-manager-bazel-experimental
     always_run: false
     optional: true
-    cluster: gke
     context: pull-cert-manager-bazel-experimental
     max_concurrency: 8
     agent: kubernetes
@@ -77,7 +75,6 @@ presubmits:
   # See https://github.com/helm/chart-testing/issues/53
   - name: pull-cert-manager-chart
     always_run: true
-    cluster: gke
     context: pull-cert-manager-chart
     max_concurrency: 8
     agent: kubernetes
@@ -115,7 +112,6 @@ presubmits:
 
   - name: pull-cert-manager-deps
     always_run: true
-    cluster: gke
     context: pull-cert-manager-deps
     max_concurrency: 4
     agent: kubernetes
@@ -149,7 +145,6 @@ presubmits:
 
   # kind based cert-manager e2e job
   - name: pull-cert-manager-e2e-v1-16
-    cluster: gke
     context: pull-cert-manager-e2e-v1-16
     always_run: false
     optional: true
@@ -210,7 +205,6 @@ presubmits:
             value: "1"
 
   - name: pull-cert-manager-e2e-v1-17
-    cluster: gke
     context: pull-cert-manager-e2e-v1-17
     always_run: false
     optional: true
@@ -271,7 +265,6 @@ presubmits:
           value: "1"
 
   - name: pull-cert-manager-e2e-v1-18
-    cluster: gke
     context: pull-cert-manager-e2e-v1-18
     always_run: false
     optional: true
@@ -331,7 +324,6 @@ presubmits:
         - name: ndots
           value: "1"
   - name: pull-cert-manager-e2e-v1-19
-    cluster: gke
     context: pull-cert-manager-e2e-v1-19
     always_run: false
     optional: true
@@ -391,7 +383,6 @@ presubmits:
         - name: ndots
           value: "1"
   - name: pull-cert-manager-e2e-v1-20
-    cluster: gke
     context: pull-cert-manager-e2e-v1-20
     always_run: true
     optional: false
@@ -459,7 +450,6 @@ presubmits:
   # See https://github.com/jetstack/cert-manager/issues/3555
   #
   - name: pull-cert-manager-e2e-v1-20-feature-issuers-venafi-tpp
-    cluster: gke
     always_run: false
     optional: true
     max_concurrency: 4

--- a/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
+++ b/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
@@ -2,7 +2,6 @@ periodics:
 
 - name: ci-cert-manager-next-bazel
   interval: 2h
-  cluster: gke
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -37,7 +36,6 @@ periodics:
 
 - name: ci-cert-manager-next-bazel-experimental
   interval: 2h
-  cluster: gke
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -71,7 +69,6 @@ periodics:
 
 - name: ci-cert-manager-next-e2e-v1-16
   interval: 2h
-  cluster: gke
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -130,7 +127,6 @@ periodics:
 
 - name: ci-cert-manager-next-e2e-v1-17
   interval: 2h
-  cluster: gke
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -189,7 +185,6 @@ periodics:
 
 - name: ci-cert-manager-next-e2e-v1-18
   interval: 2h
-  cluster: gke
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -248,7 +243,6 @@ periodics:
 
 - name: ci-cert-manager-next-e2e-v1-19
   interval: 2h
-  cluster: gke
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -307,7 +301,6 @@ periodics:
 
 - name: ci-cert-manager-next-e2e-v1-20
   interval: 2h
-  cluster: gke
   agent: kubernetes
   decorate: true
   extra_refs:

--- a/config/jobs/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
+++ b/config/jobs/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
@@ -2,7 +2,6 @@ periodics:
 
 - name: ci-cert-manager-previous-bazel
   interval: 2h
-  cluster: gke
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -37,7 +36,6 @@ periodics:
 
 - name: ci-cert-manager-previous-previous-experimental
   interval: 2h
-  cluster: gke
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -71,7 +69,6 @@ periodics:
 
 - name: ci-cert-manager-previous-e2e-v1-16
   interval: 2h
-  cluster: gke
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -130,7 +127,6 @@ periodics:
 
 - name: ci-cert-manager-previous-e2e-v1-17
   interval: 2h
-  cluster: gke
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -189,7 +185,6 @@ periodics:
 
 - name: ci-cert-manager-previous-e2e-v1-18
   interval: 2h
-  cluster: gke
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -248,7 +243,6 @@ periodics:
 
 - name: ci-cert-manager-previous-e2e-v1-19
   interval: 2h
-  cluster: gke
   agent: kubernetes
   decorate: true
   extra_refs:

--- a/config/jobs/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
+++ b/config/jobs/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
@@ -3,7 +3,6 @@ presubmits:
 
   - name: pull-cert-manager-bazel
     always_run: true
-    cluster: gke
     context: pull-cert-manager-bazel
     max_concurrency: 8
     agent: kubernetes
@@ -36,7 +35,6 @@ presubmits:
   - name: pull-cert-manager-bazel-experimental
     always_run: false
     optional: true
-    cluster: gke
     context: pull-cert-manager-bazel-experimental
     max_concurrency: 8
     agent: kubernetes
@@ -71,7 +69,6 @@ presubmits:
   # See https://github.com/helm/chart-testing/issues/53
   - name: pull-cert-manager-chart
     always_run: true
-    cluster: gke
     context: pull-cert-manager-chart
     max_concurrency: 8
     agent: kubernetes
@@ -106,7 +103,6 @@ presubmits:
 
   - name: pull-cert-manager-deps
     always_run: true
-    cluster: gke
     context: pull-cert-manager-deps
     max_concurrency: 4
     agent: kubernetes
@@ -136,7 +132,6 @@ presubmits:
           value: "1"
 
   - name: pull-cert-manager-e2e-v1-16
-    cluster: gke
     context: pull-cert-manager-e2e-v1-16
     always_run: false
     optional: true
@@ -194,7 +189,6 @@ presubmits:
           value: "1"
 
   - name: pull-cert-manager-e2e-v1-17
-    cluster: gke
     context: pull-cert-manager-e2e-v1-17
     always_run: false
     optional: true
@@ -252,7 +246,6 @@ presubmits:
           value: "1"
 
   - name: pull-cert-manager-e2e-v1-19
-    cluster: gke
     context: pull-cert-manager-e2e-v1-19
     optional: false
     always_run: true
@@ -310,7 +303,6 @@ presubmits:
           value: "1"
 
   - name: pull-cert-manager-e2e-v1-20
-    cluster: gke
     context: pull-cert-manager-e2e-v1-20
     optional: false
     always_run: true

--- a/config/jobs/cert-manager/release/cert-manager-release-presubmits.yaml
+++ b/config/jobs/cert-manager/release/cert-manager-release-presubmits.yaml
@@ -2,7 +2,6 @@ presubmits:
   cert-manager/release:
   - name: pull-cert-manager-release-verify
     always_run: true
-    cluster: gke
     context: pull-cert-manager-release-verify
     max_concurrency: 8
     agent: kubernetes

--- a/config/jobs/cert-manager/webhook-example/cert-manager-webhook-example-presubmits.yaml
+++ b/config/jobs/cert-manager/webhook-example/cert-manager-webhook-example-presubmits.yaml
@@ -3,7 +3,6 @@ presubmits:
 
   - name: pull-cert-manager-webhook-example-verify
     always_run: true
-    cluster: gke
     context: pull-cert-manager-webhook-example-verify
     max_concurrency: 8
     agent: kubernetes

--- a/config/jobs/cert-manager/website/cert-manager-website-presubmits.yaml
+++ b/config/jobs/cert-manager/website/cert-manager-website-presubmits.yaml
@@ -3,7 +3,6 @@ presubmits:
 
   - name: pull-cert-manager-website-verify
     always_run: true
-    cluster: gke
     context: pull-cert-manager-website-verify
     max_concurrency: 8
     agent: kubernetes

--- a/config/jobs/istio-csr/istio-csr-presubmits.yaml
+++ b/config/jobs/istio-csr/istio-csr-presubmits.yaml
@@ -2,7 +2,6 @@ presubmits:
   cert-manager/istio-csr:
 
   - name: pull-istio-csr-verify
-    cluster: gke
     agent: kubernetes
     decorate: true
     always_run: true
@@ -22,7 +21,6 @@ presubmits:
 
   # kind based istio-csr e2e job for Kubernetes v1.20, istio v1.7
   - name: pull-istio-csr-k8s-v1-20-istio-v1-7
-    cluster: gke
     context: pull-istio-csr-k8s-v1-20-istio-v1-7
     # Match everything except PRs that only touch docs/
     always_run: true
@@ -77,7 +75,6 @@ presubmits:
 
   # kind based istio-csr e2e job for Kubernetes v1.20, istio v1.8
   - name: pull-istio-csr-k8s-v1-20-istio-v1-8
-    cluster: gke
     context: pull-istio-csr-k8s-v1-20-istio-v1-8
     # Match everything except PRs that only touch docs/
     always_run: true
@@ -132,7 +129,6 @@ presubmits:
 
   # kind based istio-csr e2e job for Kubernetes v1.20, istio v1.9
   - name: pull-istio-csr-k8s-v1-20-istio-v1-9
-    cluster: gke
     context: pull-istio-csr-k8s-v1-20-istio-v1-9
     # Match everything except PRs that only touch docs/
     always_run: true

--- a/config/jobs/kube-oidc-proxy/kube-oidc-proxy-presubmits.yaml
+++ b/config/jobs/kube-oidc-proxy/kube-oidc-proxy-presubmits.yaml
@@ -3,7 +3,6 @@ presubmits:
 
   - name: pull-kube-oidc-proxy-verify
     always_run: true
-    cluster: gke
     context: pull-kube-oidc-proxy-verify
     max_concurrency: 8
     agent: kubernetes
@@ -23,7 +22,6 @@ presubmits:
 
   - name: pull-kube-oidc-proxy-demo
     always_run: true
-    cluster: gke
     context: pull-kube-oidc-proxy-demo
     max_concurrency: 2
     agent: kubernetes
@@ -47,7 +45,6 @@ presubmits:
   - name: pull-kube-oidc-proxy-e2e-v1-11
     context: pull-kube-oidc-proxy-e2e-v1-11
     always_run: false
-    cluster: gke
     optional: true
     max_concurrency: 4
     agent: kubernetes
@@ -94,7 +91,6 @@ presubmits:
   - name: pull-kube-oidc-proxy-e2e-v1-12
     context: pull-kube-oidc-proxy-e2e-v1-12
     always_run: false
-    cluster: gke
     optional: true
     max_concurrency: 4
     agent: kubernetes
@@ -141,7 +137,6 @@ presubmits:
   - name: pull-kube-oidc-proxy-e2e-v1-13
     context: pull-kube-oidc-proxy-e2e-v1-13
     always_run: false
-    cluster: gke
     optional: true
     max_concurrency: 4
     agent: kubernetes
@@ -188,7 +183,6 @@ presubmits:
   - name: pull-kube-oidc-proxy-e2e-v1-14
     context: pull-kube-oidc-proxy-e2e-v1-14
     always_run: false
-    cluster: gke
     optional: true
     max_concurrency: 4
     agent: kubernetes
@@ -235,7 +229,6 @@ presubmits:
   - name: pull-kube-oidc-proxy-e2e-v1-15
     context: pull-kube-oidc-proxy-e2e-v1-15
     always_run: false
-    cluster: gke
     optional: true
     max_concurrency: 4
     agent: kubernetes
@@ -282,7 +275,6 @@ presubmits:
   - name: pull-kube-oidc-proxy-e2e-v1-16
     context: pull-kube-oidc-proxy-e2e-v1-16
     always_run: false
-    cluster: gke
     optional: false
     max_concurrency: 4
     agent: kubernetes
@@ -329,7 +321,6 @@ presubmits:
   - name: pull-kube-oidc-proxy-e2e-v1-17
     context: pull-kube-oidc-proxy-e2e-v1-17
     always_run: false
-    cluster: gke
     optional: true
     max_concurrency: 4
     agent: kubernetes
@@ -376,7 +367,6 @@ presubmits:
   - name: pull-kube-oidc-proxy-e2e-v1-18
     context: pull-kube-oidc-proxy-e2e-v1-18
     always_run: true
-    cluster: gke
     optional: false
     max_concurrency: 4
     agent: kubernetes

--- a/config/jobs/preflight/preflight-presubmits.yaml
+++ b/config/jobs/preflight/preflight-presubmits.yaml
@@ -2,7 +2,6 @@ presubmits:
   jetstack/preflight:
 
   - name: pull-preflight-unit
-    cluster: gke
     agent: kubernetes
     decorate: true
     always_run: true

--- a/config/jobs/testing/testing-periodics.yaml
+++ b/config/jobs/testing/testing-periodics.yaml
@@ -2,7 +2,6 @@ periodics:
 
 - name: periodic-testing-retester
   interval: 20m  # Retest at most 1 PR per 20m, which should not DOS the queue.
-  cluster: gke
   agent: kubernetes
   decorate: true
   annotations:
@@ -50,7 +49,6 @@ periodics:
 
 - name: periodic-testing-close
   interval: 1h
-  cluster: gke
   agent: kubernetes
   decorate: true
   annotations:
@@ -87,7 +85,6 @@ periodics:
 
 - name: periodic-testing-rotten
   interval: 1h
-  cluster: gke
   agent: kubernetes
   decorate: true
   annotations:
@@ -127,7 +124,6 @@ periodics:
 
 - name: periodic-testing-stale
   interval: 1h
-  cluster: gke
   agent: kubernetes
   decorate: true
   annotations:

--- a/config/jobs/version-checker/version-checker-presubmits.yaml
+++ b/config/jobs/version-checker/version-checker-presubmits.yaml
@@ -2,7 +2,6 @@ presubmits:
   jetstack/version-checker:
 
   - name: pull-version-checker-verify
-    cluster: gke
     agent: kubernetes
     decorate: true
     always_run: true


### PR DESCRIPTION
We have upgraded Prow which has changed the config file format. Rather than specifying `cluster: gke` we now use a context from kubeconfig

/assign @munnerz 
/release-note-none