### PR TITLE
Passes GCP creds file to crier

### DIFF
--- a/prow/cluster/crier_deployment.yaml
+++ b/prow/cluster/crier_deployment.yaml
@@ -40,6 +40,7 @@ spec:
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
         - --kubernetes-blob-storage-workers=1
+        - --gcs-credentials-file=/etc/gcp/service-account.json
         volumeMounts:
         - name: config
           mountPath: /etc/config
@@ -49,6 +50,9 @@ spec:
           readOnly: true
         - name: oauth
           mountPath: /etc/github
+          readOnly: true
+        - name: gcp-sa-creds
+          mountPath: /etc/gcp
           readOnly: true
       volumes:
       - name: config
@@ -60,3 +64,6 @@ spec:
       - name: oauth
         secret:
           secretName: oauth-token
+      - name: gcp-sa-creds
+        secret:
+          secretName: service-account


### PR DESCRIPTION
Crier needs to push to GCS.

This PR gives it credentials of `jetstack-logs` GCP SA, stored in a manually created k8s secret. This is a temporary solution as we are going to re-build the Prow cluster.

Signed-off-by: irbekrm <irbekrm@gmail.com>

```release-note
NONE
```