### PR TITLE
Pass kubeconfig for build cluster to crier

### DIFF
--- a/prow/cluster/crier_deployment.yaml
+++ b/prow/cluster/crier_deployment.yaml
@@ -41,6 +41,7 @@ spec:
         - --github-endpoint=https://api.github.com
         - --kubernetes-blob-storage-workers=1
         - --gcs-credentials-file=/etc/gcp/service-account.json
+        - --kubeconfig=/etc/kube/config
         volumeMounts:
         - name: config
           mountPath: /etc/config
@@ -53,6 +54,9 @@ spec:
           readOnly: true
         - name: gcp-sa-creds
           mountPath: /etc/gcp
+          readOnly: true
+        - name: kubeconfig
+          mountPath: /etc/kube
           readOnly: true
       volumes:
       - name: config
@@ -67,3 +71,6 @@ spec:
       - name: gcp-sa-creds
         secret:
           secretName: service-account
+      - name: kubeconfig
+        secret:
+          secretName: crier-kubeconfig


### PR DESCRIPTION
This PR should be the last bit needed to fix the issue with all our tests being marked as failed in TestGrid #464 

It passes kubeconfig for build cluster (were the ProwJob pods are) to Prow's crier.

I had to manually create a few resources as a temporary solution before we automate this whole setup:

- a `get-test-pods` role (with permissions to list, get, patch pods & get events) and a `crier-get-pods` rolebinding (that binds the role to `crierclient` user)  in `test-pods` namespace in the build cluster and cert and key for `crierclient` user.
- kubeconfig stored in a `crier-kubeconfig` secret in build-infra cluster for `crierclient` user with `default` and `gke` contexts <- this needs some debugging, it looks like that although we removed the `gke` context, some(?) prowjobs still refer to it. It seemed to make sense to temporarily create a new kubeconfig to fix this issue and then debug the contexts issue.

I have already applied this change (as it is manual process) and it seems to have fixed the isue, see TestGrid https://testgrid.k8s.io/jetstack-cert-manager-master#ci-cert-manager-e2e-v1-20&show-stale-tests=

Closes #464 
/kind bug
Signed-off-by: irbekrm <irbekrm@gmail.com>