### PR TITLE
Bazel v2.2.0-> v3.7.2 for cm release-next

### DIFF
--- a/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
+++ b/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
@@ -264,7 +264,7 @@ periodics:
     preset-venafi-cloud-credentials: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-056d642-2.2.0
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
       args:
       - runner
       - devel/ci-run-e2e.sh


### PR DESCRIPTION
I missed bumping the Bazel version for cert-manager release-next periodic job for Kubernetes v1.19 after I upgraded Bazel everywhere else, it has been failing since https://testgrid.k8s.io/jetstack-cert-manager-next#ci-cert-manager-next-e2e-v1-19&show-stale-tests=

Signed-off-by: irbekrm <irbekrm@gmail.com>

/kind cleanup
/release-note NONE