### PR TITLE
Move release previous to be v1.3

### DIFF
--- a/config/jobs/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
+++ b/config/jobs/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
@@ -247,8 +247,8 @@ presubmits:
 
   - name: pull-cert-manager-e2e-v1-19
     context: pull-cert-manager-e2e-v1-19
-    optional: false
-    always_run: true
+    optional: true
+    always_run: false
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -310,7 +310,7 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
-    - release-1.1
+    - release-1.3
     annotations:
       testgrid-create-test-group: 'false'
     labels:


### PR DESCRIPTION
I am guessing that we only want current patches into `v1.3` cert-manager to run against Kubernetes `v1.20`? Same as we do with merges into master.
Currently we are trying to merge a patch into `release-1.3` and [it's pending](https://github.com/jetstack/cert-manager/pull/3886) - this PR attempts to fix that. 

Signed-off-by: irbekrm <irbekrm@gmail.com>

/kind cleanup