### PR TITLE
triageparty: upgrade from 1.2.1 to 1.3.0 to fix "similar" bug

### DIFF
--- a/triage_party/triageparty_deployment.yaml
+++ b/triage_party/triageparty_deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: triageparty
-        image: triageparty/triage-party:1.2.1
+        image: triageparty/triage-party:1.3.0
         env:
         - name: GITHUB_TOKEN
           valueFrom:


### PR DESCRIPTION
Upgrading fixes the followinbg bug:

![similar-label-bug](https://user-images.githubusercontent.com/2195781/114992306-e7709780-9e9a-11eb-901e-25e193a8a2f9.png)


Fixes #477 