### PR TITLE
Disable unused plugins for preflight

### DIFF
--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -229,8 +229,6 @@ plugins:
   jetstack/preflight:
   - approve
   - dco
-  - owners-label
-  - release-note
   - verify-owners
 
   jetstack/version-checker:


### PR DESCRIPTION
You can check the description of the plugins here: https://prow.k8s.io/plugins