### PR TITLE
Test previous release with Kubernetes v1.20

### DIFF
--- a/config/jobs/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
+++ b/config/jobs/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
@@ -298,3 +298,61 @@ periodics:
       options:
       - name: ndots
         value: "1"
+
+- name: ci-cert-manager-previous-e2e-v1-20
+  interval: 2h
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: jetstack
+    repo: cert-manager
+    base_ref: release-1.3
+  annotations:
+    testgrid-create-test-group: 'true'
+    testgrid-dashboards: jetstack-cert-manager-previous
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    description: Runs the end-to-end test suite against a Kubernetes v1.20 cluster
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-cloudflare-credentials: "true"
+    preset-venafi-tpp-credentials: "true"
+    preset-venafi-cloud-credentials: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+      args:
+      - runner
+      - devel/ci-run-e2e.sh
+      resources:
+        requests:
+          cpu: 6
+          memory: 12Gi
+      env:
+      - name: K8S_VERSION
+        value: "1.20"
+      securityContext:
+        privileged: true
+        capabilities:
+          add: ["SYS_ADMIN"]
+      volumeMounts:
+      - mountPath: /lib/modules
+        name: modules
+        readOnly: true
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    volumes:
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"


### PR DESCRIPTION
This PR creates a new periodic Prow job that runs `cert-manager` e2e tests for previous `cert-manager` release (currently that is `v1.3` on Kubernetes `v1.20`).

Fixes #486 

As I understand, the Prow job configs will get updated once this  PR is merged- `bazel run //prow/cluster:production.apply` does not do that.

Signed-off-by: irbekrm <irbekrm@gmail.com>