### PR TITLE
Switch default cert-manager presubmit test to use K8s 1.21

### DIFF
--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -384,8 +384,8 @@ presubmits:
           value: "1"
   - name: pull-cert-manager-e2e-v1-20
     context: pull-cert-manager-e2e-v1-20
-    always_run: true
-    optional: false
+    always_run: false
+    optional: true
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -418,6 +418,65 @@ presubmits:
         env:
         - name: K8S_VERSION
           value: "1.20"
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+  - name: pull-cert-manager-e2e-v1-21
+    context: pull-cert-manager-e2e-v1-21
+    always_run: true
+    optional: false
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    branches:
+    - master
+    - release-1.4
+    annotations:
+      testgrid-create-test-group: 'true'
+      testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
+      description: Runs the end-to-end test suite against a Kubernetes v1.21 cluster
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-cloudflare-credentials: "true"
+      preset-venafi-tpp-credentials: "true"
+      preset-venafi-cloud-credentials: "true"
+      preset-retry-flakey-tests: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+        args:
+        - runner
+        - devel/ci-run-e2e.sh
+        resources:
+          requests:
+            cpu: 6
+            memory: 12Gi
+        env:
+        - name: K8S_VERSION
+          value: "1.21"
         securityContext:
           privileged: true
           capabilities:


### PR DESCRIPTION
Context: https://github.com/jetstack/cert-manager/pull/4029#issuecomment-844098188
Fixes: #476

```release-note
NONE
```