### PR TITLE
Require cert-manager presubmits only against k8s 1.21

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -70,7 +70,7 @@ branch-protection:
             - pull-cert-manager-bazel
             - pull-cert-manager-deps
             - pull-cert-manager-chart
-            - pull-cert-manager-e2e-v1-20
+            - pull-cert-manager-e2e-v1-21
         cert-manager-csi:
           protect: true
           required_status_checks:


### PR DESCRIPTION
I think we only want to require 1.21 presubmits, at the moment 1.20 still shows up for new PRs, see https://github.com/jetstack/cert-manager/pull/4034


Signed-off-by: irbekrm <irbekrm@gmail.com>