### PR TITLE
Revert "bump cert-manager-release-previous-presubmits"

### DIFF
--- a/config/jobs/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
+++ b/config/jobs/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
@@ -304,63 +304,6 @@ presubmits:
 
   - name: pull-cert-manager-e2e-v1-20
     context: pull-cert-manager-e2e-v1-20
-    optional: true
-    always_run: false
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    branches:
-    - release-1.3
-    annotations:
-      testgrid-create-test-group: 'false'
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-cloudflare-credentials: "true"
-      preset-venafi-tpp-credentials: "true"
-      preset-venafi-cloud-credentials: "true"
-      preset-retry-flakey-tests: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
-        args:
-        - runner
-        - devel/ci-run-e2e.sh
-        resources:
-          requests:
-            cpu: 6
-            memory: 12Gi
-        env:
-        - name: K8S_VERSION
-          value: "1.20"
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-
-  - name: pull-cert-manager-e2e-v1-21
-    context: pull-cert-manager-e2e-v1-21
     optional: false
     always_run: true
     max_concurrency: 4
@@ -391,7 +334,7 @@ presubmits:
             memory: 12Gi
         env:
         - name: K8S_VERSION
-          value: "1.21"
+          value: "1.20"
         securityContext:
           privileged: true
           capabilities:


### PR DESCRIPTION
Reverts jetstack/testing#490

Because the cert-manager `release-1.3` doesn't have the necessary changes in `devel/cluster/create.sh` to support K8S 1.21. See https://github.com/jetstack/cert-manager/pull/4029#issuecomment-847760465 