### PR TITLE
Temporarily revert "Require cert-manager presubmits only against k8s …

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -70,7 +70,7 @@ branch-protection:
             - pull-cert-manager-bazel
             - pull-cert-manager-deps
             - pull-cert-manager-chart
-            - pull-cert-manager-e2e-v1-21
+            - pull-cert-manager-e2e-v1-20
         cert-manager-csi:
           protect: true
           required_status_checks:


### PR DESCRIPTION
…1.21"

This *temporarily* reverts the requirement for all PRs against `cert-manager` to pass the e2e test on k8s v1.21, so that we can get this cherry-pick in https://github.com/jetstack/cert-manager/pull/4058

After that we should re-instate the requirement.

This reverts commit 62f61d43b6f36af52a78276752d44c06c37d560d.