### PR TITLE
Updating RBAC roles to match upstream kubernetes test-infra

### DIFF
--- a/prow/cluster/deck_rbac.yaml
+++ b/prow/cluster/deck_rbac.yaml
@@ -5,57 +5,58 @@ metadata:
   name: "deck"
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: default
-  name: "deck"
+  name: deck
 rules:
-  - apiGroups:
-      - "prow.k8s.io"
-    resources:
-      - prowjobs
-    verbs:
-      - get
-      - list
-      # Required when deck runs with `--rerun-creates-job=true`
-      - create
+- apiGroups:
+  - "prow.k8s.io"
+  resources:
+  - prowjobs
+  verbs:
+  - get
+  - list
+  - watch
+  # Required when deck runs with `--rerun-creates-job=true`
+  - create
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: test-pods
-  name: "deck"
+  name: deck
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - pods/log
-    verbs:
-      - get
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: default
-  name: "deck"
+  name: deck
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: "deck"
+  name: deck
 subjects:
 - kind: ServiceAccount
-  name: "deck"
+  name: deck
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: test-pods
-  name: "deck"
+  name: deck
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: "deck"
+  name: deck
 subjects:
 - kind: ServiceAccount
-  name: "deck"
+  name: deck
   namespace: default

--- a/prow/cluster/hook_rbac.yaml
+++ b/prow/cluster/hook_rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   name: "hook"
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: default
   name: "hook"
@@ -17,6 +17,8 @@ rules:
     verbs:
       - create
       - get
+      - list
+      - update
   - apiGroups:
       - ""
     resources:
@@ -27,7 +29,7 @@ rules:
       - update
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: default
   name: "hook"

--- a/prow/cluster/horologium_rbac.yaml
+++ b/prow/cluster/horologium_rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   name: "horologium"
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: default
   name: "horologium"
@@ -17,9 +17,10 @@ rules:
     verbs:
       - create
       - list
+      - watch
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: default
   name: "horologium"

--- a/prow/cluster/pipeline_rbac.yaml
+++ b/prow/cluster/pipeline_rbac.yaml
@@ -27,12 +27,12 @@ rules:
   - prow.k8s.io
   resources:
   - prowjobs
-  - prowjobs/status
   verbs:
   - get
   - list
   - watch
   - update
+  - patch
 
 ---
 

--- a/prow/cluster/plank_rbac.yaml
+++ b/prow/cluster/plank_rbac.yaml
@@ -19,6 +19,8 @@ rules:
       - create
       - list
       - update
+      - patch
+      - watch
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/prow/cluster/sinker_rbac.yaml
+++ b/prow/cluster/sinker_rbac.yaml
@@ -5,39 +5,54 @@ metadata:
   name: "sinker"
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: default
   name: "sinker"
 rules:
   - apiGroups:
-      - "prow.k8s.io"
+    - "prow.k8s.io"
     resources:
-      - prowjobs
+    - prowjobs
     verbs:
-      - delete
-      - list
-      - watch
-      - get
+    - delete
+    - list
+    - watch
+    - get
   - apiGroups:
-      - ""
+    - coordination.k8s.io
     resources:
-      - configmaps
+    - leases
     resourceNames:
-      - prow-sinker-leaderlock
+    - prow-sinker-leaderlock
     verbs:
-      - get
-      - update
+    - get
+    - update
   - apiGroups:
-      - ""
+    - coordination.k8s.io
     resources:
-      - configmaps
-      - events
+    - leases
     verbs:
-      - create
+    - create
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    resourceNames:
+    - prow-sinker-leaderlock
+    verbs:
+    - get
+    - update
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    - events
+    verbs:
+    - create
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: test-pods
   name: "sinker"
@@ -49,9 +64,12 @@ rules:
     verbs:
       - delete
       - list
+      - watch
+      - get
+      - patch
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: default
   name: "sinker"
@@ -64,7 +82,7 @@ subjects:
   name: "sinker"
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: test-pods
   name: "sinker"

--- a/prow/cluster/statusreconciler_rbac.yaml
+++ b/prow/cluster/statusreconciler_rbac.yaml
@@ -5,10 +5,10 @@ metadata:
   name: "statusreconciler"
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: default
-  name: "statusreconciler"
+  name: statusreconciler
 rules:
   - apiGroups:
       - "prow.k8s.io"
@@ -18,14 +18,14 @@ rules:
       - create
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: default
-  name: "statusreconciler"
+  name: statusreconciler
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: "statusreconciler"
+  name: statusreconciler
 subjects:
 - kind: ServiceAccount
-  name: "statusreconciler"
+  name: statusreconciler

--- a/prow/cluster/tide_rbac.yaml
+++ b/prow/cluster/tide_rbac.yaml
@@ -5,10 +5,10 @@ metadata:
   name: "tide"
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: default
-  name: "tide"
+  name: tide
 rules:
   - apiGroups:
       - "prow.k8s.io"
@@ -17,16 +17,18 @@ rules:
     verbs:
       - create
       - list
+      - get
+      - watch
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: default
-  name: "tide"
+  name: tide
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: "tide"
+  name: tide
 subjects:
 - kind: ServiceAccount
-  name: "tide"
+  name: tide


### PR DESCRIPTION
Due to recent changes of disabling ABAC. We now need to update our RBAC roles to ensure Prow and other services can run jobs successfully.