### PR TITLE
Add cert-manager/csi-lib to the labelsync cronjob

### DIFF
--- a/prow/cluster/labelsync_cronjob.yaml
+++ b/prow/cluster/labelsync_cronjob.yaml
@@ -33,7 +33,7 @@ spec:
               - --config=/etc/config/labels.yaml
               - --confirm=true
               # TODO: enable label_sync across the whole org
-              - --only=jetstack/cert-manager,jetstack/testing,jetstack/kube-oidc-proxy,jetstack/tarmak,jetstack/terraform-google-gke-cluster,cert-manager/release,cert-manager/webhook-example,cert-manager/website,jetstack/cert-manager-nginx-plus-lab
+              - --only=jetstack/cert-manager,jetstack/testing,jetstack/kube-oidc-proxy,jetstack/tarmak,jetstack/terraform-google-gke-cluster,cert-manager/release,cert-manager/webhook-example,cert-manager/website,jetstack/cert-manager-nginx-plus-lab,cert-manager/csi-lib
               - --token=/etc/github/oauth
               volumeMounts:
               - name: oauth


### PR DESCRIPTION
Adds the new csi-lib repository to the labelsync cronjob