### PR TITLE
Upgrade cert-manager-csi base image, k8s version & cert-manager version

### DIFF
--- a/config/jobs/cert-manager-csi/cert-manager-csi-presubmits.yaml
+++ b/config/jobs/cert-manager-csi/cert-manager-csi-presubmits.yaml
@@ -14,7 +14,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20210122-46f3dbf-1.13.4
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20210331-a8721c1-1.16
         args:
         - runner
         - make
@@ -59,7 +59,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20210122-46f3dbf-1.13.4
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20210331-a8721c1-1.16
         args:
         - runner
         - make
@@ -70,9 +70,9 @@ presubmits:
             memory: 12Gi
         env:
         - name: CERT_MANAGER_CSI_K8S_VERSION
-          value: "1.16.1"
+          value: "1.20.2"
         - name: CERT_MANAGER_CSI_CERT_MANAGER_VERSION
-          value: "0.12.0"
+          value: "1.3.1"
         securityContext:
           privileged: true
           capabilities:


### PR DESCRIPTION
Required for https://github.com/jetstack/cert-manager-csi/pull/34 (as it needs a newer golang version).

Also included updated the environment overrides for the k8s version + cert-manager version

Signed-off-by: James Munnelly <jmunnelly@apple.com>