### PR TITLE
Request less cpu for e2e tests

### DIFF
--- a/config/jobs/cert-manager-csi/cert-manager-csi-presubmits.yaml
+++ b/config/jobs/cert-manager-csi/cert-manager-csi-presubmits.yaml
@@ -66,7 +66,7 @@ presubmits:
         - e2e
         resources:
           requests:
-            cpu: 6
+            cpu: 3500m
             memory: 12Gi
         env:
         - name: CERT_MANAGER_CSI_K8S_VERSION

--- a/config/jobs/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager-periodics.yaml
@@ -96,7 +96,7 @@ periodics:
       - devel/ci-run-e2e.sh
       resources:
         requests:
-          cpu: 6
+          cpu: 3500m
           memory: 12Gi
       env:
       - name: K8S_VERSION
@@ -154,7 +154,7 @@ periodics:
       - devel/ci-run-e2e.sh
       resources:
         requests:
-          cpu: 6
+          cpu: 3500m
           memory: 12Gi
       env:
       - name: K8S_VERSION
@@ -212,7 +212,7 @@ periodics:
       - devel/ci-run-e2e.sh
       resources:
         requests:
-          cpu: 6
+          cpu: 3500m
           memory: 12Gi
       env:
       - name: K8S_VERSION
@@ -270,7 +270,7 @@ periodics:
       - devel/ci-run-e2e.sh
       resources:
         requests:
-          cpu: 6
+          cpu: 3500m
           memory: 12Gi
       env:
       - name: K8S_VERSION
@@ -328,7 +328,7 @@ periodics:
       - devel/ci-run-e2e.sh
       resources:
         requests:
-          cpu: 6
+          cpu: 3500m
           memory: 12Gi
       env:
       - name: K8S_VERSION

--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -175,7 +175,7 @@ presubmits:
         - devel/ci-run-e2e.sh
         resources:
           requests:
-            cpu: 6
+            cpu: 3500m
             memory: 12Gi
         env:
         - name: K8S_VERSION
@@ -235,7 +235,7 @@ presubmits:
         - devel/ci-run-e2e.sh
         resources:
           requests:
-            cpu: 6
+            cpu: 3500m
             memory: 12Gi
         env:
         - name: K8S_VERSION
@@ -295,7 +295,7 @@ presubmits:
         - devel/ci-run-e2e.sh
         resources:
           requests:
-            cpu: 6
+            cpu: 3500m
             memory: 12Gi
         env:
         - name: K8S_VERSION
@@ -354,7 +354,7 @@ presubmits:
         - devel/ci-run-e2e.sh
         resources:
           requests:
-            cpu: 6
+            cpu: 3500m
             memory: 12Gi
         env:
         - name: K8S_VERSION
@@ -413,7 +413,7 @@ presubmits:
         - devel/ci-run-e2e.sh
         resources:
           requests:
-            cpu: 6
+            cpu: 3500m
             memory: 12Gi
         env:
         - name: K8S_VERSION
@@ -472,7 +472,7 @@ presubmits:
         - devel/ci-run-e2e.sh
         resources:
           requests:
-            cpu: 6
+            cpu: 3500m
             memory: 12Gi
         env:
         - name: K8S_VERSION
@@ -534,7 +534,7 @@ presubmits:
         - '\[Feature:Issuers:Venafi:TPP\]'
         resources:
           requests:
-            cpu: 6
+            cpu: 3500m
             memory: 12Gi
         env:
         - name: K8S_VERSION

--- a/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
+++ b/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
@@ -96,7 +96,7 @@ periodics:
       - devel/ci-run-e2e.sh
       resources:
         requests:
-          cpu: 6
+          cpu: 3500m
           memory: 12Gi
       env:
       - name: K8S_VERSION
@@ -154,7 +154,7 @@ periodics:
       - devel/ci-run-e2e.sh
       resources:
         requests:
-          cpu: 6
+          cpu: 3500m
           memory: 12Gi
       env:
       - name: K8S_VERSION
@@ -212,7 +212,7 @@ periodics:
       - devel/ci-run-e2e.sh
       resources:
         requests:
-          cpu: 6
+          cpu: 3500m
           memory: 12Gi
       env:
       - name: K8S_VERSION
@@ -270,7 +270,7 @@ periodics:
       - devel/ci-run-e2e.sh
       resources:
         requests:
-          cpu: 6
+          cpu: 3500m
           memory: 12Gi
       env:
       - name: K8S_VERSION
@@ -328,7 +328,7 @@ periodics:
       - devel/ci-run-e2e.sh
       resources:
         requests:
-          cpu: 6
+          cpu: 3500m
           memory: 12Gi
       env:
       - name: K8S_VERSION

--- a/config/jobs/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
+++ b/config/jobs/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
@@ -96,7 +96,7 @@ periodics:
       - devel/ci-run-e2e.sh
       resources:
         requests:
-          cpu: 6
+          cpu: 3500m
           memory: 12Gi
       env:
       - name: K8S_VERSION
@@ -154,7 +154,7 @@ periodics:
       - devel/ci-run-e2e.sh
       resources:
         requests:
-          cpu: 6
+          cpu: 3500m
           memory: 12Gi
       env:
       - name: K8S_VERSION
@@ -212,7 +212,7 @@ periodics:
       - devel/ci-run-e2e.sh
       resources:
         requests:
-          cpu: 6
+          cpu: 3500m
           memory: 12Gi
       env:
       - name: K8S_VERSION
@@ -270,7 +270,7 @@ periodics:
       - devel/ci-run-e2e.sh
       resources:
         requests:
-          cpu: 6
+          cpu: 3500m
           memory: 12Gi
       env:
       - name: K8S_VERSION
@@ -328,7 +328,7 @@ periodics:
       - devel/ci-run-e2e.sh
       resources:
         requests:
-          cpu: 6
+          cpu: 3500m
           memory: 12Gi
       env:
       - name: K8S_VERSION

--- a/config/jobs/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
+++ b/config/jobs/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
@@ -159,7 +159,7 @@ presubmits:
         - devel/ci-run-e2e.sh
         resources:
           requests:
-            cpu: 6
+            cpu: 3500m
             memory: 12Gi
         env:
         - name: K8S_VERSION
@@ -216,7 +216,7 @@ presubmits:
         - devel/ci-run-e2e.sh
         resources:
           requests:
-            cpu: 6
+            cpu: 3500m
             memory: 12Gi
         env:
         - name: K8S_VERSION
@@ -273,7 +273,7 @@ presubmits:
         - devel/ci-run-e2e.sh
         resources:
           requests:
-            cpu: 6
+            cpu: 3500m
             memory: 12Gi
         env:
         - name: K8S_VERSION
@@ -330,7 +330,7 @@ presubmits:
         - devel/ci-run-e2e.sh
         resources:
           requests:
-            cpu: 6
+            cpu: 3500m
             memory: 12Gi
         env:
         - name: K8S_VERSION
@@ -387,7 +387,7 @@ presubmits:
         - devel/ci-run-e2e.sh
         resources:
           requests:
-            cpu: 6
+            cpu: 3500m
             memory: 12Gi
         env:
         - name: K8S_VERSION

--- a/config/jobs/istio-csr/istio-csr-presubmits.yaml
+++ b/config/jobs/istio-csr/istio-csr-presubmits.yaml
@@ -42,7 +42,7 @@ presubmits:
         - e2e
         resources:
           requests:
-            cpu: 6
+            cpu: 3500m
             memory: 12Gi
         env:
         - name: K8S_VERSION
@@ -96,7 +96,7 @@ presubmits:
         - e2e
         resources:
           requests:
-            cpu: 6
+            cpu: 3500m
             memory: 12Gi
         env:
         - name: K8S_VERSION
@@ -150,7 +150,7 @@ presubmits:
         - e2e
         resources:
           requests:
-            cpu: 6
+            cpu: 3500m
             memory: 12Gi
         env:
         - name: K8S_VERSION

--- a/config/jobs/kube-oidc-proxy/kube-oidc-proxy-presubmits.yaml
+++ b/config/jobs/kube-oidc-proxy/kube-oidc-proxy-presubmits.yaml
@@ -65,7 +65,7 @@ presubmits:
           value: "1.11.10"
         resources:
           requests:
-            cpu: 6
+            cpu: 3500m
             memory: 12Gi
         securityContext:
           privileged: true
@@ -111,7 +111,7 @@ presubmits:
           value: "1.12.10"
         resources:
           requests:
-            cpu: 6
+            cpu: 3500m
             memory: 12Gi
         securityContext:
           privileged: true
@@ -157,7 +157,7 @@ presubmits:
           value: "1.13.10"
         resources:
           requests:
-            cpu: 6
+            cpu: 3500m
             memory: 12Gi
         securityContext:
           privileged: true
@@ -203,7 +203,7 @@ presubmits:
           value: "1.14.10"
         resources:
           requests:
-            cpu: 6
+            cpu: 3500m
             memory: 12Gi
         securityContext:
           privileged: true
@@ -249,7 +249,7 @@ presubmits:
           value: "1.15.7"
         resources:
           requests:
-            cpu: 6
+            cpu: 3500m
             memory: 12Gi
         securityContext:
           privileged: true
@@ -295,7 +295,7 @@ presubmits:
           value: "1.16.4"
         resources:
           requests:
-            cpu: 6
+            cpu: 3500m
             memory: 12Gi
         securityContext:
           privileged: true
@@ -341,7 +341,7 @@ presubmits:
           value: "1.17.2"
         resources:
           requests:
-            cpu: 6
+            cpu: 3500m
             memory: 12Gi
         securityContext:
           privileged: true
@@ -387,7 +387,7 @@ presubmits:
           value: "1.18.0"
         resources:
           requests:
-            cpu: 6
+            cpu: 3500m
             memory: 12Gi
         securityContext:
           privileged: true

--- a/config/jobs/policy-approver/policy-approver-presubmits.yaml
+++ b/config/jobs/policy-approver/policy-approver-presubmits.yaml
@@ -42,7 +42,7 @@ presubmits:
         - e2e
         resources:
           requests:
-            cpu: 6
+            cpu: 3500m
             memory: 12Gi
         env:
         - name: K8S_VERSION


### PR DESCRIPTION
Else, we run out of capacity in Prow worker's cluster.

3500m should allow us to fit two jobs (2 pods) on a n-standard-8 node

Signed-off-by: irbekrm <irbekrm@gmail.com>