### PR TITLE
Disable prowjob analysis for jobs on trusted cluster

### DIFF
--- a/config/jobs/cert-manager/website/cert-manager-website-periodics.yaml
+++ b/config/jobs/cert-manager/website/cert-manager-website-periodics.yaml
@@ -14,6 +14,7 @@ periodics:
   annotations:
     testgrid-dashboards: jetstack-cert-manager-website
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-disable-prowjob-analysis: "true"
     description: Updates the algolia search index for the cert-manager website
   spec:
     containers:

--- a/config/jobs/testing/testing-trusted.yaml
+++ b/config/jobs/testing/testing-trusted.yaml
@@ -75,7 +75,7 @@ postsubmits:
       testgrid-disable-prowjob-analysis: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-prow/transfigure
+      - image: gcr.io/k8s-prow/transfigure:v20210601-16a04c27e3
         command:
         - /transfigure.sh
         args:

--- a/config/jobs/testing/testing-trusted.yaml
+++ b/config/jobs/testing/testing-trusted.yaml
@@ -72,6 +72,7 @@ postsubmits:
     annotations:
       testgrid-dashboards: jetstack-testing-janitors
       testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-disable-prowjob-analysis: "true"
     spec:
       containers:
       - image: gcr.io/k8s-prow/transfigure
@@ -104,6 +105,7 @@ postsubmits:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-testing-janitors
       testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-disable-prowjob-analysis: "true"
       description: Build and push the 'bazelbuild' image
     spec:
       containers:
@@ -140,6 +142,7 @@ postsubmits:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-testing-janitors
       testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-disable-prowjob-analysis: "true"
       description: Build and push the 'golang-dind' image
     spec:
       containers:
@@ -176,6 +179,7 @@ postsubmits:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-testing-janitors
       testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-disable-prowjob-analysis: "true"
       description: Build and push the 'golang-nodejs' image
     spec:
       containers:
@@ -212,6 +216,7 @@ postsubmits:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-testing-janitors
       testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-disable-prowjob-analysis: "true"
       description: Build and push the 'katacoda-lint' image
     spec:
       containers:
@@ -248,6 +253,7 @@ postsubmits:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-testing-janitors
       testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-disable-prowjob-analysis: "true"
       description: Build and push the 'tarmak-ruby' image
     spec:
       containers:
@@ -284,6 +290,7 @@ postsubmits:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-testing-janitors
       testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-disable-prowjob-analysis: "true"
       description: Build and push the 'tarmak-sphinx-docs' image
     spec:
       containers:
@@ -320,6 +327,7 @@ postsubmits:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-testing-janitors
       testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-disable-prowjob-analysis: "true"
       description: Build and push the 'terraform-google-gke-cluster' image
     spec:
       containers:


### PR DESCRIPTION
See #479 for context.

This PR will update Jetstack's TestGrid config to disable 'Pod' row for jobs that run in 'trusted' cluster.
It will not itself modify the TestGrid config, but will instead trigger [this Prow job](https://github.com/jetstack/testing/blob/master/config/jobs/testing/testing-trusted.yaml#L63) which will regenerate the TestGrid config and create a PR against `k/test-infra`.
This will fix the issue with Prow jobs that run in 'trusted' cluster being marked as failed in TestGrid (see i.e https://testgrid.k8s.io/jetstack-cert-manager-website#cert-manager-website-update-index) by removing the pod row. Alternatively we could have provided 'trusted' cluster's creds to Prow- I chose to not do that for security reasons.

If you want to verify what TestGrid config gets generated, you can do so by copying the `/configurator` binary from `gcr.io/k8s-prow/transfigure` and running it with the configs in this PR `configurator --prow-config ./config/config.yaml --prow-job-config config/jobs/ --output-yaml --yaml config/testgrid/dashboards.yaml --oneshot --output generated.yaml` (I did that).


Signed-off-by: irbekrm <irbekrm@gmail.com>