### PR TITLE
Adds istio-csr istio testing version to v1.10.0 and bumps Kube to 1.21

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -41,8 +41,10 @@ branch-protection:
             contexts:
             - dco
             - pull-istio-csr-verify
-            - pull-istio-csr-k8s-v1-20-istio-v1-7
-            - pull-istio-csr-k8s-v1-20-istio-v1-8
+            - pull-istio-csr-k8s-v1-21-istio-v1-7
+            - pull-istio-csr-k8s-v1-21-istio-v1-8
+            - pull-istio-csr-k8s-v1-21-istio-v1-9
+            - pull-istio-csr-k8s-v1-21-istio-v1-10
         policy-approver:
           protect: true
           required_status_checks:

--- a/config/jobs/istio-csr/istio-csr-presubmits.yaml
+++ b/config/jobs/istio-csr/istio-csr-presubmits.yaml
@@ -19,9 +19,9 @@ presubmits:
             cpu: 1
             memory: 1Gi
 
-  # kind based istio-csr e2e job for Kubernetes v1.20, istio v1.7
-  - name: pull-istio-csr-k8s-v1-20-istio-v1-7
-    context: pull-istio-csr-k8s-v1-20-istio-v1-7
+  # kind based istio-csr e2e job for Kubernetes v1.21, istio v1.7
+  - name: pull-istio-csr-k8s-v1-21-istio-v1-7
+    context: pull-istio-csr-k8s-v1-21-istio-v1-7
     # Match everything except PRs that only touch docs/
     always_run: true
     optional: false
@@ -46,7 +46,7 @@ presubmits:
             memory: 12Gi
         env:
         - name: K8S_VERSION
-          value: "1.20.0"
+          value: "1.21.1"
         - name: ISTIO_VERSION
           value: "1.7.6"
         securityContext:
@@ -73,9 +73,9 @@ presubmits:
           - name: ndots
             value: "1"
 
-  # kind based istio-csr e2e job for Kubernetes v1.20, istio v1.8
-  - name: pull-istio-csr-k8s-v1-20-istio-v1-8
-    context: pull-istio-csr-k8s-v1-20-istio-v1-8
+  # kind based istio-csr e2e job for Kubernetes v1.21, istio v1.8
+  - name: pull-istio-csr-k8s-v1-21-istio-v1-8
+    context: pull-istio-csr-k8s-v1-21-istio-v1-8
     # Match everything except PRs that only touch docs/
     always_run: true
     optional: false
@@ -100,7 +100,7 @@ presubmits:
             memory: 12Gi
         env:
         - name: K8S_VERSION
-          value: "1.20.0"
+          value: "1.21.1"
         - name: ISTIO_VERSION
           value: "1.8.2"
         securityContext:
@@ -127,9 +127,9 @@ presubmits:
           - name: ndots
             value: "1"
 
-  # kind based istio-csr e2e job for Kubernetes v1.20, istio v1.9
-  - name: pull-istio-csr-k8s-v1-20-istio-v1-9
-    context: pull-istio-csr-k8s-v1-20-istio-v1-9
+  # kind based istio-csr e2e job for Kubernetes v1.21, istio v1.9
+  - name: pull-istio-csr-k8s-v1-21-istio-v1-9
+    context: pull-istio-csr-k8s-v1-21-istio-v1-9
     # Match everything except PRs that only touch docs/
     always_run: true
     optional: false
@@ -154,9 +154,63 @@ presubmits:
             memory: 12Gi
         env:
         - name: K8S_VERSION
-          value: "1.20.0"
+          value: "1.21.1"
         - name: ISTIO_VERSION
           value: "1.9.1"
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+
+  # kind based istio-csr e2e job for Kubernetes v1.21, istio v1.10
+  - name: pull-istio-csr-k8s-v1-21-istio-v1-10
+    context: pull-istio-csr-k8s-v1-21-istio-v1-10
+    # Match everything except PRs that only touch docs/
+    always_run: true
+    optional: false
+    max_concurrency: 8
+    agent: kubernetes
+    decorate: true
+    branches:
+    - ^master$
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20210122-46f3dbf-1.15.7
+        args:
+        - runner
+        - make
+        - e2e
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        env:
+        - name: K8S_VERSION
+          value: "1.21.1"
+        - name: ISTIO_VERSION
+          value: "1.10.0"
         securityContext:
           privileged: true
           capabilities:


### PR DESCRIPTION
Signed-off-by: joshvanl <vleeuwenjoshua@gmail.com>

/assign @jakexks 

```release-note
NONE
```