### PR TITLE
Bump cpu for pull-cert-manager-release-verify

### DIFF
--- a/config/jobs/cert-manager/release/cert-manager-release-presubmits.yaml
+++ b/config/jobs/cert-manager/release/cert-manager-release-presubmits.yaml
@@ -20,7 +20,7 @@ presubmits:
         - ./test/presubmit.sh
         resources:
           requests:
-            cpu: 2
+            cpu: 3500m
             memory: 4Gi
       dnsConfig:
         options:


### PR DESCRIPTION
This PR bumps the cpu requested by `pull-cert-manager-release-verify` job 2 -> 3500m.
`pull-cert-manager-release-verify` runs `cmrel gcb stage` which builds all `cert-manager` release artifacts for all platforms.

This job is now taking about 45- 55 minutes to run which is too slow, see i.e here https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_release/37/pull-cert-manager-release-verify/1402530354358652928

3500m was chosen because that allows us to fit two jobs onto one `n1-standard-8` node (taking into account the amount of cpu allocated to kubelet).

Signed-off-by: irbekrm <irbekrm@gmail.com>