### PR TITLE
Explain why we went with 3500m for the cpu request, cf #510

### DIFF
--- a/config/jobs/cert-manager/release/cert-manager-release-presubmits.yaml
+++ b/config/jobs/cert-manager/release/cert-manager-release-presubmits.yaml
@@ -20,6 +20,9 @@ presubmits:
         - ./test/presubmit.sh
         resources:
           requests:
+            # 3500m was chosen because that allows us to fit two jobs onto one
+            # n1-standard-8 node, taking into account the amount of CPU allocated
+            # to the kubelet. https://github.com/jetstack/testing/pull/510
             cpu: 3500m
             memory: 4Gi
       dnsConfig:


### PR DESCRIPTION
I think we forgot to document why we changed the CPU value in #510.

```release-note
NONE
```