### PR TITLE
Bump cert-manager release versions

### DIFF
--- a/config/jobs/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager-periodics.yaml
@@ -373,3 +373,64 @@ periodics:
       options:
       - name: ndots
         value: "1"
+
+- name: ci-cert-manager-e2e-v1-21
+  interval: 2h
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: jetstack
+    repo: cert-manager
+    base_ref: master
+  annotations:
+    testgrid-create-test-group: 'true'
+    testgrid-dashboards: jetstack-cert-manager-master
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    description: Runs the end-to-end test suite against a Kubernetes v1.21 cluster
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-cloudflare-credentials: "true"
+    preset-venafi-tpp-credentials: "true"
+    preset-venafi-cloud-credentials: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+      args:
+      - runner
+      - devel/ci-run-e2e.sh
+      resources:
+        requests:
+          cpu: 3500m
+          memory: 12Gi
+      env:
+      - name: K8S_VERSION
+        value: "1.20"
+      # Enable CertificateSigningRequest e2e tests for v1.19+ clusters
+      - name: FEATURE_GATES
+        value: "ExperimentalCertificateSigningRequestControllers=true"
+      securityContext:
+        privileged: true
+        capabilities:
+          add: ["SYS_ADMIN"]
+      volumeMounts:
+      - mountPath: /lib/modules
+        name: modules
+        readOnly: true
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    volumes:
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"

--- a/config/jobs/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager-periodics.yaml
@@ -15,7 +15,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-master
-    description: Runs 'bazel test //...'
+    description: Runs 'bazel test --jobs=1 //...'
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -49,7 +49,7 @@ periodics:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-master
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs 'bazel test //...' using the 'experimental' Bazel version
+    description: Runs 'bazel test --jobs=1 //...' using the 'experimental' Bazel version
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210331-363c37a-experimental

--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.4
+    - release-1.5
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
@@ -45,7 +45,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.4
+    - release-1.5
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
@@ -83,7 +83,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.4
+    - release-1.5
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
@@ -120,7 +120,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.4
+    - release-1.5
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
@@ -155,7 +155,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.4
+    - release-1.5
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
@@ -218,7 +218,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.4
+    - release-1.5
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
@@ -281,7 +281,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.4
+    - release-1.5
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
@@ -344,7 +344,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.4
+    - release-1.5
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
@@ -407,7 +407,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.4
+    - release-1.5
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
@@ -470,7 +470,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.4
+    - release-1.5
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking

--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -334,6 +334,7 @@ presubmits:
         options:
         - name: ndots
           value: "1"
+
   - name: pull-cert-manager-e2e-v1-19
     context: pull-cert-manager-e2e-v1-19
     always_run: false

--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -13,7 +13,7 @@ presubmits:
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
-      description: Runs 'bazel test //...'
+      description: Runs 'bazel test --jobs=1 //...'
     labels:
       preset-service-account: "true"
       preset-bazel-remote-cache-enabled: "true"
@@ -49,7 +49,7 @@ presubmits:
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
-      description: Runs 'bazel test //...' using the 'experimental' Bazel version
+      description: Runs 'bazel test --jobs=1 //...' using the 'experimental' Bazel version
     labels:
       preset-service-account: "true"
       preset-bazel-remote-cache-enabled: "true"
@@ -396,6 +396,7 @@ presubmits:
         options:
         - name: ndots
           value: "1"
+
   - name: pull-cert-manager-e2e-v1-20
     context: pull-cert-manager-e2e-v1-20
     always_run: false
@@ -458,6 +459,7 @@ presubmits:
         options:
         - name: ndots
           value: "1"
+
   - name: pull-cert-manager-e2e-v1-21
     context: pull-cert-manager-e2e-v1-21
     always_run: true

--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -531,7 +531,7 @@ presubmits:
   #
   # See https://github.com/jetstack/cert-manager/issues/3555
   #
-  - name: pull-cert-manager-e2e-v1-20-feature-issuers-venafi-tpp
+  - name: pull-cert-manager-e2e-v1-21-feature-issuers-venafi-tpp
     always_run: false
     optional: true
     max_concurrency: 4
@@ -539,7 +539,7 @@ presubmits:
     decorate: true
     branches: []
     annotations:
-      description: Runs the E2E tests labelled [Feature:Issuers:Venafi:TPP] against a Kubernetes v1.20 cluster
+      description: Runs the E2E tests labelled [Feature:Issuers:Venafi:TPP] against a Kubernetes v1.21 cluster
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -561,7 +561,7 @@ presubmits:
             memory: 12Gi
         env:
         - name: K8S_VERSION
-          value: "1.20"
+          value: "1.21"
         # Enable CertificateSigningRequest e2e tests for v1.19+ clusters
         - name: FEATURE_GATES
           value: "ExperimentalCertificateSigningRequestControllers=true"

--- a/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
+++ b/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
@@ -16,7 +16,7 @@ periodics:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-next
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs 'bazel test //...'
+    description: Runs 'bazel test --jobs=1 //...'
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -50,7 +50,7 @@ periodics:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-next
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs 'bazel test //...' using the 'experimental' Bazel version
+    description: Runs 'bazel test --jobs=1 //...' using the 'experimental' Bazel version
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210331-363c37a-experimental

--- a/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
+++ b/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.4
+    base_ref: release-1.5
   labels:
     preset-service-account: "true"
     preset-bazel-remote-cache-enabled: "true"
@@ -42,7 +42,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.4
+    base_ref: release-1.5
   labels:
     preset-service-account: "true"
     preset-bazel-scratch-dir: "true"
@@ -76,7 +76,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.4
+    base_ref: release-1.5
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
@@ -137,7 +137,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.4
+    base_ref: release-1.5
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-next
@@ -198,7 +198,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.4
+    base_ref: release-1.5
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-next
@@ -259,7 +259,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.4
+    base_ref: release-1.5
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-next
@@ -320,7 +320,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.4
+    base_ref: release-1.5
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-next

--- a/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
+++ b/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
@@ -373,3 +373,64 @@ periodics:
       options:
       - name: ndots
         value: "1"
+
+- name: ci-cert-manager-next-e2e-v1-21
+  interval: 2h
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: jetstack
+    repo: cert-manager
+    base_ref: release-1.5
+  annotations:
+    testgrid-create-test-group: 'true'
+    testgrid-dashboards: jetstack-cert-manager-next
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    description: Runs the end-to-end test suite against a Kubernetes v1.21 cluster
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-cloudflare-credentials: "true"
+    preset-venafi-tpp-credentials: "true"
+    preset-venafi-cloud-credentials: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+      args:
+      - runner
+      - devel/ci-run-e2e.sh
+      resources:
+        requests:
+          cpu: 3500m
+          memory: 12Gi
+      env:
+      - name: K8S_VERSION
+        value: "1.21"
+      # Enable CertificateSigningRequest e2e tests for v1.19+ clusters
+      - name: FEATURE_GATES
+        value: "ExperimentalCertificateSigningRequestControllers=true"
+      securityContext:
+        privileged: true
+        capabilities:
+          add: ["SYS_ADMIN"]
+      volumeMounts:
+      - mountPath: /lib/modules
+        name: modules
+        readOnly: true
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    volumes:
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"

--- a/config/jobs/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
+++ b/config/jobs/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.3
+    base_ref: release-1.4
   labels:
     preset-service-account: "true"
     preset-bazel-remote-cache-enabled: "true"
@@ -42,7 +42,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.3
+    base_ref: release-1.4
   labels:
     preset-service-account: "true"
     preset-bazel-scratch-dir: "true"
@@ -76,7 +76,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.3
+    base_ref: release-1.4
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
@@ -137,7 +137,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.3
+    base_ref: release-1.4
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
@@ -198,7 +198,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.3
+    base_ref: release-1.4
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
@@ -259,7 +259,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.3
+    base_ref: release-1.4
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
@@ -320,7 +320,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.3
+    base_ref: release-1.4
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous

--- a/config/jobs/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
+++ b/config/jobs/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
@@ -16,7 +16,7 @@ periodics:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs 'bazel test //...'
+    description: Runs 'bazel test --jobs=1 //...'
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -50,7 +50,7 @@ periodics:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs 'bazel test //...' using the 'experimental' Bazel version
+    description: Runs 'bazel test --jobs=1 //...' using the 'experimental' Bazel version
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210331-363c37a-experimental

--- a/config/jobs/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
+++ b/config/jobs/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
@@ -373,3 +373,64 @@ periodics:
       options:
       - name: ndots
         value: "1"
+
+- name: ci-cert-manager-previous-e2e-v1-21
+  interval: 2h
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: jetstack
+    repo: cert-manager
+    base_ref: release-1.4
+  annotations:
+    testgrid-create-test-group: 'true'
+    testgrid-dashboards: jetstack-cert-manager-previous
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    description: Runs the end-to-end test suite against a Kubernetes v1.21 cluster
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-cloudflare-credentials: "true"
+    preset-venafi-tpp-credentials: "true"
+    preset-venafi-cloud-credentials: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+      args:
+      - runner
+      - devel/ci-run-e2e.sh
+      resources:
+        requests:
+          cpu: 3500m
+          memory: 12Gi
+      env:
+      - name: K8S_VERSION
+        value: "1.21"
+      # Enable CertificateSigningRequest e2e tests for v1.19+ clusters
+      - name: FEATURE_GATES
+        value: "ExperimentalCertificateSigningRequestControllers=true"
+      securityContext:
+        privileged: true
+        capabilities:
+          add: ["SYS_ADMIN"]
+      volumeMounts:
+      - mountPath: /lib/modules
+        name: modules
+        readOnly: true
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    volumes:
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"

--- a/config/jobs/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
+++ b/config/jobs/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
@@ -8,7 +8,7 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
-    - release-1.3
+    - release-1.4
     annotations:
       testgrid-create-test-group: 'false'
     labels:
@@ -41,7 +41,7 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
-    - release-1.3
+    - release-1.4
     annotations:
       testgrid-create-test-group: 'false'
     labels:
@@ -76,7 +76,7 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
-    - release-1.3
+    - release-1.4
     annotations:
       testgrid-create-test-group: 'false'
     labels:
@@ -110,7 +110,7 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
-    - release-1.3
+    - release-1.4
     annotations:
       testgrid-create-test-group: 'false'
     labels:
@@ -141,7 +141,7 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
-    - release-1.3
+    - release-1.4
     annotations:
       testgrid-create-test-group: 'false'
     labels:
@@ -201,7 +201,7 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
-    - release-1.3
+    - release-1.4
     annotations:
       testgrid-create-test-group: 'false'
     labels:
@@ -261,7 +261,7 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
-    - release-1.3
+    - release-1.4
     annotations:
       testgrid-create-test-group: 'false'
     labels:
@@ -321,7 +321,7 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
-    - release-1.3
+    - release-1.4
     annotations:
       testgrid-create-test-group: 'false'
     labels:
@@ -381,7 +381,7 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
-    - release-1.3
+    - release-1.4
     annotations:
       testgrid-create-test-group: 'false'
     labels:

--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -93,7 +93,8 @@ repo_milestone:
 
 milestone_applier:
   jetstack/cert-manager:
-    master: v1.4
+    master: v1.5
+    release-1.4: v1.4
     release-1.3: v1.3
     release-1.2: v1.2
     release-1.1: v1.1
@@ -110,9 +111,10 @@ milestone_applier:
   cert-manager/website:
     # cert-manager/website uses master branch for 'current' version and the
     # release-next branch for the 'next' version
-    release-next: v1.4
-    master: v1.3
+    release-next: v1.5
+    master: v1.4
     # Older versions are archived into named release branches
+    release-1.3: v1.3
     release-1.2: v1.2
     release-1.1: v1.1
     release-1.0: v1.0


### PR DESCRIPTION
This PR:

- bumps cert-manager versions so that release-next is now `release-1.5` and release-previous is `release-1.4` (See #466 for how this was done last time)
- makes all periodics against all releases run e2e tests also against k8s v1.21- I think this now makes sense?
- makes the optional `pull-cert-manager-e2e-v1-21-feature-issuers-venafi-tpp` test run against k8s `v1.21` (change from `v1.20`)
- updates a few comments

Do we need to create a `release-1.5` branch on `cert-manager` repo before merging this PR?