### PR TITLE
Bumps versions for golang-nodejs image

### DIFF
--- a/images/golang-nodejs/build.yaml
+++ b/images/golang-nodejs/build.yaml
@@ -1,10 +1,10 @@
 name: golang-nodejs # Name of the image to be built
 
 variants:
-  "1.13.4":
+  "1.16":
     arguments:
-      BASE_IMAGE: "node:13.0.1"
-      GO_VERSION: "1.13.4"
+      BASE_IMAGE: "node:16.3.0"
+      GO_VERSION: "1.16.5"
 
 # Image names to be tagged and pushed
 images:


### PR DESCRIPTION
Bumps versions of Go and Node for golang-nodejs image.

Signed-off-by: irbekrm <irbekrm@gmail.com>