### PR TITLE
Adds a new CI image with Bazel

### DIFF
--- a/config/jobs/testing/testing-trusted.yaml
+++ b/config/jobs/testing/testing-trusted.yaml
@@ -195,6 +195,42 @@ postsubmits:
           capabilities:
             add: ["SYS_ADMIN"]
 
+  - name: post-testing-push-bazel-tools
+    cluster: trusted
+    run_if_changed: '^images/bazel-tools/'
+    branches:
+    - master
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-image-deploy: "true"
+      preset-deployer-service-account: "true"
+      preset-deployer-github-token: "true"
+      preset-deployer-ssh-key: "true"
+    annotations:
+      testgrid-create-test-group: 'true'
+      testgrid-dashboards: jetstack-testing-janitors
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      description: Build and push the 'bazel-tools' image
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-056d642-2.2.0
+        args:
+        # Wrap the release script with the runner so we can use docker-in-docker
+        - runner
+        - images/builder/ci-runner.sh
+        - images/bazel-tools
+        - --confirm=true
+        resources:
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+
   - name: post-testing-push-katacoda-lint
     cluster: trusted
     run_if_changed: '^images/katacoda-lint/'

--- a/images/bazel-tools/Dockerfile
+++ b/images/bazel-tools/Dockerfile
@@ -1,0 +1,31 @@
+# Copyright 2021 The Jetstack contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Includes bazel, make, node, go, goversion, jq
+ARG BASE_IMAGE
+
+FROM ${BASE_IMAGE}
+
+LABEL maintainer="cert-manager-maintainers@googlegroups.com"
+
+# install goversion
+RUN go get github.com/rsc/goversion@v1.2.0
+
+ARG NODE_VERSION
+
+# install jq, nodejs
+RUN apt-get install -y \ 
+    jq \
+    nodejs=${NODE_VERSION}
+

--- a/images/bazel-tools/build.yaml
+++ b/images/bazel-tools/build.yaml
@@ -1,0 +1,12 @@
+name: bazel-tools # Name of the image to be built
+
+variants:
+  "10.24":
+    arguments:
+      BASE_IMAGE: "eu.gcr.io/jetstack-build-infra-images/golang-dind@sha256:bf41f2a8f6191842ad3ff56a071448ed6a8bdcece4d6d62c5d91733c2f1f3541"
+      NODE_VERSION: "10.24.0~dfsg-1~deb10u1"
+
+# Image names to be tagged and pushed
+images:
+- ${_REGISTRY}/${_NAME}:${_DATE_STAMP}-${_GIT_REF}-${NODE_VERSION}
+- ${_REGISTRY}/${_NAME}:latest-${NODE_VERSION}


### PR DESCRIPTION
This PR builds a new image with Bazel, Docker, Node, Go for GitHub actions jobs that need to run Bazel.
This is mostly for the FIPS-compliant cert-manager building.



Signed-off-by: irbekrm <irbekrm@gmail.com>