### PR TITLE
Use a semver Docker tag

### DIFF
--- a/images/bazel-tools/build.yaml
+++ b/images/bazel-tools/build.yaml
@@ -5,6 +5,9 @@ variants:
     arguments:
       BASE_IMAGE: "eu.gcr.io/jetstack-build-infra-images/golang-dind@sha256:bf41f2a8f6191842ad3ff56a071448ed6a8bdcece4d6d62c5d91733c2f1f3541"
       NODE_VERSION: "10.24.0~dfsg-1~deb10u1"
+      # This DOCKER_TAG is the Docker tag that corresponds to the Node version
+      # we use. We don't use the Node version directly because it is not a valid
+      # Docker tag.
       DOCKER_TAG: "10.24.0"
 
 # Image names to be tagged and pushed

--- a/images/bazel-tools/build.yaml
+++ b/images/bazel-tools/build.yaml
@@ -5,8 +5,9 @@ variants:
     arguments:
       BASE_IMAGE: "eu.gcr.io/jetstack-build-infra-images/golang-dind@sha256:bf41f2a8f6191842ad3ff56a071448ed6a8bdcece4d6d62c5d91733c2f1f3541"
       NODE_VERSION: "10.24.0~dfsg-1~deb10u1"
+      DOCKER_TAG: "10.24.0"
 
 # Image names to be tagged and pushed
 images:
-- ${_REGISTRY}/${_NAME}:${_DATE_STAMP}-${_GIT_REF}-${NODE_VERSION}
-- ${_REGISTRY}/${_NAME}:latest-${NODE_VERSION}
+- ${_REGISTRY}/${_NAME}:${_DATE_STAMP}-${_GIT_REF}-${DOCKER_TAG}
+- ${_REGISTRY}/${_NAME}:latest-${DOCKER_TAG}


### PR DESCRIPTION
Hardcode Docker tag for `bazel-tools` image for the specific variant built.
This change is needed because the Node version used is not a valid Docker tag.
It looks like hardcoding it is the simplest solution as the Node version cannot be specified by just a semver tag and parsing the NODE_VERSION in the script causes issues due to the special characters in it.

To try building the image (without pushing) run `bazel run //images/builder -- --build-dir $(pwd)/images/bazel-tools` from within this repo.

Signed-off-by: irbekrm <irbekrm@gmail.com>