### PR TITLE
Adds GOPATH/bin to path

### DIFF
--- a/images/bazel-tools/Dockerfile
+++ b/images/bazel-tools/Dockerfile
@@ -22,6 +22,9 @@ LABEL maintainer="cert-manager-maintainers@googlegroups.com"
 # install goversion
 RUN go get github.com/rsc/goversion@v1.2.0
 
+# Add GOPATH/bin to PATH
+ENV PATH=/root/go/bin:$PATH
+
 ARG NODE_VERSION
 
 # install jq, nodejs


### PR DESCRIPTION
This PR just adds $GOPATH/bin to PATH for `bazel-tools` image.

Signed-off-by: irbekrm <irbekrm@gmail.com>