### PR TITLE
Allows to trigger Venafi Cloud e2e tests separately

### DIFF
--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -527,7 +527,7 @@ presubmits:
   # An E2E test job to allow us to manually trigger the Venafi TPP E2E tests
   # with the following GitHub comment:
   #
-  #  /test pull-cert-manager-e2e-v1-20-feature-issuers-venafi-tpp
+  #  /test pull-cert-manager-e2e-v1-21-feature-issuers-venafi-tpp
   #
   # See https://github.com/jetstack/cert-manager/issues/3555
   #
@@ -555,6 +555,71 @@ presubmits:
         - devel/ci-run-e2e.sh
         - -ginkgo.focus
         - '\[Feature:Issuers:Venafi:TPP\]'
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        env:
+        - name: K8S_VERSION
+          value: "1.21"
+        # Enable CertificateSigningRequest e2e tests for v1.19+ clusters
+        - name: FEATURE_GATES
+          value: "ExperimentalCertificateSigningRequestControllers=true"
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+
+  # An E2E test job to allow us to manually trigger the Venafi Cloud E2E tests
+  # with the following GitHub comment:
+  #
+  #  /test pull-cert-manager-e2e-v1-21-feature-issuers-venafi-cloud
+  #
+  # This is useful as we sometimes disable regular runs of Venafi Cloud tests due to some issues.
+  #
+  - name: pull-cert-manager-e2e-v1-21-feature-issuers-venafi-cloud
+    always_run: false
+    optional: true
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    branches: []
+    annotations:
+      description: Runs the E2E tests labelled [Feature:Issuers:Venafi:Cloud] against a Kubernetes v1.21 cluster
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-venafi-tpp-credentials: "true"
+      preset-retry-flakey-tests: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+        args:
+        - runner
+        - devel/ci-run-e2e.sh
+        - -ginkgo.focus
+        - '\[Feature:Issuers:Venafi:Cloud\]'
         resources:
           requests:
             cpu: 3500m


### PR DESCRIPTION
This PR creates a new Prow job that can be run 'manually' with `/test pull-cert-manager-e2e-v1-21-feature-issuers-venafi-cloud` to run just the Venafi Cloud e2e tests.

This is useful as we sometimes disable these tests for regular presubmits/periodics due to flakiness- this way we can still run them manually from the CI when needed using the creds in the test cluster.


Signed-off-by: irbekrm <irbekrm@gmail.com>