### PR TITLE
Upgrade test

### DIFF
--- a/config/jobs/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager-periodics.yaml
@@ -407,7 +407,7 @@ periodics:
           memory: 12Gi
       env:
       - name: K8S_VERSION
-        value: "1.20"
+        value: "1.21"
       # Enable CertificateSigningRequest e2e tests for v1.19+ clusters
       - name: FEATURE_GATES
         value: "ExperimentalCertificateSigningRequestControllers=true"

--- a/config/jobs/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager-periodics.yaml
@@ -434,3 +434,61 @@ periodics:
       options:
       - name: ndots
         value: "1"
+
+- name: ci-cert-manager-upgrade-v1-21
+  interval: 8h
+  agent: kubernetes
+  decorate: true
+  # extra refs specify what repo should be cloned
+  extra_refs:
+  - org: jetstack
+    repo: cert-manager
+    base_ref: master
+  annotations:
+    testgrid-create-test-group: 'true'
+    testgrid-dashboards: jetstack-cert-manager-master
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    description: Runs cert-manager upgrade test every 8 hours
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-bazel-scratch-dir: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+      args:
+      - runner
+      - make
+      - cluster
+      - verify_upgrade
+      resources:
+        requests:
+          cpu: 3500m
+          memory: 12Gi
+      env:
+      - name: K8S_VERSION
+        value: "1.21"
+      securityContext:
+        privileged: true
+        capabilities:
+          add: ["SYS_ADMIN"]
+      volumeMounts:
+      - mountPath: /lib/modules
+        name: modules
+        readOnly: true
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    volumes:
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"

--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -653,3 +653,63 @@ presubmits:
         options:
         - name: ndots
           value: "1"
+
+  # Verifies upgrade from the latest published release with both Helm chart and
+  # static manifests. This is an optional test.
+  - name: pull-cert-manager-upgrade-v1-21
+    # Run only when requested.
+    always_run: false
+    optional: true
+    # No more than 4 instances of this job at the same time.
+    max_concurrency: 4
+    # This job will run on Kubernetes cluster.
+    agent: kubernetes
+    # Pod utilities will be set up.
+    decorate: true
+    branches: []
+    annotations:
+      description: Runs cert-manager upgrade from latest published release
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+        args:
+        - runner
+        - make
+        - cluster
+        - verify_upgrade
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        env:
+        # Used by https://github.com/jetstack/cert-manager/blob/master/devel/cluster/create-kind.sh
+        - name: K8S_VERSION
+          value: "1.21"
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"

--- a/prow/README.md
+++ b/prow/README.md
@@ -111,3 +111,24 @@ Here is the process to upgrade Prow:
     ```sh
     bazel run //prow/cluster:production.apply
     ```
+
+## Creating new Prowjobs
+
+See documentation for ProwJobs in [k/test-infra](https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md).
+
+### Testing locally
+
+ProwJobs can be tested locally by running the (interactive) `./prow/pj-on-kind.sh` script.
+This script will spin up a local KIND cluster and create a new ProwJob instance for which there will be a Pod created that will be running the actual test.
+
+See [documentation in k/test-infra](https://github.com/kubernetes/test-infra/blob/master/prow/build_test_update.md#How-to-test-a-ProwJob) for how the script works.
+
+An example of running `pull-cert-manager-upgrade-v1-21` job locally:
+
+1. Remove Bazel presets from job config, so it doesn't look for Bazel cache creds
+2. Run `./prow/pj-on-kind.sh pull-cert-manager-upgrade-v1-21`
+3. Pass some cert-manager PR number when requested. This will be checked out.
+4. Pass 'empty' for any storage volumes when requested.
+5. Retrieve kubeconfig for the kind cluster `kind get kubeconfig --name mkpod` and set KUBECONFIG
+6. `kubectl get pods` - to get the name of the pod that is running the test
+7. `kubectl logs <pod-name> -c test -f` stream the logs

--- a/prow/pj-on-kind.sh
+++ b/prow/pj-on-kind.sh
@@ -15,10 +15,10 @@
 # limitations under the License.
 # */
 
+# This script is copied from k/test-infra
+# https://github.com/kubernetes/test-infra/blob/488e767e326f6c7189cbf0682e7f926040ae959c/prow/pj-on-kind.sh
 # Runs prow/pj-on-kind.sh with config arguments specific to Jetstack Prow config.
 # Requries go, docker, and kubectl.
-
-# Copied and adapted from https://github.com/istio/test-infra/blob/master/prow/pj-on-kind.sh
 
 # Example usage:
 # ./prow/pj-on-kind.sh ci-cert-manager-e2e-v1-21
@@ -27,11 +27,103 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-set -x
 SCRIPT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
 export REPO_ROOT="${SCRIPT_ROOT}/.."
 
 export CONFIG_PATH="${REPO_ROOT}/config/config.yaml"
 export JOB_CONFIG_PATH="${REPO_ROOT}/config/jobs"
 
-bash <(curl -sSfL https://raw.githubusercontent.com/kubernetes/test-infra/master/prow/pj-on-kind.sh) "$@"
+function main() {
+  # Point kubectl at the mkpod cluster.
+  export KUBECONFIG="${HOME}/.kube/kind-config-mkpod"
+  parseArgs "$@"
+  ensureInstall
+
+  # Generate PJ and Pod.
+  docker pull gcr.io/k8s-prow/mkpj:latest
+  docker run -i --rm -v "${PWD}:${PWD}" -v "${config}:${config}" ${job_config_mnt} -w "${PWD}" gcr.io/k8s-prow/mkpj:latest "--config-path=${config}" "--job=${job}" ${job_config_flag} > "${PWD}/pj.yaml"
+  docker pull gcr.io/k8s-prow/mkpod:latest
+  docker run -i --rm -v "${PWD}:${PWD}" -w "${PWD}" gcr.io/k8s-prow/mkpod:latest --build-id=snowflake "--prow-job=${PWD}/pj.yaml" --local "--out-dir=${out_dir}/${job}" > "${PWD}/pod.yaml"
+
+  # Add any k8s resources that the pod depends on to the kind cluster here. (secrets, configmaps, etc.)
+
+  # Deploy pod and watch.
+  echo "Applying pod to the mkpod cluster. Configure kubectl for the mkpod cluster with:"
+  echo ">  export KUBECONFIG='${KUBECONFIG}'"
+  pod=$(kubectl apply -f "${PWD}/pod.yaml" | cut -d ' ' -f 1)
+  kubectl get "${pod}" -w
+}
+
+# Prep and check args.
+function parseArgs() {
+  # Use node mounts under /mnt/disks/ so pods behave well on COS nodes too. https://cloud.google.com/container-optimized-os/docs/concepts/disks-and-filesystem
+  job="${1:-}"
+  config="${CONFIG_PATH:-}"
+  job_config_path="${JOB_CONFIG_PATH:-}"
+  out_dir="${OUT_DIR:-/mnt/disks/prowjob-out}"
+  kind_config="${KIND_CONFIG:-}"
+  node_dir="${NODE_DIR:-/mnt/disks/kind-node}"  # Any pod hostPath mounts should be under this dir to reach the true host via the kind node.
+
+  local new_only="  (Only used when creating a new kind cluster.)"
+  echo "job=${job}"
+  echo "CONFIG_PATH=${config}"
+  echo "JOB_CONFIG_PATH=${job_config_path}"
+  echo "OUT_DIR=${out_dir} ${new_only}"
+  echo "KIND_CONFIG=${kind_config} ${new_only}"
+  echo "NODE_DIR=${node_dir} ${new_only}"
+
+  if [[ -z "${job}" ]]; then
+    echo "Must specify a job name as the first argument."
+    exit 2
+  fi
+  if [[ -z "${config}" ]]; then
+    echo "Must specify config.yaml location via CONFIG_PATH env var."
+    exit 2
+  fi
+  job_config_flag=""
+  job_config_mnt=""
+  if [[ -n "${job_config_path}" ]]; then
+    job_config_flag="--job-config-path=${job_config_path}"
+    job_config_mnt="-v ${job_config_path}:${job_config_path}"
+  fi
+}
+
+# Ensures installation of prow tools, kind, and a kind cluster named "mkpod".
+function ensureInstall() {
+  # Install kind and set up cluster if not already done.
+  if ! command -v kind >/dev/null 2>&1; then
+    echo "Installing kind..."
+    GO111MODULE="on" go get sigs.k8s.io/kind@v0.7.0
+  fi
+  local found="false"
+  for clust in $(kind get clusters); do
+    if [[ "${clust}" == "mkpod" ]]; then
+      found="true"
+      break
+    fi
+  done
+  if [[ "${found}" == "false" ]]; then
+    # Need to create the "mkpod" kind cluster.
+    if [[ -n "${kind_config}" ]]; then
+      kind create cluster --name=mkpod "--config=${kind_config}" --wait=5m
+    else
+      # Create a temporary kind config file.
+      local temp_config="${PWD}/temp-mkpod-kind-config.yaml"
+      cat <<EOF > "${temp_config}"
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - extraMounts:
+      - containerPath: ${out_dir}
+        hostPath: ${out_dir}
+      # host <-> node mount for hostPath volumes in Pods. (All hostPaths should be under ${node_dir} to reach the host.)
+      - containerPath: ${node_dir}
+        hostPath: ${node_dir}
+EOF
+      kind create cluster --name=mkpod "--config=${temp_config}" --wait=5m
+      rm "${temp_config}"
+    fi
+  fi
+}
+
+main "$@"

--- a/prow/pj-on-kind.sh
+++ b/prow/pj-on-kind.sh
@@ -1,13 +1,13 @@
-
 #!/usr/bin/env bash
-# Copyright 2021 The Jetstack contributors.
 
+# Copyright 2021 The Jetstack contributors.
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/prow/pj-on-kind.sh
+++ b/prow/pj-on-kind.sh
@@ -1,0 +1,37 @@
+
+#!/usr/bin/env bash
+# Copyright 2021 The Jetstack contributors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# */
+
+# Runs prow/pj-on-kind.sh with config arguments specific to Jetstack Prow config.
+# Requries go, docker, and kubectl.
+
+# Copied and adapted from https://github.com/istio/test-infra/blob/master/prow/pj-on-kind.sh
+
+# Example usage:
+# ./prow/pj-on-kind.sh ci-cert-manager-e2e-v1-21
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+set -x
+SCRIPT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+export REPO_ROOT="${SCRIPT_ROOT}/.."
+
+export CONFIG_PATH="${REPO_ROOT}/config/config.yaml"
+export JOB_CONFIG_PATH="${REPO_ROOT}/config/jobs"
+
+bash <(curl -sSfL https://raw.githubusercontent.com/kubernetes/test-infra/master/prow/pj-on-kind.sh) "$@"


### PR DESCRIPTION
This PR:

- Adds a periodic prow job that would test cert-manager upgrade from latest published release to the current master every 8 hrs
- Adds an *optional* pre-submit that would do the same ^ 
- Adds a small script for testing prow job locally
- Updates Readme with some documentation on how to test prow jobs locally
- Corrects k8s version for an unrelated e2e test

Arguably the new ProwJobs and the local testing docs/script could be 2 separate PRs, happy to split if that would help to review.
I added the script as I was looking for a way to test the jobs added in this PR, so it made sense at the time.

This PR depends on https://github.com/jetstack/cert-manager/pull/4204 which should be merged first.

I have tested the new presubmit prow job locally (as described in the Readme addition).
The new periodic prow job can be tested locally once https://github.com/jetstack/cert-manager/pull/4204 merges.

Fixes #525 