### PR TITLE
Build new CI images with go v1.16.6

### DIFF
--- a/images/golang-dind/build.yaml
+++ b/images/golang-dind/build.yaml
@@ -1,10 +1,10 @@
 name: golang-dind # Name of the image to be built
 
 variants:
-  "1.16":
+  "1.16.6":
     arguments:
       BASE_IMAGE: "eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210331-363c37a-3.5.0"
-      GO_VERSION: "1.16"
+      GO_VERSION: "1.16.6"
   "1.15.7":
     arguments:
       BASE_IMAGE: "eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210331-363c37a-3.5.0"

--- a/images/golang-nodejs/build.yaml
+++ b/images/golang-nodejs/build.yaml
@@ -1,10 +1,10 @@
 name: golang-nodejs # Name of the image to be built
 
 variants:
-  "1.16":
+  "1.16.6":
     arguments:
       BASE_IMAGE: "node:16.3.0"
-      GO_VERSION: "1.16.5"
+      GO_VERSION: "1.16.6"
 
 # Image names to be tagged and pushed
 images:


### PR DESCRIPTION
This will now be pulling https://dl.google.com/go/go1.16.6.linux-amd64.tar.gz

(I had made a mistake earlier by only specifying minor version in these two files, but it shouldn't matter)



Signed-off-by: irbekrm <irbekrm@gmail.com>