### PR TITLE
Make upgrade test run on each PR

### DIFF
--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -574,6 +574,68 @@ presubmits:
         - name: ndots
           value: "1"
 
+  # Verifies upgrade from the latest published release with both Helm chart and
+  # static manifests. This is an optional test.
+  - name: pull-cert-manager-upgrade
+    # Run always
+    always_run: true 
+    optional: false 
+    # No more than 4 instances of this job at the same time.
+    max_concurrency: 4
+    # This job will run on Kubernetes cluster.
+    agent: kubernetes
+    # Pod utilities will be set up.
+    decorate: true
+    branches:
+    - master
+    - release-1.6
+    annotations:
+      description: Runs cert-manager upgrade from latest published release
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+        args:
+        - runner
+        - make
+        - cluster
+        - verify_upgrade
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        env:
+        # Used by https://github.com/jetstack/cert-manager/blob/master/devel/cluster/create-kind.sh
+        - name: K8S_VERSION
+          value: "1.22"
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+
   # An E2E test job to allow us to manually trigger the Venafi TPP E2E tests
   # with the following GitHub comment:
   #
@@ -671,66 +733,6 @@ presubmits:
             cpu: 3500m
             memory: 12Gi
         env:
-        - name: K8S_VERSION
-          value: "1.22"
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-
-  # Verifies upgrade from the latest published release with both Helm chart and
-  # static manifests. This is an optional test.
-  - name: pull-cert-manager-upgrade
-    # Run only when requested.
-    always_run: false
-    optional: true
-    # No more than 4 instances of this job at the same time.
-    max_concurrency: 4
-    # This job will run on Kubernetes cluster.
-    agent: kubernetes
-    # Pod utilities will be set up.
-    decorate: true
-    branches: []
-    annotations:
-      description: Runs cert-manager upgrade from latest published release
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-        args:
-        - runner
-        - make
-        - cluster
-        - verify_upgrade
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        env:
-        # Used by https://github.com/jetstack/cert-manager/blob/master/devel/cluster/create-kind.sh
         - name: K8S_VERSION
           value: "1.22"
         securityContext:


### PR DESCRIPTION
This PR makes the upgrade test to run on each pull request.

This is because our e2e tests are now running with experimental feature gates enabled and will also be running with the `gateway-shim` controller enabled and the Gateway API CRDs installed once [cert-manager#4158](https://github.com/jetstack/cert-manager/pull/4158) gets merged- so it seems to make sense to also run this as a smoke test that a simple installation still works.

The commit only has a few lines changed, but because I moved the job above two similar jobs, Git calculated the diff in a weird way.

Signed-off-by: irbekrm <irbekrm@gmail.com>