### PR TITLE
Bumps cert-manager website golang image tag to 1.16

### DIFF
--- a/config/jobs/cert-manager/website/cert-manager-website-periodics.yaml
+++ b/config/jobs/cert-manager/website/cert-manager-website-periodics.yaml
@@ -18,7 +18,7 @@ periodics:
     description: Updates the algolia search index for the cert-manager website
   spec:
     containers:
-    - image: "eu.gcr.io/jetstack-build-infra-images/golang-nodejs:20191129-c49853e-1.13.4"
+    - image: "eu.gcr.io/jetstack-build-infra-images/golang-nodejs:20210713-2212311-1.16.6"
       args:
       - bash
       - scripts/index

--- a/config/jobs/cert-manager/website/cert-manager-website-presubmits.yaml
+++ b/config/jobs/cert-manager/website/cert-manager-website-presubmits.yaml
@@ -14,7 +14,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: "eu.gcr.io/jetstack-build-infra-images/golang-nodejs:20191129-c49853e-1.13.4"
+      - image: "eu.gcr.io/jetstack-build-infra-images/golang-nodejs:20210713-2212311-1.16.6"
         args:
         - ./scripts/verify-release
         resources:


### PR DESCRIPTION
Signed-off-by: joshvanl <vleeuwenjoshua@gmail.com>

/assign @jakexks 

```release-note
NONE
```