### PR TITLE
Kind image script

### DIFF
--- a/images/README.md
+++ b/images/README.md
@@ -1,0 +1,15 @@
+# testing/images
+
+Images used for various CI jobs for cert-manager and related projects.
+
+All images are built in Prow. There is a Prow job per image in [config/jobs/testing/test-trusted.yaml](config/jobs/testing/test-trusted.yaml).
+
+Most images are built using the scripts in [image/builder](images/builder).
+
+### kind
+
+[images/kind](images/kind) contains a script to build our own KIND image- this may be useful when needing to test against a particular version of Kubernetes for which there is no 'official' KIND image yet.
+
+To build for a new Kubernetes version, change the  in images/kind/build.sh - this should trigger `post-testing-push-kind` Prow job and a `gcr.io/jetstack-build-infra-images/kind:<KUBERNETES_VERSION>` image should get built and pushed.
+
+This image build does not use [image/builder](images/builder) functionality because the image is built with KIND CLI, not Docker.

--- a/images/README.md
+++ b/images/README.md
@@ -8,8 +8,8 @@ Most images are built using the scripts in [image/builder](images/builder).
 
 ### kind
 
-[images/kind](images/kind) contains a script to build our own KIND image- this may be useful when needing to test against a particular version of Kubernetes for which there is no 'official' KIND image yet.
+[images/kind](images/kind) contains a script to build our own kind image—this may be useful when needing to test against a particular version of Kubernetes for which there is no 'official' kind image yet.
 
-To build for a new Kubernetes version, change the  in images/kind/build.sh - this should trigger `post-testing-push-kind` Prow job and a `gcr.io/jetstack-build-infra-images/kind:<KUBERNETES_VERSION>` image should get built and pushed.
+To build for a new Kubernetes version, change the `KUBERNETES_VERSION` variable in `images/kind/build.sh`—­this should trigger the `post-testing-push-kind` Prow job and a `gcr.io/jetstack-build-infra-images/kind:<KUBERNETES_VERSION>` image should get built and pushed.
 
-This image build does not use [image/builder](images/builder) functionality because the image is built with KIND CLI, not Docker.
+This image build does not use [image/builder](images/builder) functionality because the image is built with `kind`, not Docker.

--- a/images/kind/build.sh
+++ b/images/kind/build.sh
@@ -21,7 +21,7 @@ set -o pipefail
 # Tag to check out in k/k repo. Kind will build Kubernetes binaries from that
 # tag and include in the built KIND image.
 KUBERNETES_VERSION=v1.22.0-beta.2
-# Version of the KIND CLI to use to build the KIND image.
+# Version of the kind CLI to use to build the kind image.
 KIND_BASE_VERSION=v0.11.1
 
 echo "Downloading dependencies..."

--- a/images/kind/build.sh
+++ b/images/kind/build.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Jetstack contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Tag to check out in k/k repo. Kind will build Kubernetes binaries from that
+# tag and include in the built KIND image.
+KUBERNETES_VERSION=v1.22.0-beta.2
+# Version of the KIND CLI to use to build the KIND image.
+KIND_BASE_VERSION=v0.11.1
+
+echo "Downloading dependencies..."
+
+go get sigs.k8s.io/kind@${KIND_BASE_VERSION}
+export PATH=$(go env GOPATH)/bin:$PATH
+
+# go get seems to not work for k/k see https://github.com/kubernetes/kubernetes/issues/79384
+kube_path=$(go env GOPATH)/src/k8s.io/kubernetes
+mkdir -p $kube_path
+git clone --branch ${KUBERNETES_VERSION} \
+	--depth 1 \
+	https://github.com/kubernetes/kubernetes \
+	${kube_path}
+
+image_tag=gcr.io/jetstack-build-infra-images/kind:${KUBERNETES_VERSION}
+
+echo "Building $image_tag..."
+kind build node-image \
+	--image ${image_tag}
+
+echo "Activating service account..."
+gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
+
+echo "Generating docker credentials..."
+gcloud auth configure-docker --quiet
+
+echo "Pushing ${image_tag}..."
+docker push ${image_tag}
+
+echo "${image_tag} built and pushed!"


### PR DESCRIPTION
This PR adds a basic script to build KIND images for a particular Kubernetes version.

This is not expected to be used much, but at the same time it seems better to still build these image via CI.

#533 should be merged first, so that the new `post-testing-push-kind` Prow job that #533 adds can get triggered on the change that will be the merging of _this_ PR.

Once this succeeds and an image gets built, I will PR a v1.22 version of KIND in [cert-manager here-ish](https://github.com/jetstack/cert-manager/blob/master/devel/cluster/create-kind.sh#L33-L49) and add a new optional Prow job that we can run on presubmits.

Fixes #519 

/kind cleanup