### PR TITLE
Corrects registry name

### DIFF
--- a/images/kind/build.sh
+++ b/images/kind/build.sh
@@ -37,7 +37,7 @@ git clone --branch ${KUBERNETES_VERSION} \
 	https://github.com/kubernetes/kubernetes \
 	${kube_path}
 
-image_tag=gcr.io/jetstack-build-infra-images/kind:${KUBERNETES_VERSION}
+image_tag=eu.gcr.io/jetstack-build-infra-images/kind:${KUBERNETES_VERSION}
 
 echo "Building $image_tag..."
 kind build node-image \


### PR DESCRIPTION
Corrects the registry name in the kind image script.

The previous push of this image [failed](https://storage.googleapis.com/jetstack-logs/logs/post-testing-push-kind/1418169703783731200/build-log.txt) and I think this _may_ have been the reason. I don't have access to the trusted cluster for debugging, but the GCP SA used [should have the right permissions](https://github.com/jetstack/terraform-jetstack/blob/master/jetstack_build_infra_images.tf#L21).

Signed-off-by: irbekrm <irbekrm@gmail.com>