### PR TITLE
Adds an optional Prow job to run cert-manager e2e tests against k8s 1.22

### DIFF
--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -713,3 +713,66 @@ presubmits:
         options:
         - name: ndots
           value: "1"
+
+  - name: pull-cert-manager-e2e-v1-22
+    context: pull-cert-manager-e2e-v1-22
+    always_run: false
+    optional: true
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    branches:
+    - master
+    - release-1.5
+    annotations:
+      testgrid-create-test-group: 'true'
+      testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
+      description: Runs the end-to-end test suite against a Kubernetes v1.22 cluster
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-cloudflare-credentials: "true"
+      preset-venafi-tpp-credentials: "true"
+      preset-venafi-cloud-credentials: "true"
+      preset-retry-flakey-tests: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+        args:
+        - runner
+        - devel/ci-run-e2e.sh
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        env:
+        - name: K8S_VERSION
+          value: "1.22"
+        # Enable CertificateSigningRequest e2e tests for v1.19+ clusters
+        - name: FEATURE_GATES
+          value: "ExperimentalCertificateSigningRequestControllers=true"
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"


### PR DESCRIPTION
An optional Prow presubmit to run cert-manager e2e tests against Kubernetes v1.22.

There is a related PR [cert-manager#4240](https://github.com/jetstack/cert-manager/pull/4240) that adds an option to build v1.22 cluster to the relevant script in cert-manager codebase.

/kind cleanup

Signed-off-by: irbekrm <irbekrm@gmail.com>