### PR TITLE
Bump k8s version for v1.22 image

### DIFF
--- a/images/kind/build.sh
+++ b/images/kind/build.sh
@@ -20,7 +20,7 @@ set -o pipefail
 
 # Tag to check out in k/k repo. Kind will build Kubernetes binaries from that
 # tag and include in the built KIND image.
-KUBERNETES_VERSION=v1.22.0-rc.0
+KUBERNETES_VERSION=v1.22.0
 # Version of the kind CLI to use to build the kind image.
 KIND_BASE_VERSION=v0.11.1
 


### PR DESCRIPTION
Bump k8s version to v1.22.0

Once this image gets built and we have  seen e2e tests pass with that, I'd like to make this run by default on presubmits.

Signed-off-by: irbekrm <irbekrm@gmail.com>