### PR TITLE
Enable Gateway API Feature gate on k8s 1.19+

### DIFF
--- a/config/jobs/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager-periodics.yaml
@@ -286,9 +286,9 @@ periodics:
       env:
       - name: K8S_VERSION
         value: "1.19"
-      # Enable CertificateSigningRequest e2e tests for v1.19+ clusters
+      # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
       - name: FEATURE_GATES
-        value: "ExperimentalCertificateSigningRequestControllers=true"
+        value: "ExperimentalCertificateSigningRequestControllers=true\\,ExperimentalGatewayAPISupport=true"
       securityContext:
         privileged: true
         capabilities:
@@ -347,9 +347,9 @@ periodics:
       env:
       - name: K8S_VERSION
         value: "1.20"
-      # Enable CertificateSigningRequest e2e tests for v1.19+ clusters
+      # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
       - name: FEATURE_GATES
-        value: "ExperimentalCertificateSigningRequestControllers=true"
+        value: "ExperimentalCertificateSigningRequestControllers=true\\,ExperimentalGatewayAPISupport=true"
       securityContext:
         privileged: true
         capabilities:
@@ -408,9 +408,9 @@ periodics:
       env:
       - name: K8S_VERSION
         value: "1.21"
-      # Enable CertificateSigningRequest e2e tests for v1.19+ clusters
+      # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
       - name: FEATURE_GATES
-        value: "ExperimentalCertificateSigningRequestControllers=true"
+        value: "ExperimentalCertificateSigningRequestControllers=true\\,ExperimentalGatewayAPISupport=true"
       securityContext:
         privileged: true
         capabilities:

--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -371,9 +371,9 @@ presubmits:
         env:
         - name: K8S_VERSION
           value: "1.19"
-        # Enable CertificateSigningRequest e2e tests for v1.19+ clusters
+        # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
         - name: FEATURE_GATES
-          value: "ExperimentalCertificateSigningRequestControllers=true"
+          value: "ExperimentalCertificateSigningRequestControllers=true\\,ExperimentalGatewayAPISupport=true"
         securityContext:
           privileged: true
           capabilities:
@@ -434,9 +434,9 @@ presubmits:
         env:
         - name: K8S_VERSION
           value: "1.20"
-        # Enable CertificateSigningRequest e2e tests for v1.19+ clusters
+        # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
         - name: FEATURE_GATES
-          value: "ExperimentalCertificateSigningRequestControllers=true"
+          value: "ExperimentalCertificateSigningRequestControllers=true\\,ExperimentalGatewayAPISupport=true"
         securityContext:
           privileged: true
           capabilities:
@@ -497,9 +497,9 @@ presubmits:
         env:
         - name: K8S_VERSION
           value: "1.21"
-        # Enable CertificateSigningRequest e2e tests for v1.19+ clusters
+        # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
         - name: FEATURE_GATES
-          value: "ExperimentalCertificateSigningRequestControllers=true"
+          value: "ExperimentalCertificateSigningRequestControllers=true\\,ExperimentalGatewayAPISupport=true"
         securityContext:
           privileged: true
           capabilities:
@@ -627,9 +627,9 @@ presubmits:
         env:
         - name: K8S_VERSION
           value: "1.21"
-        # Enable CertificateSigningRequest e2e tests for v1.19+ clusters
+        # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
         - name: FEATURE_GATES
-          value: "ExperimentalCertificateSigningRequestControllers=true"
+          value: "ExperimentalCertificateSigningRequestControllers=true\\,ExperimentalGatewayAPISupport=true"
         securityContext:
           privileged: true
           capabilities:
@@ -750,9 +750,9 @@ presubmits:
         env:
         - name: K8S_VERSION
           value: "1.22"
-        # Enable CertificateSigningRequest e2e tests for v1.19+ clusters
+        # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
         - name: FEATURE_GATES
-          value: "ExperimentalCertificateSigningRequestControllers=true"
+          value: "ExperimentalCertificateSigningRequestControllers=true\\,ExperimentalGatewayAPISupport=true"
         securityContext:
           privileged: true
           capabilities:

--- a/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
+++ b/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
@@ -286,9 +286,9 @@ periodics:
       env:
       - name: K8S_VERSION
         value: "1.19"
-      # Enable CertificateSigningRequest e2e tests for v1.19+ clusters
+      # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
       - name: FEATURE_GATES
-        value: "ExperimentalCertificateSigningRequestControllers=true"
+        value: "ExperimentalCertificateSigningRequestControllers=true\\,ExperimentalGatewayAPISupport=true"
       securityContext:
         privileged: true
         capabilities:
@@ -347,9 +347,9 @@ periodics:
       env:
       - name: K8S_VERSION
         value: "1.20"
-      # Enable CertificateSigningRequest e2e tests for v1.19+ clusters
+      # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
       - name: FEATURE_GATES
-        value: "ExperimentalCertificateSigningRequestControllers=true"
+        value: "ExperimentalCertificateSigningRequestControllers=true\\,ExperimentalGatewayAPISupport=true"
       securityContext:
         privileged: true
         capabilities:
@@ -408,9 +408,9 @@ periodics:
       env:
       - name: K8S_VERSION
         value: "1.21"
-      # Enable CertificateSigningRequest e2e tests for v1.19+ clusters
+      # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
       - name: FEATURE_GATES
-        value: "ExperimentalCertificateSigningRequestControllers=true"
+        value: "ExperimentalCertificateSigningRequestControllers=true\\,ExperimentalGatewayAPISupport=true"
       securityContext:
         privileged: true
         capabilities:


### PR DESCRIPTION
This will allow the tests in https://github.com/jetstack/cert-manager/pull/4310 to pass.

/release-note-none