### PR TITLE
\\\\, -> ,

### DIFF
--- a/config/jobs/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager-periodics.yaml
@@ -288,7 +288,7 @@ periodics:
         value: "1.19"
       # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
       - name: FEATURE_GATES
-        value: "ExperimentalCertificateSigningRequestControllers=true\\\\,ExperimentalGatewayAPISupport=true"
+        value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
       securityContext:
         privileged: true
         capabilities:
@@ -349,7 +349,7 @@ periodics:
         value: "1.20"
       # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
       - name: FEATURE_GATES
-        value: "ExperimentalCertificateSigningRequestControllers=true\\\\,ExperimentalGatewayAPISupport=true"
+        value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
       securityContext:
         privileged: true
         capabilities:
@@ -410,7 +410,7 @@ periodics:
         value: "1.21"
       # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
       - name: FEATURE_GATES
-        value: "ExperimentalCertificateSigningRequestControllers=true\\\\,ExperimentalGatewayAPISupport=true"
+        value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
       securityContext:
         privileged: true
         capabilities:

--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -373,7 +373,7 @@ presubmits:
           value: "1.19"
         # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
         - name: FEATURE_GATES
-          value: "ExperimentalCertificateSigningRequestControllers=true\\\\,ExperimentalGatewayAPISupport=true"
+          value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
         securityContext:
           privileged: true
           capabilities:
@@ -436,7 +436,7 @@ presubmits:
           value: "1.20"
         # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
         - name: FEATURE_GATES
-          value: "ExperimentalCertificateSigningRequestControllers=true\\\\,ExperimentalGatewayAPISupport=true"
+          value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
         securityContext:
           privileged: true
           capabilities:
@@ -499,7 +499,7 @@ presubmits:
           value: "1.21"
         # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
         - name: FEATURE_GATES
-          value: "ExperimentalCertificateSigningRequestControllers=true\\\\,ExperimentalGatewayAPISupport=true"
+          value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
         securityContext:
           privileged: true
           capabilities:
@@ -629,7 +629,7 @@ presubmits:
           value: "1.21"
         # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
         - name: FEATURE_GATES
-          value: "ExperimentalCertificateSigningRequestControllers=true\\\\,ExperimentalGatewayAPISupport=true"
+          value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
         securityContext:
           privileged: true
           capabilities:
@@ -752,7 +752,7 @@ presubmits:
           value: "1.22"
         # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
         - name: FEATURE_GATES
-          value: "ExperimentalCertificateSigningRequestControllers=true\\\\,ExperimentalGatewayAPISupport=true"
+          value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
         securityContext:
           privileged: true
           capabilities:

--- a/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
+++ b/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
@@ -288,7 +288,7 @@ periodics:
         value: "1.19"
       # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
       - name: FEATURE_GATES
-        value: "ExperimentalCertificateSigningRequestControllers=true\\\\,ExperimentalGatewayAPISupport=true"
+        value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
       securityContext:
         privileged: true
         capabilities:
@@ -349,7 +349,7 @@ periodics:
         value: "1.20"
       # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
       - name: FEATURE_GATES
-        value: "ExperimentalCertificateSigningRequestControllers=true\\\\,ExperimentalGatewayAPISupport=true"
+        value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
       securityContext:
         privileged: true
         capabilities:
@@ -410,7 +410,7 @@ periodics:
         value: "1.21"
       # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
       - name: FEATURE_GATES
-        value: "ExperimentalCertificateSigningRequestControllers=true\\\\,ExperimentalGatewayAPISupport=true"
+        value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
       securityContext:
         privileged: true
         capabilities:


### PR DESCRIPTION
\\\\\\\\, causes some problems with the tests; lets instead fix the scripts in cert-manager and pass the string correctly here