### PR TITLE
Export GINKGO_SKIP/GINKGO_FOCUS env vars in test containers

### DIFF
--- a/config/jobs/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager-periodics.yaml
@@ -84,7 +84,7 @@ periodics:
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
-    preset-venafi-cloud-credentials: "true"
+    preset-k8s-pre-v19-env: "true"
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-master
@@ -103,9 +103,6 @@ periodics:
       env:
       - name: K8S_VERSION
         value: "1.16"
-      # Disable CertificateSigningRequest e2e tests for pre v1.19 clusters
-      - name: FEATURE_GATES
-        value: "ExperimentalCertificateSigningRequestControllers=false"
       securityContext:
         privileged: true
         capabilities:
@@ -150,7 +147,7 @@ periodics:
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
-    preset-venafi-cloud-credentials: "true"
+    preset-k8s-pre-v19-env: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -164,9 +161,6 @@ periodics:
       env:
       - name: K8S_VERSION
         value: "1.17"
-      # Disable CertificateSigningRequest e2e tests for pre v1.19 clusters
-      - name: FEATURE_GATES
-        value: "ExperimentalCertificateSigningRequestControllers=false"
       securityContext:
         privileged: true
         capabilities:
@@ -211,7 +205,7 @@ periodics:
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
-    preset-venafi-cloud-credentials: "true"
+    preset-k8s-pre-v19-env: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -225,9 +219,6 @@ periodics:
       env:
       - name: K8S_VERSION
         value: "1.18"
-      # Disable CertificateSigningRequest e2e tests for pre v1.19 clusters
-      - name: FEATURE_GATES
-        value: "ExperimentalCertificateSigningRequestControllers=false"
       securityContext:
         privileged: true
         capabilities:
@@ -272,7 +263,7 @@ periodics:
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
-    preset-venafi-cloud-credentials: "true"
+    preset-k8s-v19-plus-env: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -286,9 +277,6 @@ periodics:
       env:
       - name: K8S_VERSION
         value: "1.19"
-      # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
-      - name: FEATURE_GATES
-        value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
       securityContext:
         privileged: true
         capabilities:
@@ -333,7 +321,7 @@ periodics:
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
-    preset-venafi-cloud-credentials: "true"
+    preset-k8s-v19-plus-env: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -347,9 +335,6 @@ periodics:
       env:
       - name: K8S_VERSION
         value: "1.20"
-      # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
-      - name: FEATURE_GATES
-        value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
       securityContext:
         privileged: true
         capabilities:
@@ -394,7 +379,7 @@ periodics:
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
-    preset-venafi-cloud-credentials: "true"
+    preset-k8s-v19-plus-env: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -408,9 +393,6 @@ periodics:
       env:
       - name: K8S_VERSION
         value: "1.21"
-      # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
-      - name: FEATURE_GATES
-        value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
       securityContext:
         privileged: true
         capabilities:
@@ -455,7 +437,7 @@ periodics:
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
-    preset-venafi-cloud-credentials: "true"
+    preset-k8s-v19-plus-env: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -469,9 +451,65 @@ periodics:
       env:
       - name: K8S_VERSION
         value: "1.22"
-      # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
-      - name: FEATURE_GATES
-        value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
+      securityContext:
+        privileged: true
+        capabilities:
+          add: ["SYS_ADMIN"]
+      volumeMounts:
+      - mountPath: /lib/modules
+        name: modules
+        readOnly: true
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    volumes:
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+
+# This test runs Venafi Cloud tests once every 24hrs.
+# This is the only CI test job that runs those.
+- name: ci-cert-manager-venafi-cloud
+  interval: 24h
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: jetstack
+    repo: cert-manager
+    base_ref: master
+  annotations:
+    testgrid-create-test-group: 'true'
+    testgrid-dashboards: jetstack-cert-manager-master
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    description: Runs the end-to-end test suite against a Kubernetes v1.22 cluster
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-venafi-cloud-credentials: "true"
+    preset-ginkgo-focus-venafi-cloud: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+      args:
+      - runner
+      - devel/ci-run-e2e.sh
+      resources:
+        requests:
+          cpu: 3500m
+          memory: 12Gi
+      env:
+      - name: K8S_VERSION
+        value: "1.22"
       securityContext:
         privileged: true
         capabilities:
@@ -577,6 +615,7 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
     preset-bazel-scratch-dir: "true"
     preset-aws-credentials: "true"
+    preset-ginkgo-focus-http01-ingress: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/golang-aws@sha256:1f330e4c9552ca383d157067b73fb0e090b64b0777939fd59e58b60e06020d66
@@ -596,7 +635,7 @@ periodics:
         cd /home && \
         ls && \
         cd /home/prow/go/src/github.com/jetstack/cert-manager && \
-        ./devel/run-e2e.sh --ginkgo.focus "Public ACME Server HTTP01 Issuer" --acme-server-url=https://acme-staging-v02.api.letsencrypt.org/directory --ingress-controller-domain=aws.e2e-tests.cert-manager.io --testing-acme-email=cert-manager-dev-alerts@googlegroups.com --kubernetes-config=/home/prow/go/src/github.com/cert-manager/test-infra/aws/kubeconfig_cert-manager-cluster || true && \
+        ./devel/run-e2e.sh --acme-server-url=https://acme-staging-v02.api.letsencrypt.org/directory --ingress-controller-domain=aws.e2e-tests.cert-manager.io --testing-acme-email=cert-manager-dev-alerts@googlegroups.com --kubernetes-config=/home/prow/go/src/github.com/cert-manager/test-infra/aws/kubeconfig_cert-manager-cluster || true && \
         cd /home/prow/go/src/github.com/cert-manager/test-infra/aws && \
         terraform destroy -auto-approve;
       resources:

--- a/config/jobs/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager-periodics.yaml
@@ -84,7 +84,8 @@ periodics:
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
-    preset-k8s-pre-v19-env: "true"
+    preset-disable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-master
@@ -147,7 +148,8 @@ periodics:
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
-    preset-k8s-pre-v19-env: "true"
+    preset-disable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -205,7 +207,8 @@ periodics:
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
-    preset-k8s-pre-v19-env: "true"
+    preset-disable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -263,7 +266,8 @@ periodics:
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
-    preset-k8s-v19-plus-env: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -321,7 +325,8 @@ periodics:
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
-    preset-k8s-v19-plus-env: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -379,7 +384,8 @@ periodics:
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
-    preset-k8s-v19-plus-env: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -437,7 +443,8 @@ periodics:
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
-    preset-k8s-v19-plus-env: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2

--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -167,8 +167,8 @@ presubmits:
       preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
       preset-venafi-tpp-credentials: "true"
-      preset-venafi-cloud-credentials: "true"
       preset-retry-flakey-tests: "true"
+      preset-k8s-pre-v19-env: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -182,9 +182,6 @@ presubmits:
         env:
         - name: K8S_VERSION
           value: "1.16"
-        # Disable CertificateSigningRequest e2e tests for pre v1.19 clusters
-        - name: FEATURE_GATES
-          value: "ExperimentalCertificateSigningRequestControllers=false"
         securityContext:
           privileged: true
           capabilities:
@@ -230,8 +227,8 @@ presubmits:
       preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
       preset-venafi-tpp-credentials: "true"
-      preset-venafi-cloud-credentials: "true"
       preset-retry-flakey-tests: "true"
+      preset-k8s-pre-v19-env: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -245,9 +242,6 @@ presubmits:
         env:
         - name: K8S_VERSION
           value: "1.17"
-        # Disable CertificateSigningRequest e2e tests for pre v1.19 clusters
-        - name: FEATURE_GATES
-          value: "ExperimentalCertificateSigningRequestControllers=false"
         securityContext:
           privileged: true
           capabilities:
@@ -293,8 +287,8 @@ presubmits:
       preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
       preset-venafi-tpp-credentials: "true"
-      preset-venafi-cloud-credentials: "true"
       preset-retry-flakey-tests: "true"
+      preset-k8s-pre-v19-env: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -308,9 +302,6 @@ presubmits:
         env:
         - name: K8S_VERSION
           value: "1.18"
-        # Disable CertificateSigningRequest e2e tests for pre v1.19 clusters
-        - name: FEATURE_GATES
-          value: "ExperimentalCertificateSigningRequestControllers=false"
         securityContext:
           privileged: true
           capabilities:
@@ -356,8 +347,8 @@ presubmits:
       preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
       preset-venafi-tpp-credentials: "true"
-      preset-venafi-cloud-credentials: "true"
       preset-retry-flakey-tests: "true"
+      preset-k8s-v19-plus-env: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -371,9 +362,6 @@ presubmits:
         env:
         - name: K8S_VERSION
           value: "1.19"
-        # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
-        - name: FEATURE_GATES
-          value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
         securityContext:
           privileged: true
           capabilities:
@@ -419,8 +407,8 @@ presubmits:
       preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
       preset-venafi-tpp-credentials: "true"
-      preset-venafi-cloud-credentials: "true"
       preset-retry-flakey-tests: "true"
+      preset-k8s-v19-plus-env: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -434,9 +422,6 @@ presubmits:
         env:
         - name: K8S_VERSION
           value: "1.20"
-        # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
-        - name: FEATURE_GATES
-          value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
         securityContext:
           privileged: true
           capabilities:
@@ -482,8 +467,8 @@ presubmits:
       preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
       preset-venafi-tpp-credentials: "true"
-      preset-venafi-cloud-credentials: "true"
       preset-retry-flakey-tests: "true"
+      preset-k8s-v19-plus-env: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -497,9 +482,6 @@ presubmits:
         env:
         - name: K8S_VERSION
           value: "1.21"
-        # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
-        - name: FEATURE_GATES
-          value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
         securityContext:
           privileged: true
           capabilities:
@@ -546,8 +528,8 @@ presubmits:
       preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
       preset-venafi-tpp-credentials: "true"
-      preset-venafi-cloud-credentials: "true"
       preset-retry-flakey-tests: "true"
+      preset-k8s-v19-plus-env: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -561,9 +543,6 @@ presubmits:
         env:
         - name: K8S_VERSION
           value: "1.22"
-        # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
-        - name: FEATURE_GATES
-          value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
         securityContext:
           privileged: true
           capabilities:
@@ -603,7 +582,7 @@ presubmits:
     decorate: true
     branches: []
     annotations:
-      description: Runs the E2E tests labelled [Feature:Issuers:Venafi:TPP] against a Kubernetes v1.22 cluster
+      description: Runs the E2E tests with 'Venafi TPP' in name
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -611,14 +590,13 @@ presubmits:
       preset-bazel-scratch-dir: "true"
       preset-venafi-tpp-credentials: "true"
       preset-retry-flakey-tests: "true"
+      preset-ginkgo-focus-venafi-tpp: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
         args:
         - runner
         - devel/ci-run-e2e.sh
-        - -ginkgo.focus
-        - '\[Feature:Issuers:Venafi:TPP\]'
         resources:
           requests:
             cpu: 3500m
@@ -626,9 +604,6 @@ presubmits:
         env:
         - name: K8S_VERSION
           value: "1.22"
-        # Enable CertificateSigningRequest e2e tests for v1.19+ clusters
-        - name: FEATURE_GATES
-          value: "ExperimentalCertificateSigningRequestControllers=true"
         securityContext:
           privileged: true
           capabilities:
@@ -668,7 +643,7 @@ presubmits:
     decorate: true
     branches: []
     annotations:
-      description: Runs the E2E tests labelled [Feature:Issuers:Venafi:Cloud] against a Kubernetes v1.22 cluster
+      description: Runs the E2E tests with 'Venafi TPP' in name
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -676,6 +651,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
       preset-venafi-cloud-credentials: "true"
       preset-retry-flakey-tests: "true"
+      preset-ginkgo-focus-venafi-cloud: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -683,7 +659,6 @@ presubmits:
         - runner
         - devel/ci-run-e2e.sh
         - -ginkgo.focus
-        - '\[Feature:Issuers:Venafi:Cloud\]'
         resources:
           requests:
             cpu: 3500m
@@ -691,9 +666,6 @@ presubmits:
         env:
         - name: K8S_VERSION
           value: "1.22"
-        # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
-        - name: FEATURE_GATES
-          value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
         securityContext:
           privileged: true
           capabilities:

--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -168,7 +168,8 @@ presubmits:
       preset-cloudflare-credentials: "true"
       preset-venafi-tpp-credentials: "true"
       preset-retry-flakey-tests: "true"
-      preset-k8s-pre-v19-env: "true"
+      preset-disable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -228,7 +229,8 @@ presubmits:
       preset-cloudflare-credentials: "true"
       preset-venafi-tpp-credentials: "true"
       preset-retry-flakey-tests: "true"
-      preset-k8s-pre-v19-env: "true"
+      preset-disable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -288,7 +290,8 @@ presubmits:
       preset-cloudflare-credentials: "true"
       preset-venafi-tpp-credentials: "true"
       preset-retry-flakey-tests: "true"
-      preset-k8s-pre-v19-env: "true"
+      preset-disable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -348,7 +351,8 @@ presubmits:
       preset-cloudflare-credentials: "true"
       preset-venafi-tpp-credentials: "true"
       preset-retry-flakey-tests: "true"
-      preset-k8s-v19-plus-env: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -408,7 +412,8 @@ presubmits:
       preset-cloudflare-credentials: "true"
       preset-venafi-tpp-credentials: "true"
       preset-retry-flakey-tests: "true"
-      preset-k8s-v19-plus-env: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -468,7 +473,8 @@ presubmits:
       preset-cloudflare-credentials: "true"
       preset-venafi-tpp-credentials: "true"
       preset-retry-flakey-tests: "true"
-      preset-k8s-v19-plus-env: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -529,7 +535,8 @@ presubmits:
       preset-cloudflare-credentials: "true"
       preset-venafi-tpp-credentials: "true"
       preset-retry-flakey-tests: "true"
-      preset-k8s-v19-plus-env: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2

--- a/config/jobs/cert-manager/config.yaml
+++ b/config/jobs/cert-manager/config.yaml
@@ -81,25 +81,26 @@ presets:
         name: aws
         key: region
 
-# Specific cert-manager e2e test suites can be skipped here by setting
-# GINKGO_SKIP value.
 - labels:
-    preset-k8s-pre-v19-env: "true"
+    preset-disable-all-feature-gates: "true"
   env:
-  - name: GINKGO_SKIP
-    value: "Venafi Cloud"
   - name: FEATURE_GATES
     value: "ExperimentalCertificateSigningRequestControllers=false,ExperimentalGatewayAPISupport=false"
 
-# Specific cert-manager e2e test suites can be skipped here by setting
-# GINKGO_SKIP value.
 - labels:
-    preset-k8s-v19-plus-env: "true"
+    preset-enable-all-feature-gates: "true"
+  env:
+  - name: FEATURE_GATES
+    value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
+
+# Specific cert-manager e2e test suites can be skipped for all e2e tests here by setting
+# GINKGO_SKIP value
+# i.e 'Venafi Cloud|Gateway' will skip all Venafi Cloud and Gateway tests.
+- labels:
+    preset-ginkgo-skip-default: "true"
   env:
   - name: GINKGO_SKIP
     value: "Venafi Cloud"
-  - name: FEATURE_GATES
-    value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
 
 - labels:
     preset-ginkgo-focus-http01-ingress: "true"

--- a/config/jobs/cert-manager/config.yaml
+++ b/config/jobs/cert-manager/config.yaml
@@ -80,3 +80,43 @@ presets:
       secretKeyRef:
         name: aws
         key: region
+
+# Specific cert-manager e2e test suites can be skipped here by setting
+# GINKGO_SKIP value.
+- labels:
+    preset-k8s-pre-v19-env: "true"
+  env:
+  - name: GINKGO_SKIP
+    value: "Venafi Cloud"
+  - name: FEATURE_GATES
+    value: "ExperimentalCertificateSigningRequestControllers=false,ExperimentalGatewayAPISupport=false"
+
+# Specific cert-manager e2e test suites can be skipped here by setting
+# GINKGO_SKIP value.
+- labels:
+    preset-k8s-v19-plus-env: "true"
+  env:
+  - name: GINKGO_SKIP
+    value: "Venafi Cloud"
+  - name: FEATURE_GATES
+    value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
+
+- labels:
+    preset-ginkgo-focus-http01-ingress: "true"
+  env:
+  - name: GINKGO_SKIP
+    value: "Gateway"
+  - name: GINKGO_FOCUS
+    value: "Public ACME Server HTTP01 Issuer"
+
+- labels:
+    preset-ginkgo-focus-venafi-tpp: "true"
+  env:
+  - name: GINKGO_FOCUS
+    value: 'Venafi TPP'
+
+- labels:
+    preset-ginkgo-focus-venafi-cloud: "true"
+  env:
+  - name: GINKGO_FOCUS
+    value: 'Venafi Cloud'

--- a/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
+++ b/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
@@ -85,6 +85,7 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
     preset-venafi-cloud-credentials: "true"
+    preset-k8s-pre-v19-env: "true"
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-next
@@ -103,9 +104,6 @@ periodics:
       env:
       - name: K8S_VERSION
         value: "1.16"
-      # Disable CertificateSigningRequest e2e tests for pre v1.19 clusters
-      - name: FEATURE_GATES
-        value: "ExperimentalCertificateSigningRequestControllers=false"
       securityContext:
         privileged: true
         capabilities:
@@ -151,6 +149,7 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
     preset-venafi-cloud-credentials: "true"
+    preset-k8s-pre-v19-env: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -164,9 +163,6 @@ periodics:
       env:
       - name: K8S_VERSION
         value: "1.17"
-      # Disable CertificateSigningRequest e2e tests for pre v1.19 clusters
-      - name: FEATURE_GATES
-        value: "ExperimentalCertificateSigningRequestControllers=false"
       securityContext:
         privileged: true
         capabilities:
@@ -212,6 +208,7 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
     preset-venafi-cloud-credentials: "true"
+    preset-k8s-pre-v19-env: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -225,9 +222,6 @@ periodics:
       env:
       - name: K8S_VERSION
         value: "1.18"
-      # Disable CertificateSigningRequest e2e tests for pre v1.19 clusters
-      - name: FEATURE_GATES
-        value: "ExperimentalCertificateSigningRequestControllers=false"
       securityContext:
         privileged: true
         capabilities:
@@ -273,6 +267,7 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
     preset-venafi-cloud-credentials: "true"
+    preset-k8s-v19-plus-env: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -286,9 +281,6 @@ periodics:
       env:
       - name: K8S_VERSION
         value: "1.19"
-      # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
-      - name: FEATURE_GATES
-        value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
       securityContext:
         privileged: true
         capabilities:
@@ -334,6 +326,7 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
     preset-venafi-cloud-credentials: "true"
+    preset-k8s-v19-plus-env: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -347,9 +340,6 @@ periodics:
       env:
       - name: K8S_VERSION
         value: "1.20"
-      # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
-      - name: FEATURE_GATES
-        value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
       securityContext:
         privileged: true
         capabilities:
@@ -395,6 +385,7 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
     preset-venafi-cloud-credentials: "true"
+    preset-k8s-v19-plus-env: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -408,9 +399,6 @@ periodics:
       env:
       - name: K8S_VERSION
         value: "1.21"
-      # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
-      - name: FEATURE_GATES
-        value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
       securityContext:
         privileged: true
         capabilities:
@@ -456,6 +444,7 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
     preset-venafi-cloud-credentials: "true"
+    preset-k8s-v19-plus-env: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -469,9 +458,6 @@ periodics:
       env:
       - name: K8S_VERSION
         value: "1.22"
-      # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
-      - name: FEATURE_GATES
-        value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
       securityContext:
         privileged: true
         capabilities:

--- a/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
+++ b/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
@@ -85,7 +85,7 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
     preset-venafi-cloud-credentials: "true"
-    preset-k8s-pre-v19-env: "true"
+    preset-disable-all-feature-gates: "true"
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-next
@@ -149,7 +149,7 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
     preset-venafi-cloud-credentials: "true"
-    preset-k8s-pre-v19-env: "true"
+    preset-disable-all-feature-gates: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -208,7 +208,7 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
     preset-venafi-cloud-credentials: "true"
-    preset-k8s-pre-v19-env: "true"
+    preset-disable-all-feature-gates: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -267,7 +267,7 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
     preset-venafi-cloud-credentials: "true"
-    preset-k8s-v19-plus-env: "true"
+    preset-enable-all-feature-gates: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -326,7 +326,7 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
     preset-venafi-cloud-credentials: "true"
-    preset-k8s-v19-plus-env: "true"
+    preset-enable-all-feature-gates: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -385,7 +385,7 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
     preset-venafi-cloud-credentials: "true"
-    preset-k8s-v19-plus-env: "true"
+    preset-enable-all-feature-gates: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -444,7 +444,7 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
     preset-venafi-cloud-credentials: "true"
-    preset-k8s-v19-plus-env: "true"
+    preset-enable-all-feature-gates: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2

--- a/config/jobs/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
+++ b/config/jobs/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
@@ -85,7 +85,7 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
     preset-venafi-cloud-credentials: "true"
-    preset-k8s-pre-v19-env: "true"
+    preset-disable-all-feature-gates: "true"
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
@@ -149,7 +149,7 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
     preset-venafi-cloud-credentials: "true"
-    preset-k8s-pre-v19-env: "true"
+    preset-disable-all-feature-gates: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -208,7 +208,7 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
     preset-venafi-cloud-credentials: "true"
-    preset-k8s-pre-v19-env: "true"
+    preset-disable-all-feature-gates: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -267,7 +267,7 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
     preset-venafi-cloud-credentials: "true"
-    preset-k8s-v19-plus-env: "true"
+    preset-enable-all-feature-gates: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -326,7 +326,7 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
     preset-venafi-cloud-credentials: "true"
-    preset-k8s-v19-plus-env: "true"
+    preset-enable-all-feature-gates: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -385,7 +385,7 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
     preset-venafi-cloud-credentials: "true"
-    preset-k8s-v19-plus-env: "true"
+    preset-enable-all-feature-gates: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -444,7 +444,7 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
     preset-venafi-cloud-credentials: "true"
-    preset-k8s-v19-plus-env: "true"
+    preset-enable-all-feature-gates: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2

--- a/config/jobs/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
+++ b/config/jobs/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
@@ -85,6 +85,7 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
     preset-venafi-cloud-credentials: "true"
+    preset-k8s-pre-v19-env: "true"
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
@@ -103,9 +104,6 @@ periodics:
       env:
       - name: K8S_VERSION
         value: "1.16"
-      # Disable CertificateSigningRequest and Gateway API e2e tests for pre v1.19 clusters
-      - name: FEATURE_GATES
-        value: "ExperimentalCertificateSigningRequestControllers=false,ExperimentalGatewayAPISupport=false"
       securityContext:
         privileged: true
         capabilities:
@@ -151,6 +149,7 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
     preset-venafi-cloud-credentials: "true"
+    preset-k8s-pre-v19-env: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -164,9 +163,6 @@ periodics:
       env:
       - name: K8S_VERSION
         value: "1.17"
-      # Disable CertificateSigningRequest and Gateway API e2e tests for pre v1.19 clusters
-      - name: FEATURE_GATES
-        value: "ExperimentalCertificateSigningRequestControllers=false,ExperimentalGatewayAPISupport=false"
       securityContext:
         privileged: true
         capabilities:
@@ -212,6 +208,7 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
     preset-venafi-cloud-credentials: "true"
+    preset-k8s-pre-v19-env: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -225,9 +222,6 @@ periodics:
       env:
       - name: K8S_VERSION
         value: "1.18"
-      # Disable CertificateSigningRequest and Gateway API e2e tests for pre v1.19 clusters
-      - name: FEATURE_GATES
-        value: "ExperimentalCertificateSigningRequestControllers=false,ExperimentalGatewayAPISupport=false"
       securityContext:
         privileged: true
         capabilities:
@@ -273,6 +267,7 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
     preset-venafi-cloud-credentials: "true"
+    preset-k8s-v19-plus-env: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -286,9 +281,6 @@ periodics:
       env:
       - name: K8S_VERSION
         value: "1.19"
-      # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
-      - name: FEATURE_GATES
-        value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
       securityContext:
         privileged: true
         capabilities:
@@ -334,6 +326,7 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
     preset-venafi-cloud-credentials: "true"
+    preset-k8s-v19-plus-env: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -347,9 +340,6 @@ periodics:
       env:
       - name: K8S_VERSION
         value: "1.20"
-      # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
-      - name: FEATURE_GATES
-        value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
       securityContext:
         privileged: true
         capabilities:
@@ -395,6 +385,7 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
     preset-venafi-cloud-credentials: "true"
+    preset-k8s-v19-plus-env: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -408,9 +399,6 @@ periodics:
       env:
       - name: K8S_VERSION
         value: "1.21"
-      # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
-      - name: FEATURE_GATES
-        value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
       securityContext:
         privileged: true
         capabilities:
@@ -456,6 +444,7 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
     preset-venafi-cloud-credentials: "true"
+    preset-k8s-v19-plus-env: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -469,9 +458,6 @@ periodics:
       env:
       - name: K8S_VERSION
         value: "1.22"
-      # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
-      - name: FEATURE_GATES
-        value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
       securityContext:
         privileged: true
         capabilities:

--- a/config/jobs/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
+++ b/config/jobs/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
@@ -153,7 +153,7 @@ presubmits:
       preset-venafi-tpp-credentials: "true"
       preset-venafi-cloud-credentials: "true"
       preset-retry-flakey-tests: "true"
-      preset-k8s-pre-v19-env: "true"
+      preset-disable-all-feature-gates: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -211,7 +211,7 @@ presubmits:
       preset-venafi-tpp-credentials: "true"
       preset-venafi-cloud-credentials: "true"
       preset-retry-flakey-tests: "true"
-      preset-k8s-pre-v19-env: "true"
+      preset-disable-all-feature-gates: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -269,7 +269,7 @@ presubmits:
       preset-venafi-tpp-credentials: "true"
       preset-venafi-cloud-credentials: "true"
       preset-retry-flakey-tests: "true"
-      preset-k8s-pre-v19-env: "true"
+      preset-disable-all-feature-gates: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -327,7 +327,7 @@ presubmits:
       preset-venafi-tpp-credentials: "true"
       preset-venafi-cloud-credentials: "true"
       preset-retry-flakey-tests: "true"
-      preset-k8s-v19-plus-env: "true"
+      preset-enable-all-feature-gates: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -385,7 +385,7 @@ presubmits:
       preset-venafi-tpp-credentials: "true"
       preset-venafi-cloud-credentials: "true"
       preset-retry-flakey-tests: "true"
-      preset-k8s-v19-plus-env: "true"
+      preset-enable-all-feature-gates: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -443,7 +443,7 @@ presubmits:
       preset-venafi-tpp-credentials: "true"
       preset-venafi-cloud-credentials: "true"
       preset-retry-flakey-tests: "true"
-      preset-k8s-pre-v19-env: "true"
+      preset-disable-all-feature-gates: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -501,7 +501,7 @@ presubmits:
       preset-venafi-tpp-credentials: "true"
       preset-venafi-cloud-credentials: "true"
       preset-retry-flakey-tests: "true"
-      preset-k8s-v19-plus-env: "true"
+      preset-enable-all-feature-gates: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2

--- a/config/jobs/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
+++ b/config/jobs/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
@@ -153,6 +153,7 @@ presubmits:
       preset-venafi-tpp-credentials: "true"
       preset-venafi-cloud-credentials: "true"
       preset-retry-flakey-tests: "true"
+      preset-k8s-pre-v19-env: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -166,9 +167,6 @@ presubmits:
         env:
         - name: K8S_VERSION
           value: "1.16"
-        # Disable CertificateSigningRequest and Gateway API e2e tests for pre v1.19 clusters
-        - name: FEATURE_GATES
-          value: "ExperimentalCertificateSigningRequestControllers=false,ExperimentalGatewayAPISupport=false"
         securityContext:
           privileged: true
           capabilities:
@@ -213,6 +211,7 @@ presubmits:
       preset-venafi-tpp-credentials: "true"
       preset-venafi-cloud-credentials: "true"
       preset-retry-flakey-tests: "true"
+      preset-k8s-pre-v19-env: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -226,9 +225,6 @@ presubmits:
         env:
         - name: K8S_VERSION
           value: "1.17"
-        # Disable CertificateSigningRequest and Gateway API e2e tests for pre v1.19 clusters
-        - name: FEATURE_GATES
-          value: "ExperimentalCertificateSigningRequestControllers=false,ExperimentalGatewayAPISupport=false"
         securityContext:
           privileged: true
           capabilities:
@@ -273,6 +269,7 @@ presubmits:
       preset-venafi-tpp-credentials: "true"
       preset-venafi-cloud-credentials: "true"
       preset-retry-flakey-tests: "true"
+      preset-k8s-pre-v19-env: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -286,9 +283,6 @@ presubmits:
         env:
         - name: K8S_VERSION
           value: "1.18"
-        # Disable CertificateSigningRequest and Gateway API e2e tests for pre v1.19 clusters
-        - name: FEATURE_GATES
-          value: "ExperimentalCertificateSigningRequestControllers=false,ExperimentalGatewayAPISupport=false"
         securityContext:
           privileged: true
           capabilities:
@@ -312,6 +306,7 @@ presubmits:
         options:
         - name: ndots
           value: "1"
+
   - name: pull-cert-manager-e2e-v1-19
     context: pull-cert-manager-e2e-v1-19
     optional: true
@@ -332,6 +327,7 @@ presubmits:
       preset-venafi-tpp-credentials: "true"
       preset-venafi-cloud-credentials: "true"
       preset-retry-flakey-tests: "true"
+      preset-k8s-v19-plus-env: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -345,9 +341,6 @@ presubmits:
         env:
         - name: K8S_VERSION
           value: "1.19"
-        # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
-        - name: FEATURE_GATES
-          value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
         securityContext:
           privileged: true
           capabilities:
@@ -392,6 +385,7 @@ presubmits:
       preset-venafi-tpp-credentials: "true"
       preset-venafi-cloud-credentials: "true"
       preset-retry-flakey-tests: "true"
+      preset-k8s-v19-plus-env: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -405,9 +399,6 @@ presubmits:
         env:
         - name: K8S_VERSION
           value: "1.20"
-        # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
-        - name: FEATURE_GATES
-          value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
         securityContext:
           privileged: true
           capabilities:
@@ -452,6 +443,7 @@ presubmits:
       preset-venafi-tpp-credentials: "true"
       preset-venafi-cloud-credentials: "true"
       preset-retry-flakey-tests: "true"
+      preset-k8s-pre-v19-env: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -465,9 +457,6 @@ presubmits:
         env:
         - name: K8S_VERSION
           value: "1.21"
-        # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
-        - name: FEATURE_GATES
-          value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
         securityContext:
           privileged: true
           capabilities:
@@ -512,6 +501,7 @@ presubmits:
       preset-venafi-tpp-credentials: "true"
       preset-venafi-cloud-credentials: "true"
       preset-retry-flakey-tests: "true"
+      preset-k8s-v19-plus-env: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -525,9 +515,6 @@ presubmits:
         env:
         - name: K8S_VERSION
           value: "1.22"
-        # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
-        - name: FEATURE_GATES
-          value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
         securityContext:
           privileged: true
           capabilities:


### PR DESCRIPTION
This PR:

- defines new presets where env vars can be defined to be exported in tests

- all tests running against Kubernetes v1.19 and newer will have `FETURE_GATES` set to `ExperimentalCertificateSigningRequestControllers=true`

- all tests running against Kubernetes v1.18 and older will have `FEATURE_GATES` set to `ExperimentalCertificateSigningRequestControllers=false`

- hopefully fixes the [currently red aws tests](https://testgrid.k8s.io/jetstack-cert-manager-master#aws-tests) by ensuring the Gateway tests are skipped

- all tests will skip Venafi Cloud e2e tests and a new periodic is added that will run the Venafi Cloud e2e tests only every 24 hours.

Signed-off-by: irbekrm <irbekrm@gmail.com>