### PR TITLE
Bump releases

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -81,7 +81,7 @@ branch-protection:
             - pull-cert-manager-bazel
             - pull-cert-manager-deps
             - pull-cert-manager-chart
-            - pull-cert-manager-e2e-v1-21
+            - pull-cert-manager-e2e-v1-22
         cert-manager-csi:
           protect: true
           required_status_checks:

--- a/config/jobs/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager-periodics.yaml
@@ -435,7 +435,69 @@ periodics:
       - name: ndots
         value: "1"
 
-- name: ci-cert-manager-upgrade-v1-21
+- name: ci-cert-manager-e2e-v1-22
+  interval: 2h
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: jetstack
+    repo: cert-manager
+    base_ref: master
+  annotations:
+    testgrid-create-test-group: 'true'
+    testgrid-dashboards: jetstack-cert-manager-master
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    description: Runs the end-to-end test suite against a Kubernetes v1.22 cluster
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-cloudflare-credentials: "true"
+    preset-venafi-tpp-credentials: "true"
+    preset-venafi-cloud-credentials: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+      args:
+      - runner
+      - devel/ci-run-e2e.sh
+      resources:
+        requests:
+          cpu: 3500m
+          memory: 12Gi
+      env:
+      - name: K8S_VERSION
+        value: "1.22"
+      # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
+      - name: FEATURE_GATES
+        value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
+      securityContext:
+        privileged: true
+        capabilities:
+          add: ["SYS_ADMIN"]
+      volumeMounts:
+      - mountPath: /lib/modules
+        name: modules
+        readOnly: true
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    volumes:
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+
+
+- name: ci-cert-manager-upgrade
   interval: 8h
   agent: kubernetes
   decorate: true
@@ -468,7 +530,7 @@ periodics:
           memory: 12Gi
       env:
       - name: K8S_VERSION
-        value: "1.21"
+        value: "1.22"
       securityContext:
         privileged: true
         capabilities:

--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -463,8 +463,8 @@ presubmits:
 
   - name: pull-cert-manager-e2e-v1-21
     context: pull-cert-manager-e2e-v1-21
-    always_run: true
-    optional: false
+    always_run: false
+    optional: true
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -524,6 +524,70 @@ presubmits:
         - name: ndots
           value: "1"
 
+  - name: pull-cert-manager-e2e-v1-22
+    context: pull-cert-manager-e2e-v1-22
+    # This is the default e2e test ran for all PRs to master.
+    always_run: true
+    optional: false
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    branches:
+    - master
+    - release-1.6
+    annotations:
+      testgrid-create-test-group: 'true'
+      testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
+      description: Runs the end-to-end test suite against a Kubernetes v1.22 cluster
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-cloudflare-credentials: "true"
+      preset-venafi-tpp-credentials: "true"
+      preset-venafi-cloud-credentials: "true"
+      preset-retry-flakey-tests: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+        args:
+        - runner
+        - devel/ci-run-e2e.sh
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        env:
+        - name: K8S_VERSION
+          value: "1.22"
+        # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
+        - name: FEATURE_GATES
+          value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+
   # An E2E test job to allow us to manually trigger the Venafi TPP E2E tests
   # with the following GitHub comment:
   #
@@ -531,7 +595,7 @@ presubmits:
   #
   # See https://github.com/jetstack/cert-manager/issues/3555
   #
-  - name: pull-cert-manager-e2e-v1-21-feature-issuers-venafi-tpp
+  - name: pull-cert-manager-e2e-v1-22-feature-issuers-venafi-tpp
     always_run: false
     optional: true
     max_concurrency: 4
@@ -539,7 +603,7 @@ presubmits:
     decorate: true
     branches: []
     annotations:
-      description: Runs the E2E tests labelled [Feature:Issuers:Venafi:TPP] against a Kubernetes v1.21 cluster
+      description: Runs the E2E tests labelled [Feature:Issuers:Venafi:TPP] against a Kubernetes v1.22 cluster
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -561,7 +625,7 @@ presubmits:
             memory: 12Gi
         env:
         - name: K8S_VERSION
-          value: "1.21"
+          value: "1.22"
         # Enable CertificateSigningRequest e2e tests for v1.19+ clusters
         - name: FEATURE_GATES
           value: "ExperimentalCertificateSigningRequestControllers=true"
@@ -604,7 +668,7 @@ presubmits:
     decorate: true
     branches: []
     annotations:
-      description: Runs the E2E tests labelled [Feature:Issuers:Venafi:Cloud] against a Kubernetes v1.21 cluster
+      description: Runs the E2E tests labelled [Feature:Issuers:Venafi:Cloud] against a Kubernetes v1.22 cluster
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -626,7 +690,7 @@ presubmits:
             memory: 12Gi
         env:
         - name: K8S_VERSION
-          value: "1.21"
+          value: "1.22"
         # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
         - name: FEATURE_GATES
           value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
@@ -656,7 +720,7 @@ presubmits:
 
   # Verifies upgrade from the latest published release with both Helm chart and
   # static manifests. This is an optional test.
-  - name: pull-cert-manager-upgrade-v1-21
+  - name: pull-cert-manager-upgrade
     # Run only when requested.
     always_run: false
     optional: true
@@ -689,70 +753,7 @@ presubmits:
         env:
         # Used by https://github.com/jetstack/cert-manager/blob/master/devel/cluster/create-kind.sh
         - name: K8S_VERSION
-          value: "1.21"
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-
-  - name: pull-cert-manager-e2e-v1-22
-    context: pull-cert-manager-e2e-v1-22
-    always_run: false
-    optional: true
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    branches:
-    - master
-    - release-1.6
-    annotations:
-      testgrid-create-test-group: 'true'
-      testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
-      description: Runs the end-to-end test suite against a Kubernetes v1.22 cluster
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-cloudflare-credentials: "true"
-      preset-venafi-tpp-credentials: "true"
-      preset-venafi-cloud-credentials: "true"
-      preset-retry-flakey-tests: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
-        args:
-        - runner
-        - devel/ci-run-e2e.sh
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        env:
-        - name: K8S_VERSION
           value: "1.22"
-        # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
-        - name: FEATURE_GATES
-          value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
         securityContext:
           privileged: true
           capabilities:

--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.5
+    - release-1.6
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
@@ -45,7 +45,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.5
+    - release-1.6
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
@@ -83,7 +83,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.5
+    - release-1.6
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
@@ -120,7 +120,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.5
+    - release-1.6
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
@@ -155,7 +155,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.5
+    - release-1.6
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
@@ -218,7 +218,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.5
+    - release-1.6
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
@@ -281,7 +281,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.5
+    - release-1.6
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
@@ -344,7 +344,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.5
+    - release-1.6
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
@@ -407,7 +407,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.5
+    - release-1.6
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
@@ -470,7 +470,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.5
+    - release-1.6
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
@@ -723,7 +723,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.5
+    - release-1.6
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking

--- a/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
+++ b/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
@@ -434,3 +434,64 @@ periodics:
       options:
       - name: ndots
         value: "1"
+
+- name: ci-cert-manager-next-e2e-v1-22
+  interval: 2h
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: jetstack
+    repo: cert-manager
+    base_ref: release-1.6
+  annotations:
+    testgrid-create-test-group: 'true'
+    testgrid-dashboards: jetstack-cert-manager-next
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    description: Runs the end-to-end test suite against a Kubernetes v1.22 cluster
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-cloudflare-credentials: "true"
+    preset-venafi-tpp-credentials: "true"
+    preset-venafi-cloud-credentials: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+      args:
+      - runner
+      - devel/ci-run-e2e.sh
+      resources:
+        requests:
+          cpu: 3500m
+          memory: 12Gi
+      env:
+      - name: K8S_VERSION
+        value: "1.22"
+      # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
+      - name: FEATURE_GATES
+        value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
+      securityContext:
+        privileged: true
+        capabilities:
+          add: ["SYS_ADMIN"]
+      volumeMounts:
+      - mountPath: /lib/modules
+        name: modules
+        readOnly: true
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    volumes:
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"

--- a/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
+++ b/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.5
+    base_ref: release-1.6
   labels:
     preset-service-account: "true"
     preset-bazel-remote-cache-enabled: "true"
@@ -42,7 +42,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.5
+    base_ref: release-1.6
   labels:
     preset-service-account: "true"
     preset-bazel-scratch-dir: "true"
@@ -76,7 +76,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.5
+    base_ref: release-1.6
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
@@ -137,7 +137,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.5
+    base_ref: release-1.6
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-next
@@ -198,7 +198,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.5
+    base_ref: release-1.6
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-next
@@ -259,7 +259,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.5
+    base_ref: release-1.6
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-next
@@ -320,7 +320,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.5
+    base_ref: release-1.6
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-next
@@ -381,7 +381,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.5
+    base_ref: release-1.6
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-next

--- a/config/jobs/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
+++ b/config/jobs/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.4
+    base_ref: release-1.5
   labels:
     preset-service-account: "true"
     preset-bazel-remote-cache-enabled: "true"
@@ -42,7 +42,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.4
+    base_ref: release-1.5
   labels:
     preset-service-account: "true"
     preset-bazel-scratch-dir: "true"
@@ -76,7 +76,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.4
+    base_ref: release-1.5
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
@@ -137,7 +137,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.4
+    base_ref: release-1.5
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
@@ -198,7 +198,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.4
+    base_ref: release-1.5
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
@@ -259,7 +259,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.4
+    base_ref: release-1.5
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
@@ -320,7 +320,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.4
+    base_ref: release-1.5
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
@@ -381,7 +381,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.4
+    base_ref: release-1.5
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous

--- a/config/jobs/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
+++ b/config/jobs/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
@@ -8,7 +8,7 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
-    - release-1.4
+    - release-1.5
     annotations:
       testgrid-create-test-group: 'false'
     labels:
@@ -41,7 +41,7 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
-    - release-1.4
+    - release-1.5
     annotations:
       testgrid-create-test-group: 'false'
     labels:
@@ -76,7 +76,7 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
-    - release-1.4
+    - release-1.5
     annotations:
       testgrid-create-test-group: 'false'
     labels:
@@ -110,7 +110,7 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
-    - release-1.4
+    - release-1.5
     annotations:
       testgrid-create-test-group: 'false'
     labels:
@@ -141,7 +141,7 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
-    - release-1.4
+    - release-1.5
     annotations:
       testgrid-create-test-group: 'false'
     labels:
@@ -201,7 +201,7 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
-    - release-1.4
+    - release-1.5
     annotations:
       testgrid-create-test-group: 'false'
     labels:
@@ -261,7 +261,7 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
-    - release-1.4
+    - release-1.5
     annotations:
       testgrid-create-test-group: 'false'
     labels:
@@ -321,7 +321,7 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
-    - release-1.4
+    - release-1.5
     annotations:
       testgrid-create-test-group: 'false'
     labels:
@@ -381,7 +381,7 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
-    - release-1.4
+    - release-1.5
     annotations:
       testgrid-create-test-group: 'false'
     labels:

--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -98,7 +98,8 @@ repo_milestone:
 
 milestone_applier:
   jetstack/cert-manager:
-    master: v1.5
+    master: v1.6
+    release-1.5: v1.5
     release-1.4: v1.4
     release-1.3: v1.3
     release-1.2: v1.2
@@ -116,9 +117,10 @@ milestone_applier:
   cert-manager/website:
     # cert-manager/website uses master branch for 'current' version and the
     # release-next branch for the 'next' version
-    release-next: v1.5
-    master: v1.4
+    release-next: v1.6
+    master: v1.5
     # Older versions are archived into named release branches
+    release-1.4: v1.4
     release-1.3: v1.3
     release-1.2: v1.2
     release-1.1: v1.1


### PR DESCRIPTION
This PR:

- bumps cert-manager release tags as we just released v1.5
- run presubmits against Kubernetes v1.22 by default (before it was v1.21)
- adds a periodic for release next to run tests on Kubernetes v1.22

Signed-off-by: irbekrm <irbekrm@gmail.com>