### PR TITLE
fixing path in aws periodic job

### DIFF
--- a/config/jobs/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager-periodics.yaml
@@ -497,6 +497,10 @@ periodics:
   interval: 48h
   agent: kubernetes
   decorate: true
+  extra_refs:            # Periodic job doesn't clone any repo by default, needs to be added explicitly
+    - org: cert-manager
+      repo: test-infra
+      base_ref: master
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-master
@@ -516,19 +520,20 @@ periodics:
       - -c
       - |
         set -euo && \
-        git clone https://github.com/jetstack/cert-manager.git && \
-        git clone https://github.com/cert-manager/test-infra.git && \
-        cd test-infra/aws && \
+        ls && \
+        pwd && \
+        cd /home/prow/go/src/github.com/jetstack/cert-manager/test-infra/aws && \
         terraform init && \
         trap 'terraform destroy -auto-approve' ERR && \
         terraform apply -auto-approve && \
         ls && \
         pwd && \
-        cd .. && \
-        cd .. && \
+        cd /home && \
+        ls && \
+        git clone https://github.com/jetstack/cert-manager.git && \
         cd cert-manager && \
-        ./devel/run-e2e.sh --ginkgo.focus "Public ACME Server HTTP01 Issuer" --acme-server-url=https://acme-staging-v02.api.letsencrypt.org/directory --ingress-controller-domain=aws.e2e-tests.cert-manager.io --testing-acme-email=cert-manager-dev-alerts@googlegroups.com --kubernetes-config=/go/test-infra/aws/kubeconfig_cert-manager-cluster || true && \
-        cd /go/test-infra/aws && \
+        ./devel/run-e2e.sh --ginkgo.focus "Public ACME Server HTTP01 Issuer" --acme-server-url=https://acme-staging-v02.api.letsencrypt.org/directory --ingress-controller-domain=aws.e2e-tests.cert-manager.io --testing-acme-email=cert-manager-dev-alerts@googlegroups.com --kubernetes-config=/home/prow/go/src/github.com/jetstack/cert-manager/test-infra/aws/kubeconfig_cert-manager-cluster || true && \
+        cd /home/prow/go/src/github.com/jetstack/cert-manager/test-infra/aws && \
         terraform destroy -auto-approve;
       resources:
         requests:

--- a/config/jobs/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager-periodics.yaml
@@ -527,8 +527,8 @@ periodics:
         cd .. && \
         cd .. && \
         cd cert-manager && \
-        ./devel/run-e2e.sh --ginkgo.focus "Public ACME Server HTTP01 Issuer" --acme-server-url=https://acme-staging-v02.api.letsencrypt.org/directory --ingress-controller-domain=aws.e2e-tests.cert-manager.io --testing-acme-email=cert-manager-dev-alerts@googlegroups.com --kubernetes-config=/home/prow/go/src/github.com/jetstack/cert-manager/test-infra/aws/kubeconfig_cert-manager-cluster || true && \
-        cd /home/prow/go/src/github.com/jetstack/cert-manager/test-infra/aws && \
+        ./devel/run-e2e.sh --ginkgo.focus "Public ACME Server HTTP01 Issuer" --acme-server-url=https://acme-staging-v02.api.letsencrypt.org/directory --ingress-controller-domain=aws.e2e-tests.cert-manager.io --testing-acme-email=cert-manager-dev-alerts@googlegroups.com --kubernetes-config=/go/test-infra/aws/kubeconfig_cert-manager-cluster || true && \
+        cd /go/test-infra/aws && \
         terraform destroy -auto-approve;
       resources:
         requests:

--- a/config/jobs/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager-periodics.yaml
@@ -501,6 +501,9 @@ periodics:
     - org: cert-manager
       repo: test-infra
       base_ref: master
+    - org: jetstack
+      repo: cert-manager
+      base_ref: master
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-master
@@ -522,7 +525,7 @@ periodics:
         set -euo && \
         ls && \
         pwd && \
-        cd /home/prow/go/src/github.com/jetstack/cert-manager/test-infra/aws && \
+        cd /home/prow/go/src/github.com/cert-manager/test-infra/aws && \
         terraform init && \
         trap 'terraform destroy -auto-approve' ERR && \
         terraform apply -auto-approve && \
@@ -530,10 +533,9 @@ periodics:
         pwd && \
         cd /home && \
         ls && \
-        git clone https://github.com/jetstack/cert-manager.git && \
-        cd cert-manager && \
-        ./devel/run-e2e.sh --ginkgo.focus "Public ACME Server HTTP01 Issuer" --acme-server-url=https://acme-staging-v02.api.letsencrypt.org/directory --ingress-controller-domain=aws.e2e-tests.cert-manager.io --testing-acme-email=cert-manager-dev-alerts@googlegroups.com --kubernetes-config=/home/prow/go/src/github.com/jetstack/cert-manager/test-infra/aws/kubeconfig_cert-manager-cluster || true && \
-        cd /home/prow/go/src/github.com/jetstack/cert-manager/test-infra/aws && \
+        cd /home/prow/go/src/github.com/jetstack/cert-manager && \
+        ./devel/run-e2e.sh --ginkgo.focus "Public ACME Server HTTP01 Issuer" --acme-server-url=https://acme-staging-v02.api.letsencrypt.org/directory --ingress-controller-domain=aws.e2e-tests.cert-manager.io --testing-acme-email=cert-manager-dev-alerts@googlegroups.com --kubernetes-config=/home/prow/go/src/github.com/cert-manager/test-infra/aws/kubeconfig_cert-manager-cluster || true && \
+        cd /home/prow/go/src/github.com/cert-manager/test-infra/aws && \
         terraform destroy -auto-approve;
       resources:
         requests:

--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -786,9 +786,6 @@ presubmits:
     - org: cert-manager
       repo: test-infra
       base_ref: master
-    - org: jetstack
-      repo: cert-manager
-      base_ref: master
     branches:
     - master
     annotations:

--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -782,6 +782,10 @@ presubmits:
     optional: true
     agent: kubernetes
     decorate: true
+    extra_refs:            # Periodic job doesn't clone any repo by default, needs to be added explicitly
+    - org: cert-manager
+      repo: test-infra
+      base_ref: master
     branches:
     - master
     annotations:
@@ -803,16 +807,17 @@ presubmits:
         - -c
         - |
           set -euo && \
-          git clone https://github.com/jetstack/cert-manager.git && \
-          git clone https://github.com/cert-manager/test-infra.git && \
-          cd test-infra/aws && \
+          ls && \
+          pwd && \
+          cd /home/prow/go/src/github.com/jetstack/cert-manager/test-infra/aws && \
           terraform init && \
           trap 'terraform destroy -auto-approve' ERR && \
           terraform apply -auto-approve && \
           ls && \
           pwd && \
-          cd .. && \
-          cd .. && \
+          cd /home && \
+          ls && \
+          git clone https://github.com/jetstack/cert-manager.git && \
           cd cert-manager && \
           ./devel/run-e2e.sh --ginkgo.focus "Public ACME Server HTTP01 Issuer" --acme-server-url=https://acme-staging-v02.api.letsencrypt.org/directory --ingress-controller-domain=aws.e2e-tests.cert-manager.io --testing-acme-email=cert-manager-dev-alerts@googlegroups.com --kubernetes-config=/home/prow/go/src/github.com/jetstack/cert-manager/test-infra/aws/kubeconfig_cert-manager-cluster || true && \
           cd /home/prow/go/src/github.com/jetstack/cert-manager/test-infra/aws && \

--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -786,6 +786,9 @@ presubmits:
     - org: cert-manager
       repo: test-infra
       base_ref: master
+    - org: jetstack
+      repo: cert-manager
+      base_ref: master
     branches:
     - master
     annotations:
@@ -809,7 +812,7 @@ presubmits:
           set -euo && \
           ls && \
           pwd && \
-          cd /home/prow/go/src/github.com/jetstack/cert-manager/test-infra/aws && \
+          cd /home/prow/go/src/github.com/cert-manager/test-infra/aws && \
           terraform init && \
           trap 'terraform destroy -auto-approve' ERR && \
           terraform apply -auto-approve && \
@@ -817,10 +820,9 @@ presubmits:
           pwd && \
           cd /home && \
           ls && \
-          git clone https://github.com/jetstack/cert-manager.git && \
-          cd cert-manager && \
-          ./devel/run-e2e.sh --ginkgo.focus "Public ACME Server HTTP01 Issuer" --acme-server-url=https://acme-staging-v02.api.letsencrypt.org/directory --ingress-controller-domain=aws.e2e-tests.cert-manager.io --testing-acme-email=cert-manager-dev-alerts@googlegroups.com --kubernetes-config=/home/prow/go/src/github.com/jetstack/cert-manager/test-infra/aws/kubeconfig_cert-manager-cluster || true && \
-          cd /home/prow/go/src/github.com/jetstack/cert-manager/test-infra/aws && \
+          cd /home/prow/go/src/github.com/jetstack/cert-manager && \
+          ./devel/run-e2e.sh --ginkgo.focus "Public ACME Server HTTP01 Issuer" --acme-server-url=https://acme-staging-v02.api.letsencrypt.org/directory --ingress-controller-domain=aws.e2e-tests.cert-manager.io --testing-acme-email=cert-manager-dev-alerts@googlegroups.com --kubernetes-config=/home/prow/go/src/github.com/cert-manager/test-infra/aws/kubeconfig_cert-manager-cluster || true && \
+          cd /home/prow/go/src/github.com/cert-manager/test-infra/aws && \
           terraform destroy -auto-approve;
         resources:
           requests:


### PR DESCRIPTION
Signed-off-by: RinkiyaKeDad <arshsharma461@gmail.com>

The periodic job apparently has a different path from the presubmit one.

Periodic job:
![image](https://user-images.githubusercontent.com/56963264/129197312-56c7f65c-33f4-43c9-948c-5ee2da7fa4ee.png)


Presubmit job:
![image](https://user-images.githubusercontent.com/56963264/129197356-5805f6fb-4eda-49bd-aa95-dfabd539a8e3.png)


/release-note-none