### PR TITLE
Enable Gateway API features in release-previous

### DIFF
--- a/config/jobs/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
+++ b/config/jobs/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
@@ -103,9 +103,9 @@ periodics:
       env:
       - name: K8S_VERSION
         value: "1.16"
-      # Disable CertificateSigningRequest e2e tests for pre v1.19 clusters
+      # Disable CertificateSigningRequest and Gateway API e2e tests for pre v1.19 clusters
       - name: FEATURE_GATES
-        value: "ExperimentalCertificateSigningRequestControllers=false"
+        value: "ExperimentalCertificateSigningRequestControllers=false,ExperimentalGatewayAPISupport=false"
       securityContext:
         privileged: true
         capabilities:
@@ -164,9 +164,9 @@ periodics:
       env:
       - name: K8S_VERSION
         value: "1.17"
-      # Disable CertificateSigningRequest e2e tests for pre v1.19 clusters
+      # Disable CertificateSigningRequest and Gateway API e2e tests for pre v1.19 clusters
       - name: FEATURE_GATES
-        value: "ExperimentalCertificateSigningRequestControllers=false"
+        value: "ExperimentalCertificateSigningRequestControllers=false,ExperimentalGatewayAPISupport=false"
       securityContext:
         privileged: true
         capabilities:
@@ -225,9 +225,9 @@ periodics:
       env:
       - name: K8S_VERSION
         value: "1.18"
-      # Disable CertificateSigningRequest e2e tests for pre v1.19 clusters
+      # Disable CertificateSigningRequest and Gateway API e2e tests for pre v1.19 clusters
       - name: FEATURE_GATES
-        value: "ExperimentalCertificateSigningRequestControllers=false"
+        value: "ExperimentalCertificateSigningRequestControllers=false,ExperimentalGatewayAPISupport=false"
       securityContext:
         privileged: true
         capabilities:
@@ -286,9 +286,9 @@ periodics:
       env:
       - name: K8S_VERSION
         value: "1.19"
-      # Enable CertificateSigningRequest e2e tests for v1.19+ clusters
+      # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
       - name: FEATURE_GATES
-        value: "ExperimentalCertificateSigningRequestControllers=true"
+        value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
       securityContext:
         privileged: true
         capabilities:
@@ -347,9 +347,9 @@ periodics:
       env:
       - name: K8S_VERSION
         value: "1.20"
-      # Enable CertificateSigningRequest e2e tests for v1.19+ clusters
+      # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
       - name: FEATURE_GATES
-        value: "ExperimentalCertificateSigningRequestControllers=true"
+        value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
       securityContext:
         privileged: true
         capabilities:
@@ -408,9 +408,9 @@ periodics:
       env:
       - name: K8S_VERSION
         value: "1.21"
-      # Enable CertificateSigningRequest e2e tests for v1.19+ clusters
+      # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
       - name: FEATURE_GATES
-        value: "ExperimentalCertificateSigningRequestControllers=true"
+        value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
       securityContext:
         privileged: true
         capabilities:
@@ -469,9 +469,9 @@ periodics:
       env:
       - name: K8S_VERSION
         value: "1.22"
-      # Enable CertificateSigningRequest e2e tests for v1.19+ clusters
+      # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
       - name: FEATURE_GATES
-        value: "ExperimentalCertificateSigningRequestControllers=true"
+        value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
       securityContext:
         privileged: true
         capabilities:

--- a/config/jobs/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
+++ b/config/jobs/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
@@ -253,6 +253,65 @@ presubmits:
         - name: ndots
           value: "1"
 
+  - name: pull-cert-manager-e2e-v1-18
+    context: pull-cert-manager-e2e-v1-18
+    always_run: false
+    optional: true
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    branches:
+    - release-1.5
+    annotations:
+      testgrid-create-test-group: 'false'
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-cloudflare-credentials: "true"
+      preset-venafi-tpp-credentials: "true"
+      preset-venafi-cloud-credentials: "true"
+      preset-retry-flakey-tests: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+        args:
+        - runner
+        - devel/ci-run-e2e.sh
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        env:
+        - name: K8S_VERSION
+          value: "1.18"
+        # Disable CertificateSigningRequest and Gateway API e2e tests for pre v1.19 clusters
+        - name: FEATURE_GATES
+          value: "ExperimentalCertificateSigningRequestControllers=false,ExperimentalGatewayAPISupport=false"
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
   - name: pull-cert-manager-e2e-v1-19
     context: pull-cert-manager-e2e-v1-19
     optional: true

--- a/config/jobs/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
+++ b/config/jobs/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
@@ -166,9 +166,9 @@ presubmits:
         env:
         - name: K8S_VERSION
           value: "1.16"
-        # Disable CertificateSigningRequest e2e tests for pre v1.19 clusters
+        # Disable CertificateSigningRequest and Gateway API e2e tests for pre v1.19 clusters
         - name: FEATURE_GATES
-          value: "ExperimentalCertificateSigningRequestControllers=false"
+          value: "ExperimentalCertificateSigningRequestControllers=false,ExperimentalGatewayAPISupport=false"
         securityContext:
           privileged: true
           capabilities:
@@ -226,9 +226,9 @@ presubmits:
         env:
         - name: K8S_VERSION
           value: "1.17"
-        # Disable CertificateSigningRequest e2e tests for pre v1.19 clusters
+        # Disable CertificateSigningRequest and Gateway API e2e tests for pre v1.19 clusters
         - name: FEATURE_GATES
-          value: "ExperimentalCertificateSigningRequestControllers=false"
+          value: "ExperimentalCertificateSigningRequestControllers=false,ExperimentalGatewayAPISupport=false"
         securityContext:
           privileged: true
           capabilities:
@@ -286,9 +286,9 @@ presubmits:
         env:
         - name: K8S_VERSION
           value: "1.19"
-        # Enable CertificateSigningRequest e2e tests for v1.19+ clusters
+        # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
         - name: FEATURE_GATES
-          value: "ExperimentalCertificateSigningRequestControllers=true"
+          value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
         securityContext:
           privileged: true
           capabilities:
@@ -346,9 +346,9 @@ presubmits:
         env:
         - name: K8S_VERSION
           value: "1.20"
-        # Enable CertificateSigningRequest e2e tests for v1.19+ clusters
+        # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
         - name: FEATURE_GATES
-          value: "ExperimentalCertificateSigningRequestControllers=true"
+          value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
         securityContext:
           privileged: true
           capabilities:
@@ -406,9 +406,9 @@ presubmits:
         env:
         - name: K8S_VERSION
           value: "1.21"
-        # Enable CertificateSigningRequest e2e tests for v1.19+ clusters
+        # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
         - name: FEATURE_GATES
-          value: "ExperimentalCertificateSigningRequestControllers=true"
+          value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
         securityContext:
           privileged: true
           capabilities:
@@ -466,9 +466,9 @@ presubmits:
         env:
         - name: K8S_VERSION
           value: "1.22"
-        # Enable CertificateSigningRequest e2e tests for v1.19+ clusters
+        # Enable CertificateSigningRequest and Gateway API e2e tests for v1.19+ clusters
         - name: FEATURE_GATES
-          value: "ExperimentalCertificateSigningRequestControllers=true"
+          value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
         securityContext:
           privileged: true
           capabilities:


### PR DESCRIPTION
* Enable Gateway API features in K8S >=1.19
* Explicitly disable it in K8S <1.19, so that if the feature graduates and is turned on by default, it doesn't start failing on old unsupported cluster versions
* Added a missing 1.18 job to the release-previous pre-submits.


This will fix the E2E failures on K8S >=1.19 seen here: https://testgrid.k8s.io/jetstack-cert-manager-previous

```release-note
Enable Gateway API features in release-previous
```