### PR TITLE
Adds go 1.17 variants for all Go images

### DIFF
--- a/images/golang-aws/build.yaml
+++ b/images/golang-aws/build.yaml
@@ -24,6 +24,12 @@ variants:
       TERRAFORM_VERSION: "1.0.3"
       BAZEL_VERSION: "4.0.0"
       GO_VERSION: "1.16.6"
+  "1.17":
+    arguments:
+      BASE_IMAGE: "golang:1.17-buster"
+      TERRAFORM_VERSION: "1.0.3"
+      BAZEL_VERSION: "4.0.0"
+      GO_VERSION: "1.17"
 
 
 # Image names to be tagged and pushed

--- a/images/golang-dind/build.yaml
+++ b/images/golang-dind/build.yaml
@@ -1,6 +1,10 @@
 name: golang-dind # Name of the image to be built
 
 variants:
+  "1.17":
+  arguments:
+      BASE_IMAGE: "eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210331-363c37a-3.5.0"
+      GO_VERSION: "1.17"
   "1.16.6":
     arguments:
       BASE_IMAGE: "eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210331-363c37a-3.5.0"

--- a/images/golang-nodejs/build.yaml
+++ b/images/golang-nodejs/build.yaml
@@ -1,6 +1,10 @@
 name: golang-nodejs # Name of the image to be built
 
 variants:
+  "1.17":
+  arguments:
+      BASE_IMAGE: "node:16.3.0"
+      GO_VERSION: "1.17"
   "1.16.6":
     arguments:
       BASE_IMAGE: "node:16.3.0"


### PR DESCRIPTION
Go 1.17 [has been released](https://golang.org/doc/go1.17) - this PR will result in building Go images with 1.17 and those can then be used to build some of our projects with Go 1.17

/kind cleanup

Signed-off-by: irbekrm <irbekrm@gmail.com>