### PR TITLE
cert-manager release: use make rather than calling a script directly

### DIFF
--- a/config/jobs/cert-manager/release/cert-manager-release-presubmits.yaml
+++ b/config/jobs/cert-manager/release/cert-manager-release-presubmits.yaml
@@ -17,7 +17,7 @@ presubmits:
       - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20210331-a8721c1-1.16
         args:
         - runner
-        - ./test/presubmit.sh
+        - make presubmit
         resources:
           requests:
             # 3500m was chosen because that allows us to fit two jobs onto one


### PR DESCRIPTION
This is possible now that https://github.com/cert-manager/release/pull/41 has been merged; it allows us to have the makefile as a one-stop-shop for all commands we might need when interacting with the project