### PR TITLE
Moves jetstack/cert-manager-csi to cert-manager/csi-driver for new repo

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -75,14 +75,6 @@ branch-protection:
             - pull-cert-manager-deps
             - pull-cert-manager-chart
             - pull-cert-manager-e2e-v1-22
-        cert-manager-csi:
-          protect: true
-          required_status_checks:
-            contexts:
-            - dco
-            - pull-cert-manager-csi-verify
-            - pull-cert-manager-csi-e2e-v1-16
-
 sinker:
   resync_period: 1h
   max_prowjob_age: 48h
@@ -259,7 +251,6 @@ tide:
   # Repositories that enable the release-notes plugin (except cert-manager)
   - repos:
     - jetstack/tarmak
-    - jetstack/cert-manager-csi
     - jetstack/kube-oidc-proxy
     - jetstack/version-checker
     - jetstack/testing

--- a/config/jobs/cert-manager/csi-driver/OWNERS
+++ b/config/jobs/cert-manager/csi-driver/OWNERS
@@ -2,5 +2,3 @@ approvers:
 - joshvanl
 reviewers:
 - joshvanl
-labels:
-- area/cert-manager-csi

--- a/config/jobs/cert-manager/csi-driver/cert-manager-csi-driver-presubmits.yaml
+++ b/config/jobs/cert-manager/csi-driver/cert-manager-csi-driver-presubmits.yaml
@@ -1,65 +1,40 @@
 presubmits:
-  jetstack/cert-manager-csi:
+  cert-manager/csi-driver:
 
-  - name: pull-cert-manager-csi-verify
-    always_run: true
-    context: pull-cert-manager-csi-verify
-    max_concurrency: 8
+  - name: pull-cert-manager-csi-driver-verify
+    context: pull-cert-manager-csi-driver-verify
     agent: kubernetes
     decorate: true
-    branches:
-    - ^master$
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
+    always_run: true
+    max_concurrency: 8
+    annotations:
+      testgrid-create-test-group: 'false'
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20210331-a8721c1-1.16
+      - image: golang:1.17
         args:
-        - runner
         - make
-        - all
+        - verify
         resources:
           requests:
-            cpu: 2
-            memory: 4Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
+            cpu: 1
+            memory: 1Gi
 
-  # kind based cert-manager-csi e2e job for Kubernetes v1.16, cert-manager v1.12
-  - name: pull-cert-manager-csi-e2e-v1-16
-    context: pull-cert-manager-csi-e2e-v1-16
+  - name: pull-cert-manager-csi-driver-e2e-v1-16
+    context: pull-cert-manager-csi-driver-e2e-v1-16
     # Match everything except PRs that only touch docs/
     always_run: true
     optional: false
     max_concurrency: 8
     agent: kubernetes
     decorate: true
-    branches:
-    - ^master$
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
+      preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20210331-a8721c1-1.16
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20210907-aa51283-1.17
         args:
         - runner
         - make
@@ -70,9 +45,9 @@ presubmits:
             memory: 12Gi
         env:
         - name: CERT_MANAGER_CSI_K8S_VERSION
-          value: "1.20.2"
+          value: "1.22.2"
         - name: CERT_MANAGER_CSI_CERT_MANAGER_VERSION
-          value: "1.3.1"
+          value: "1.5.3"
         securityContext:
           privileged: true
           capabilities:

--- a/config/labels.yaml
+++ b/config/labels.yaml
@@ -83,34 +83,6 @@ repos:
       target: both
       addedBy: prow
 
-  jetstack/cert-manager-csi:
-    labels:
-    - color: 0052cc
-      description: Indicates a PR directly modifies the 'pkg/apis' directory
-      name: area/api
-      target: both
-      addedBy: prow
-    - color: 0052cc
-      description: Indicates a PR modifies deployment configuration
-      name: area/deploy
-      target: both
-      addedBy: prow
-    - color: 0052cc
-      description: Indicates a PR modifies CSI driver code
-      name: area/driver
-      target: both
-      addedBy: prow
-    - color: 0052cc
-      description: Indicates a PR modifies cert-manager and renewal code
-      name: area/certificate
-      target: both
-      addedBy: prow
-    - color: 0052cc
-      description: Indicates a PR modifies e2e testing code
-      name: area/testing
-      target: both
-      addedBy: prow
-
   cert-manager/istio-csr:
     labels:
     - color: 0052cc
@@ -189,11 +161,6 @@ repos:
     - color: 0052cc
       description: Indicates a PR related to cert-manager
       name: area/cert-manager
-      target: both
-      addedBy: prow
-    - color: 0052cc
-      description: Indicates a PR related to cert-manager-csi
-      name: area/cert-manager-csi
       target: both
       addedBy: prow
     - color: 0052cc

--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -24,7 +24,6 @@ triggers:
 - repos:
   - jetstack/cert-manager
   - cert-manager/website
-  - jetstack/cert-manager-csi
   - cert-manager/istio-csr
   - cert-manager/trust
   only_org_members: true
@@ -60,10 +59,6 @@ repo_milestone:
     maintainers_id: 2805308
     maintainers_team: milestone-maintainers
   cert-manager/website:
-    # https://github.com/orgs/cert-manager/teams/milestone-maintainers
-    maintainers_id: 2805308
-    maintainers_team: milestone-maintainers
-  jetstack/cert-manager-csi:
     # https://github.com/orgs/cert-manager/teams/milestone-maintainers
     maintainers_id: 2805308
     maintainers_team: milestone-maintainers
@@ -114,8 +109,6 @@ milestone_applier:
     master: v0.2
     release-0.1: v0.1
     release-0.2: v0.2
-  jetstack/cert-manager-csi:
-    master: v0.1
   cert-manager/istio-csr:
     master: v0.0
   cert-manager/trust:
@@ -194,14 +187,6 @@ plugins:
     - yuks
 
   jetstack/cert-manager:
-    plugins:
-    - approve
-    - dco
-    - owners-label
-    - release-note
-    - verify-owners
-
-  jetstack/cert-manager-csi:
     plugins:
     - approve
     - dco

--- a/prow/cluster/labelsync_cronjob.yaml
+++ b/prow/cluster/labelsync_cronjob.yaml
@@ -33,7 +33,7 @@ spec:
               - --config=/etc/config/labels.yaml
               - --confirm=true
               # TODO: enable label_sync across the whole org
-              - --only=jetstack/cert-manager,jetstack/testing,jetstack/kube-oidc-proxy,jetstack/tarmak,jetstack/terraform-google-gke-cluster,cert-manager/release,cert-manager/webhook-example,cert-manager/website,jetstack/cert-manager-nginx-plus-lab,cert-manager/csi-lib,cert-manager/approver-policy
+              - --only=jetstack/cert-manager,jetstack/testing,jetstack/kube-oidc-proxy,jetstack/tarmak,jetstack/terraform-google-gke-cluster,cert-manager/release,cert-manager/webhook-example,cert-manager/website,jetstack/cert-manager-nginx-plus-lab,cert-manager/csi-lib,cert-manager/approver-policy,cert-manager/csi-driver
               - --token=/etc/github/oauth
               volumeMounts:
               - name: oauth


### PR DESCRIPTION
Signed-off-by: joshvanl <vleeuwenjoshua@gmail.com>

/assign @jakexks 

```release-note
NONE
```