### PR TITLE
Cleanup cert-manager-csi-driver e2e test names

### DIFF
--- a/config/jobs/cert-manager/csi-driver/cert-manager-csi-driver-presubmits.yaml
+++ b/config/jobs/cert-manager/csi-driver/cert-manager-csi-driver-presubmits.yaml
@@ -20,9 +20,8 @@ presubmits:
             cpu: 1
             memory: 1Gi
 
-  - name: pull-cert-manager-csi-driver-e2e-v1-16
-    context: pull-cert-manager-csi-driver-e2e-v1-16
-    # Match everything except PRs that only touch docs/
+  - name: pull-cert-manager-csi-driver-e2e
+    context: pull-cert-manager-csi-driver-e2e
     always_run: true
     optional: false
     max_concurrency: 8
@@ -43,11 +42,6 @@ presubmits:
           requests:
             cpu: 3500m
             memory: 12Gi
-        env:
-        - name: CERT_MANAGER_CSI_K8S_VERSION
-          value: "1.22.2"
-        - name: CERT_MANAGER_CSI_CERT_MANAGER_VERSION
-          value: "1.5.3"
         securityContext:
           privileged: true
           capabilities:


### PR DESCRIPTION
Signed-off-by: joshvanl <vleeuwenjoshua@gmail.com>

The environment variables weren't being used any more, so let's not confuse ourselves :slightly_smiling_face: 
/assign @jakexks 


```release-note
NONE
```