### PR TITLE
Reinstates periodic issue checkers

### DIFF
--- a/config/jobs/testing/testing-periodics.yaml
+++ b/config/jobs/testing/testing-periodics.yaml
@@ -10,9 +10,9 @@ periodics:
     description: Periodically comments /retest against approved and lgtm'd PRs that are failing
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/commenter:v20181130-0587c4793
+    - image: gcr.io/k8s-prow/commenter@sha256:dd5f3091c86f04dbca29f68de8cba21f6be4485281b0985aed4879450928001a
       args:
-      - /app/robots/commenter/commenter-image.binary
+      - /app/robots/commenter/app.binary
       - |-
         --query=is:pr
         -label:do-not-merge
@@ -57,9 +57,9 @@ periodics:
     description: Closes PRs and issues that are marked 'rotten' and have been inactive for 30d
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/commenter:v20181130-0587c4793
+    - image: gcr.io/k8s-prow/commenter@sha256:dd5f3091c86f04dbca29f68de8cba21f6be4485281b0985aed4879450928001a
       args:
-      - /app/robots/commenter/commenter-image.binary
+      - /app/robots/commenter/app.binary
       - |-
         --query=repo:jetstack/cert-manager
         -label:lifecycle/frozen
@@ -93,9 +93,9 @@ periodics:
     description: Marks PRs and issues that are marked 'stale' and have been inactive for 30d as 'rotten'
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/commenter:v20181130-0587c4793
+    - image: gcr.io/k8s-prow/commenter@sha256:dd5f3091c86f04dbca29f68de8cba21f6be4485281b0985aed4879450928001a
       args:
-      - /app/robots/commenter/commenter-image.binary
+      - /app/robots/commenter/app.binary
       - |-
         --query=repo:jetstack/cert-manager
         -label:lifecycle/frozen
@@ -132,9 +132,9 @@ periodics:
     description: Marks PRs and issues that have been inactive for 30d as 'stale'
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/commenter:v20181130-0587c4793
+    - image: gcr.io/k8s-prow/commenter@sha256:dd5f3091c86f04dbca29f68de8cba21f6be4485281b0985aed4879450928001a
       args:
-      - /app/robots/commenter/commenter-image.binary
+      - /app/robots/commenter/app.binary
       - |-
         --query=repo:jetstack/cert-manager
         -label:lifecycle/frozen


### PR DESCRIPTION
This PR just bumps versions and updates commands for periodic checks against Github issues and pull requests.

I've re-instated the periodics by manually creating a secret with an existing Jetbot GitHub token (the same that other Prow components use) that these jobs need (really the secret creation should be automated, but we can do that once we have automated Prow cluster infra bootstrap)

There are now jobs that:
- periodically retest PRs (one every 20 minutes)
- mark PRs and issues as stale after 90 days of inactivity (runs every hour and looks at max 10 issues/PRs)
- mark stale PRs/issues (that haven't been touched for 30 days) as rotten (runs every hour and looks at max 10 issues/PRs)
- close rotten PRs/issues (that haven't been touched for 30 days) (runs every hour and looks at max 10 issues/PRs)

I've manually updated jobs config and observed all the runs succeed, see an example issue that was made stale here https://github.com/jetstack/cert-manager/issues/1282


Fixes #507 





Signed-off-by: irbekrm <irbekrm@gmail.com>