### PR TITLE
Move cert-manager/istio-csr as a member of cert-manager

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -35,16 +35,6 @@ branch-protection:
             contexts:
             - dco
             - pull-cert-manager-website-verify
-        istio-csr:
-          protect: true
-          required_status_checks:
-            contexts:
-            - dco
-            - pull-istio-csr-verify
-            - pull-istio-csr-k8s-v1-21-istio-v1-7
-            - pull-istio-csr-k8s-v1-21-istio-v1-8
-            - pull-istio-csr-k8s-v1-21-istio-v1-9
-            - pull-istio-csr-k8s-v1-21-istio-v1-10
         webhook-example:
           protect: true
           required_status_checks:

--- a/config/jobs/cert-manager/istio-csr/OWNERS
+++ b/config/jobs/cert-manager/istio-csr/OWNERS
@@ -2,5 +2,3 @@ approvers:
 - joshvanl
 reviewers:
 - joshvanl
-labels:
-- area/istio-csr

--- a/config/jobs/cert-manager/istio-csr/cert-manager-istio-csr-presubmits.yaml
+++ b/config/jobs/cert-manager/istio-csr/cert-manager-istio-csr-presubmits.yaml
@@ -8,6 +8,8 @@ presubmits:
     max_concurrency: 8
     annotations:
       testgrid-create-test-group: 'false'
+    branches:
+    - ^main$
     spec:
       containers:
       - image: golang:1.16
@@ -24,6 +26,8 @@ presubmits:
     agent: kubernetes
     decorate: true
     always_run: true
+    branches:
+    - ^main$
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"

--- a/config/jobs/cert-manager/istio-csr/cert-manager-istio-csr-presubmits.yaml
+++ b/config/jobs/cert-manager/istio-csr/cert-manager-istio-csr-presubmits.yaml
@@ -1,7 +1,7 @@
 presubmits:
   cert-manager/istio-csr:
 
-  - name: pull-istio-csr-verify
+  - name: pull-cert-manager-istio-csr-verify
     agent: kubernetes
     decorate: true
     always_run: true
@@ -19,9 +19,53 @@ presubmits:
             cpu: 1
             memory: 1Gi
 
+  - name: pull-cert-manager-istio-csr-ca-rotation
+    context: pull-cert-manager-istio-csr-ca-rotation
+    agent: kubernetes
+    decorate: true
+    always_run: true
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20210907-aa51283-1.17
+        args:
+        - runner
+        - make
+        - carotation
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 4Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+
   # kind based istio-csr e2e job for Kubernetes v1.21, istio v1.7
-  - name: pull-istio-csr-k8s-v1-21-istio-v1-7
-    context: pull-istio-csr-k8s-v1-21-istio-v1-7
+  - name: pull-cert-manager-istio-csr-k8s-v1-21-istio-v1-7
+    context: pull-cert-manager-istio-csr-k8s-v1-21-istio-v1-7
     # Match everything except PRs that only touch docs/
     always_run: true
     optional: false
@@ -29,7 +73,7 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
-    - ^master$
+    - ^main$
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -74,8 +118,8 @@ presubmits:
             value: "1"
 
   # kind based istio-csr e2e job for Kubernetes v1.21, istio v1.8
-  - name: pull-istio-csr-k8s-v1-21-istio-v1-8
-    context: pull-istio-csr-k8s-v1-21-istio-v1-8
+  - name: pull-cert-manager-istio-csr-k8s-v1-21-istio-v1-8
+    context: pull-cert-manager-istio-csr-k8s-v1-21-istio-v1-8
     # Match everything except PRs that only touch docs/
     always_run: true
     optional: false
@@ -83,7 +127,7 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
-    - ^master$
+    - ^main$
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -128,8 +172,8 @@ presubmits:
             value: "1"
 
   # kind based istio-csr e2e job for Kubernetes v1.21, istio v1.9
-  - name: pull-istio-csr-k8s-v1-21-istio-v1-9
-    context: pull-istio-csr-k8s-v1-21-istio-v1-9
+  - name: pull-cert-manager-istio-csr-k8s-v1-21-istio-v1-9
+    context: pull-cert-manager-istio-csr-k8s-v1-21-istio-v1-9
     # Match everything except PRs that only touch docs/
     always_run: true
     optional: false
@@ -137,7 +181,7 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
-    - ^master$
+    - ^main$
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -182,8 +226,8 @@ presubmits:
             value: "1"
 
   # kind based istio-csr e2e job for Kubernetes v1.21, istio v1.10
-  - name: pull-istio-csr-k8s-v1-21-istio-v1-10
-    context: pull-istio-csr-k8s-v1-21-istio-v1-10
+  - name: pull-cert-manager-istio-csr-k8s-v1-21-istio-v1-10
+    context: pull-cert-manager-istio-csr-k8s-v1-21-istio-v1-10
     # Match everything except PRs that only touch docs/
     always_run: true
     optional: false
@@ -191,7 +235,7 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
-    - ^master$
+    - ^main$
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"

--- a/config/labels.yaml
+++ b/config/labels.yaml
@@ -83,19 +83,6 @@ repos:
       target: both
       addedBy: prow
 
-  cert-manager/istio-csr:
-    labels:
-    - color: 0052cc
-      description: Indicates a PR modifies deployment configuration
-      name: area/deploy
-      target: both
-      addedBy: prow
-    - color: 0052cc
-      description: Indicates a PR modifies e2e testing code
-      name: area/testing
-      target: both
-      addedBy: prow
-
   cert-manager/trust:
     labels:
     - color: 0052cc
@@ -161,11 +148,6 @@ repos:
     - color: 0052cc
       description: Indicates a PR related to cert-manager
       name: area/cert-manager
-      target: both
-      addedBy: prow
-    - color: 0052cc
-      description: Indicates a PR related to istio-csr
-      name: area/istio-csr
       target: both
       addedBy: prow
     - color: 0052cc

--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -24,7 +24,6 @@ triggers:
 - repos:
   - jetstack/cert-manager
   - cert-manager/website
-  - cert-manager/istio-csr
   - cert-manager/trust
   only_org_members: true
 
@@ -59,10 +58,6 @@ repo_milestone:
     maintainers_id: 2805308
     maintainers_team: milestone-maintainers
   cert-manager/website:
-    # https://github.com/orgs/cert-manager/teams/milestone-maintainers
-    maintainers_id: 2805308
-    maintainers_team: milestone-maintainers
-  cert-manager/istio-csr:
     # https://github.com/orgs/cert-manager/teams/milestone-maintainers
     maintainers_id: 2805308
     maintainers_team: milestone-maintainers
@@ -109,8 +104,6 @@ milestone_applier:
     master: v0.2
     release-0.1: v0.1
     release-0.2: v0.2
-  cert-manager/istio-csr:
-    master: v0.0
   cert-manager/trust:
     master: v0.1
 

--- a/prow/cluster/labelsync_cronjob.yaml
+++ b/prow/cluster/labelsync_cronjob.yaml
@@ -33,7 +33,7 @@ spec:
               - --config=/etc/config/labels.yaml
               - --confirm=true
               # TODO: enable label_sync across the whole org
-              - --only=jetstack/cert-manager,jetstack/testing,jetstack/kube-oidc-proxy,jetstack/tarmak,jetstack/terraform-google-gke-cluster,cert-manager/release,cert-manager/webhook-example,cert-manager/website,jetstack/cert-manager-nginx-plus-lab,cert-manager/csi-lib,cert-manager/approver-policy,cert-manager/csi-driver
+              - --only=jetstack/cert-manager,jetstack/testing,jetstack/kube-oidc-proxy,jetstack/tarmak,jetstack/terraform-google-gke-cluster,cert-manager/release,cert-manager/webhook-example,cert-manager/website,jetstack/cert-manager-nginx-plus-lab,cert-manager/csi-lib,cert-manager/approver-policy,cert-manager/csi-driver,cert-manager/istio-csr
               - --token=/etc/github/oauth
               volumeMounts:
               - name: oauth


### PR DESCRIPTION
Signed-off-by: joshvanl <vleeuwenjoshua@gmail.com>

Adds the `carotation` test to istio-csr.

Now that istio-csr has moved its default head branch to main, this should be merged straight away.

/assign @irbekrm 

```release-note
NONE
```