### PR TITLE
Bazel version bump

### DIFF
--- a/config/jobs/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager-periodics.yaml
@@ -34,39 +34,8 @@ periodics:
         - name: ndots
           value: "1"
 
-- name: ci-cert-manager-bazel-experimental
-  interval: 2h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: jetstack
-    repo: cert-manager
-    base_ref: master
-  labels:
-    preset-service-account: "true"
-    preset-bazel-scratch-dir: "true"
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-master
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs 'bazel test --jobs=1 //...' using the 'experimental' Bazel version
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-experimental
-      args:
-      - runner
-      - bazel
-      - test
-      - --jobs=1
-      - //...
-      resources:
-        requests:
-          cpu: 2
-          memory: 4Gi
-    dnsConfig:
-      options:
-        - name: ndots
-          value: "1"
+# Re-add bazel-experimental periodics once Bazel v5.0.0 is released and we have
+# a bazelbuild image with that https://github.com/bazelbuild/bazel/releases
 
 # kind based cert-manager e2e job
 - name: ci-cert-manager-e2e-v1-16

--- a/config/jobs/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager-periodics.yaml
@@ -18,7 +18,7 @@ periodics:
     description: Runs 'bazel test --jobs=1 //...'
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
       args:
       - runner
       - bazel
@@ -93,7 +93,7 @@ periodics:
     description: Runs the end-to-end test suite against a Kubernetes v1.16 cluster
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
       args:
       - runner
       - devel/ci-run-e2e.sh
@@ -152,7 +152,7 @@ periodics:
     preset-ginkgo-skip-default: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
       args:
       - runner
       - devel/ci-run-e2e.sh
@@ -211,7 +211,7 @@ periodics:
     preset-ginkgo-skip-default: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
       args:
       - runner
       - devel/ci-run-e2e.sh
@@ -270,7 +270,7 @@ periodics:
     preset-ginkgo-skip-default: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
       args:
       - runner
       - devel/ci-run-e2e.sh
@@ -329,7 +329,7 @@ periodics:
     preset-ginkgo-skip-default: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
       args:
       - runner
       - devel/ci-run-e2e.sh
@@ -388,7 +388,7 @@ periodics:
     preset-ginkgo-skip-default: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
       args:
       - runner
       - devel/ci-run-e2e.sh
@@ -447,7 +447,7 @@ periodics:
     preset-ginkgo-skip-default: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
       args:
       - runner
       - devel/ci-run-e2e.sh
@@ -496,7 +496,7 @@ periodics:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-master
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs the end-to-end test suite against a Kubernetes v1.22 cluster
+    description: Runs Venafi Cloud e2e tests against Kubernetes v1.22 cluster
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
@@ -506,7 +506,7 @@ periodics:
     preset-ginkgo-focus-venafi-cloud: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
       args:
       - runner
       - devel/ci-run-e2e.sh
@@ -563,7 +563,7 @@ periodics:
     preset-bazel-scratch-dir: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
       args:
       - runner
       - make

--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -20,7 +20,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
         args:
         - runner
         - bazel
@@ -95,7 +95,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
         args:
         - runner
         - make
@@ -131,7 +131,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
         args:
         - runner
         - make
@@ -172,7 +172,7 @@ presubmits:
       preset-ginkgo-skip-default: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
         args:
         - runner
         - devel/ci-run-e2e.sh
@@ -233,7 +233,7 @@ presubmits:
       preset-ginkgo-skip-default: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
         args:
         - runner
         - devel/ci-run-e2e.sh
@@ -294,7 +294,7 @@ presubmits:
       preset-ginkgo-skip-default: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
         args:
         - runner
         - devel/ci-run-e2e.sh
@@ -355,7 +355,7 @@ presubmits:
       preset-ginkgo-skip-default: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
         args:
         - runner
         - devel/ci-run-e2e.sh
@@ -416,7 +416,7 @@ presubmits:
       preset-ginkgo-skip-default: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
         args:
         - runner
         - devel/ci-run-e2e.sh
@@ -477,7 +477,7 @@ presubmits:
       preset-ginkgo-skip-default: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
         args:
         - runner
         - devel/ci-run-e2e.sh
@@ -539,7 +539,7 @@ presubmits:
       preset-ginkgo-skip-default: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
         args:
         - runner
         - devel/ci-run-e2e.sh
@@ -600,7 +600,7 @@ presubmits:
       preset-ginkgo-focus-venafi-tpp: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
         args:
         - runner
         - devel/ci-run-e2e.sh
@@ -661,7 +661,7 @@ presubmits:
       preset-ginkgo-focus-venafi-cloud: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
         args:
         - runner
         - devel/ci-run-e2e.sh
@@ -719,7 +719,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
         args:
         - runner
         - make

--- a/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
+++ b/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
@@ -35,39 +35,8 @@ periodics:
       - name: ndots
         value: "1"
 
-- name: ci-cert-manager-next-bazel-experimental
-  interval: 2h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: jetstack
-    repo: cert-manager
-    base_ref: release-1.6
-  labels:
-    preset-service-account: "true"
-    preset-bazel-scratch-dir: "true"
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-next
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs 'bazel test --jobs=1 //...' using the 'experimental' Bazel version
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-experimental
-      args:
-      - runner
-      - bazel
-      - test
-      - --jobs=1
-      - //...
-      resources:
-        requests:
-          cpu: 2
-          memory: 4Gi
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
+# Re-add bazel-experimental periodics once Bazel v5.0.0 is released and we have
+# a bazelbuild image with that https://github.com/bazelbuild/bazel/releases
 
 - name: ci-cert-manager-next-e2e-v1-16
   interval: 2h

--- a/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
+++ b/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
@@ -19,7 +19,7 @@ periodics:
     description: Runs 'bazel test --jobs=1 //...'
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
       args:
       - runner
       - bazel
@@ -93,7 +93,7 @@ periodics:
     description: Runs the end-to-end test suite against a Kubernetes v1.16 cluster
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
       args:
       - runner
       - devel/ci-run-e2e.sh
@@ -152,7 +152,7 @@ periodics:
     preset-disable-all-feature-gates: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
       args:
       - runner
       - devel/ci-run-e2e.sh
@@ -211,7 +211,7 @@ periodics:
     preset-disable-all-feature-gates: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
       args:
       - runner
       - devel/ci-run-e2e.sh
@@ -270,7 +270,7 @@ periodics:
     preset-enable-all-feature-gates: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
       args:
       - runner
       - devel/ci-run-e2e.sh
@@ -329,7 +329,7 @@ periodics:
     preset-enable-all-feature-gates: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
       args:
       - runner
       - devel/ci-run-e2e.sh
@@ -388,7 +388,7 @@ periodics:
     preset-enable-all-feature-gates: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
       args:
       - runner
       - devel/ci-run-e2e.sh
@@ -447,7 +447,7 @@ periodics:
     preset-enable-all-feature-gates: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
       args:
       - runner
       - devel/ci-run-e2e.sh

--- a/config/jobs/testing/testing-presubmits.yaml
+++ b/config/jobs/testing/testing-presubmits.yaml
@@ -36,7 +36,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-056d642-2.2.0
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
         args:
         - runner
         - bazel
@@ -63,7 +63,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-056d642-2.2.0
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
         args:
         - runner
         - bazel

--- a/config/jobs/testing/testing-trusted.yaml
+++ b/config/jobs/testing/testing-trusted.yaml
@@ -109,7 +109,7 @@ postsubmits:
       description: Build and push the 'bazelbuild' image
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-056d642-2.2.0
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
         args:
         # Wrap the release script with the runner so we can use docker-in-docker
         - runner
@@ -146,7 +146,7 @@ postsubmits:
       description: Build and push the 'golang-dind' image
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-056d642-2.2.0
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
         args:
         # Wrap the release script with the runner so we can use docker-in-docker
         - runner
@@ -183,7 +183,7 @@ postsubmits:
       description: Build and push the 'golang-nodejs' image
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-056d642-2.2.0
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
         args:
         # Wrap the release script with the runner so we can use docker-in-docker
         - runner
@@ -219,7 +219,7 @@ postsubmits:
       description: Build and push the 'bazel-tools' image
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-056d642-2.2.0
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
         args:
         # Wrap the release script with the runner so we can use docker-in-docker
         - runner
@@ -256,7 +256,7 @@ postsubmits:
       description: Build and push the 'katacoda-lint' image
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-056d642-2.2.0
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
         args:
         # Wrap the release script with the runner so we can use docker-in-docker
         - runner
@@ -293,7 +293,7 @@ postsubmits:
       description: Build and push the 'tarmak-ruby' image
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-056d642-2.2.0
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
         args:
         # Wrap the release script with the runner so we can use docker-in-docker
         - runner
@@ -330,7 +330,7 @@ postsubmits:
       description: Build and push the 'tarmak-sphinx-docs' image
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-056d642-2.2.0
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
         args:
         # Wrap the release script with the runner so we can use docker-in-docker
         - runner
@@ -367,7 +367,7 @@ postsubmits:
       description: Build and push the 'terraform-google-gke-cluster' image
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-056d642-2.2.0
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
         args:
         # Wrap the release script with the runner so we can use docker-in-docker
         - runner
@@ -438,7 +438,7 @@ postsubmits:
       description: Build and push the 'golang-aws' image
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-056d642-2.2.0
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
         args:
         # Wrap the release script with the runner so we can use docker-in-docker
         - runner

--- a/images/golang-dind/build.yaml
+++ b/images/golang-dind/build.yaml
@@ -3,7 +3,7 @@ name: golang-dind # Name of the image to be built
 variants:
   "1.17":
     arguments:
-      BASE_IMAGE: "eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210331-363c37a-3.5.0"
+      BASE_IMAGE: "eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1"
       GO_VERSION: "1.17"
   "1.16.6":
     arguments:


### PR DESCRIPTION
This PR:

- bumps Bazel version `v3.7.2` -> `v4.2.1` for cert-manager tests (we were already running the Bazel-experimental job with this version, so it should work)
- bumps Bazel version for jobs against this repo `v2.2.0` -> `v4.2.1` (I have this version locally and can run tests against this repo, so it should work)
- temporarily removes 'experimental' Bazel jobs for cert-manager `master` and `release-1.16` branches. There is currently no newer version of Bazel than `v4.2.1` and there is no point to run the same test twice against the same version. This job should be re-instated once Bazel `v5.0.0` is released and we have an image for that https://github.com/bazelbuild/bazel/releases