### PR TITLE
Temporarily disable AWS Periodic

### DIFF
--- a/config/jobs/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager-periodics.yaml
@@ -569,52 +569,53 @@ periodics:
       - name: ndots
         value: "1"
 
-- name: aws-tests
-  interval: 48h
-  agent: kubernetes
-  decorate: true
-  extra_refs:            # Periodic job doesn't clone any repo by default, needs to be added explicitly
-    - org: cert-manager
-      repo: test-infra
-      base_ref: main
-    - org: jetstack
-      repo: cert-manager
-      base_ref: master
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-master
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs the end-to-end test suite against a EKS cluster
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-bazel-remote-cache-enabled: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-aws-credentials: "true"
-    preset-ginkgo-focus-http01-ingress: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/golang-aws@sha256:1f330e4c9552ca383d157067b73fb0e090b64b0777939fd59e58b60e06020d66
-      args:
-      - bash 
-      - -c
-      - |
-        set -euo && \
-        ls && \
-        pwd && \
-        cd /home/prow/go/src/github.com/cert-manager/test-infra/aws && \
-        terraform init && \
-        trap 'terraform destroy -auto-approve' ERR && \
-        terraform apply -auto-approve && \
-        ls && \
-        pwd && \
-        cd /home && \
-        ls && \
-        cd /home/prow/go/src/github.com/jetstack/cert-manager && \
-        ./devel/run-e2e.sh --acme-server-url=https://acme-staging-v02.api.letsencrypt.org/directory --ingress-controller-domain=aws.e2e-tests.cert-manager.io --testing-acme-email=cert-manager-dev-alerts@googlegroups.com --kubernetes-config=/home/prow/go/src/github.com/cert-manager/test-infra/aws/kubeconfig_cert-manager-cluster || true && \
-        cd /home/prow/go/src/github.com/cert-manager/test-infra/aws && \
-        terraform destroy -auto-approve;
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 12Gi
+# TODO: find a permanent home for the AWS periodics and reinstate this job
+# - name: aws-tests
+#   interval: 48h
+#   agent: kubernetes
+#   decorate: true
+#   extra_refs:            # Periodic job doesn't clone any repo by default, needs to be added explicitly
+#     - org: cert-manager
+#       repo: test-infra
+#       base_ref: main
+#     - org: jetstack
+#       repo: cert-manager
+#       base_ref: master
+#   annotations:
+#     testgrid-create-test-group: 'true'
+#     testgrid-dashboards: jetstack-cert-manager-master
+#     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+#     description: Runs the end-to-end test suite against a EKS cluster
+#   labels:
+#     preset-service-account: "true"
+#     preset-dind-enabled: "true"
+#     preset-bazel-remote-cache-enabled: "true"
+#     preset-bazel-scratch-dir: "true"
+#     preset-aws-credentials: "true"
+#     preset-ginkgo-focus-http01-ingress: "true"
+#   spec:
+#     containers:
+#     - image: eu.gcr.io/jetstack-build-infra-images/golang-aws@sha256:1f330e4c9552ca383d157067b73fb0e090b64b0777939fd59e58b60e06020d66
+#       args:
+#       - bash 
+#       - -c
+#       - |
+#         set -euo && \
+#         ls && \
+#         pwd && \
+#         cd /home/prow/go/src/github.com/cert-manager/test-infra/aws && \
+#         terraform init && \
+#         trap 'terraform destroy -auto-approve' ERR && \
+#         terraform apply -auto-approve && \
+#         ls && \
+#         pwd && \
+#         cd /home && \
+#         ls && \
+#         cd /home/prow/go/src/github.com/jetstack/cert-manager && \
+#         ./devel/run-e2e.sh --acme-server-url=https://acme-staging-v02.api.letsencrypt.org/directory --ingress-controller-domain=aws.e2e-tests.cert-manager.io --testing-acme-email=cert-manager-dev-alerts@googlegroups.com --kubernetes-config=/home/prow/go/src/github.com/cert-manager/test-infra/aws/kubeconfig_cert-manager-cluster || true && \
+#         cd /home/prow/go/src/github.com/cert-manager/test-infra/aws && \
+#         terraform destroy -auto-approve;
+#       resources:
+#         requests:
+#           cpu: 3500m
+#           memory: 12Gi


### PR DESCRIPTION
We are deleting the account that this test runs in, so should find a permanent home for it and then reinstate it.