### PR TITLE
Bump golang-dind image version for cmrel presubmit

### DIFF
--- a/config/jobs/cert-manager/release/cert-manager-release-presubmits.yaml
+++ b/config/jobs/cert-manager/release/cert-manager-release-presubmits.yaml
@@ -14,7 +14,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20210331-a8721c1-1.16
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20210927-4d1bd69-1.17
         args:
         - runner
         - make


### PR DESCRIPTION
This is required now that cert-manager requires bazel 4

/kind cleanup