### PR TITLE
Adds a Bazel go cache preset

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,6 +1,6 @@
 plank:
   job_url_template: 'https://prow.build-infra.jetstack.net/view/jetstack-logs/{{if eq .Spec.Type "presubmit"}}pr-logs/pull{{else if eq .Spec.Type "batch"}}pr-logs/pull{{else}}logs{{end}}{{if .Spec.Refs}}{{if ne .Spec.Refs.Org ""}}/{{.Spec.Refs.Org}}_{{.Spec.Refs.Repo}}{{end}}{{end}}{{if eq .Spec.Type "presubmit"}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}{{else if eq .Spec.Type "batch"}}/batch{{end}}/{{.Spec.Job}}/{{.Status.BuildID}}/'
-  report_templates: 
+  report_templates:
     '*': '[Full PR test history](https://prow.build-infra.jetstack.net/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}). [Your PR dashboard](https://jetstack-build-infra.appspot.com/pr/{{with index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}). Please help us cut down on flakes by [linking to](https://git.k8s.io/community/contributors/devel/sig-testing/flaky-tests.md#github-issues-for-known-flakes) an [open issue](https://github.com/{{.Spec.Refs.Org}}/{{.Spec.Refs.Repo}}/issues?q=is:issue+is:open) when you hit one in your PR.'
   job_url_prefix_config:
     '*': https://prow.build-infra.jetstack.net/view/
@@ -201,6 +201,27 @@ presets:
   volumeMounts:
   - name: bazel-scratch
     mountPath: /bazel-scratch/.cache
+
+# Use this preset to cache Go modules and build artifacts on the prow cluster
+# nodes nodes.
+# This idea is stolen from the Istio Prow configuration.
+# You can see how they implemented it in the following PRs:
+#  https://github.com/istio/test-infra/pulls?q=is%3Apr+cache
+# Additionally configure bazel-gazelle to get Go modules from this cache. See:
+#  https://github.com/bazelbuild/bazel-gazelle/blob/136915ee0ab40b6cf6461670bf2a1a04b0929d66/repository.rst#go_repository
+- labels:
+    preset-bazel-go-cache: "true"
+  env:
+  - name: GO_REPOSITORY_USE_HOST_CACHE
+    value: "1"
+  volumes:
+  - name: go-cache
+    hostPath:
+      path: /var/tmp/prow/cache/go/pkg
+      type: DirectoryOrCreate
+  volumeMounts:
+  - name: go-cache
+    mountPath: /home/prow/go/pkg
 
 - labels:
     preset-bazel-remote-cache-enabled: "true"

--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -71,6 +71,43 @@ presubmits:
           - name: ndots
             value: "1"
 
+  - name: pull-cert-manager-bazel-gocache
+    description: Run cert-manager unit tests with Bazel using a Go cache on the local node
+    always_run: false
+    optional: true
+    context: pull-cert-manager-bazel-gocache
+    max_concurrency: 8
+    agent: kubernetes
+    decorate: true
+    branches:
+    - master
+    - release-1.6
+    annotations:
+      testgrid-create-test-group: 'false'
+      description: Runs 'bazel test --jobs=1 //...'
+    labels:
+      preset-service-account: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-go-cache: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+        args:
+        - runner
+        - bazel
+        - test
+        - --jobs=1
+        - //...
+        resources:
+          requests:
+            cpu: 2
+            memory: 4Gi
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+
   - name: pull-cert-manager-bazel-experimental
     always_run: false
     optional: true
@@ -613,8 +650,8 @@ presubmits:
   # static manifests. This is an optional test.
   - name: pull-cert-manager-upgrade
     # Run always
-    always_run: true 
-    optional: false 
+    always_run: true
+    optional: false
     # No more than 4 instances of this job at the same time.
     max_concurrency: 4
     # This job will run on Kubernetes cluster.


### PR DESCRIPTION
Saves Go modules and other Go build artifacts to a hostpath volume on the node.