### PR TITLE
Venafi Cloud e2e tests in default e2e tests against previous/next branches

### DIFF
--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -774,7 +774,7 @@ presubmits:
   #
   #  /test pull-cert-manager-e2e-v1-21-feature-issuers-venafi-cloud
   #
-  # This is useful as we sometimes disable regular runs of Venafi Cloud tests due to some issues.
+  # The regular presubmit jobs do not run Venafi Cloud e2e tests.
   #
   - name: pull-cert-manager-e2e-v1-21-feature-issuers-venafi-cloud
     always_run: false
@@ -799,7 +799,6 @@ presubmits:
         args:
         - runner
         - devel/ci-run-e2e.sh
-        - -ginkgo.focus
         resources:
           requests:
             cpu: 3500m

--- a/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
+++ b/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
@@ -53,8 +53,8 @@ periodics:
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
-    preset-venafi-cloud-credentials: "true"
     preset-disable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-next
@@ -117,8 +117,8 @@ periodics:
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
-    preset-venafi-cloud-credentials: "true"
     preset-disable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
@@ -176,8 +176,8 @@ periodics:
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
-    preset-venafi-cloud-credentials: "true"
     preset-disable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
@@ -235,8 +235,8 @@ periodics:
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
-    preset-venafi-cloud-credentials: "true"
     preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
@@ -294,8 +294,8 @@ periodics:
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
-    preset-venafi-cloud-credentials: "true"
     preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
@@ -353,8 +353,8 @@ periodics:
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
-    preset-venafi-cloud-credentials: "true"
     preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
@@ -412,8 +412,67 @@ periodics:
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
-    preset-venafi-cloud-credentials: "true"
     preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+      args:
+      - runner
+      - devel/ci-run-e2e.sh
+      resources:
+        requests:
+          cpu: 3500m
+          memory: 12Gi
+      env:
+      - name: K8S_VERSION
+        value: "1.22"
+      securityContext:
+        privileged: true
+        capabilities:
+          add: ["SYS_ADMIN"]
+      volumeMounts:
+      - mountPath: /lib/modules
+        name: modules
+        readOnly: true
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    volumes:
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+
+# This test runs Venafi Cloud tests once every 24hrs. This is the only CI test
+# job that runs those periodically against release-1.6.
+- name: ci-cert-manager-next-venafi-cloud
+  interval: 24h
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: jetstack
+    repo: cert-manager
+    base_ref: release-1.6
+  annotations:
+    testgrid-create-test-group: 'true'
+    testgrid-dashboards: jetstack-cert-manager-master
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    description: Runs Venafi Cloud e2e tests against Kubernetes v1.22 cluster
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-venafi-cloud-credentials: "true"
+    preset-ginkgo-focus-venafi-cloud: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1

--- a/config/jobs/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
+++ b/config/jobs/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
@@ -84,8 +84,8 @@ periodics:
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
-    preset-venafi-cloud-credentials: "true"
     preset-disable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
@@ -148,8 +148,8 @@ periodics:
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
-    preset-venafi-cloud-credentials: "true"
     preset-disable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -207,8 +207,8 @@ periodics:
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
-    preset-venafi-cloud-credentials: "true"
     preset-disable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -266,8 +266,8 @@ periodics:
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
-    preset-venafi-cloud-credentials: "true"
     preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -325,8 +325,8 @@ periodics:
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
-    preset-venafi-cloud-credentials: "true"
     preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -384,8 +384,8 @@ periodics:
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
-    preset-venafi-cloud-credentials: "true"
     preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -443,8 +443,67 @@ periodics:
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
     preset-venafi-tpp-credentials: "true"
-    preset-venafi-cloud-credentials: "true"
     preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+      args:
+      - runner
+      - devel/ci-run-e2e.sh
+      resources:
+        requests:
+          cpu: 3500m
+          memory: 12Gi
+      env:
+      - name: K8S_VERSION
+        value: "1.22"
+      securityContext:
+        privileged: true
+        capabilities:
+          add: ["SYS_ADMIN"]
+      volumeMounts:
+      - mountPath: /lib/modules
+        name: modules
+        readOnly: true
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    volumes:
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+
+# This test runs Venafi Cloud tests once every 24hrs. This is the only CI test
+# job that runs those periodically against release-previous.
+- name: ci-cert-manager-previous-venafi-cloud
+  interval: 24h
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: jetstack
+    repo: cert-manager
+    base_ref: release-1.5
+  annotations:
+    testgrid-create-test-group: 'true'
+    testgrid-dashboards: jetstack-cert-manager-master
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    description: Runs Venafi Cloud e2e tests against Kubernetes v1.22 cluster
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-venafi-cloud-credentials: "true"
+    preset-ginkgo-focus-venafi-cloud: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2

--- a/config/jobs/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
+++ b/config/jobs/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
@@ -151,9 +151,9 @@ presubmits:
       preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
       preset-venafi-tpp-credentials: "true"
-      preset-venafi-cloud-credentials: "true"
       preset-retry-flakey-tests: "true"
       preset-disable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -209,9 +209,9 @@ presubmits:
       preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
       preset-venafi-tpp-credentials: "true"
-      preset-venafi-cloud-credentials: "true"
       preset-retry-flakey-tests: "true"
       preset-disable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -267,9 +267,9 @@ presubmits:
       preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
       preset-venafi-tpp-credentials: "true"
-      preset-venafi-cloud-credentials: "true"
       preset-retry-flakey-tests: "true"
       preset-disable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -325,9 +325,9 @@ presubmits:
       preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
       preset-venafi-tpp-credentials: "true"
-      preset-venafi-cloud-credentials: "true"
       preset-retry-flakey-tests: "true"
       preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -383,9 +383,9 @@ presubmits:
       preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
       preset-venafi-tpp-credentials: "true"
-      preset-venafi-cloud-credentials: "true"
       preset-retry-flakey-tests: "true"
       preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -441,9 +441,9 @@ presubmits:
       preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
       preset-venafi-tpp-credentials: "true"
-      preset-venafi-cloud-credentials: "true"
       preset-retry-flakey-tests: "true"
       preset-disable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
@@ -499,9 +499,71 @@ presubmits:
       preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
       preset-venafi-tpp-credentials: "true"
-      preset-venafi-cloud-credentials: "true"
       preset-retry-flakey-tests: "true"
       preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+        args:
+        - runner
+        - devel/ci-run-e2e.sh
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        env:
+        - name: K8S_VERSION
+          value: "1.22"
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+
+  # An E2E test job to allow us to manually trigger the Venafi Cloud E2E tests
+  # with the following GitHub comment:
+  #
+  #  /test pull-cert-manager-e2e-v1-22-feature-issuers-venafi-cloud
+  #
+  # The regular presubmit jobs do not run Venafi Cloud e2e tests.
+  #
+  - name: pull-cert-manager-e2e-v1-22-feature-issuers-venafi-cloud
+    always_run: false
+    optional: true
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    branches:
+    - release-1.5
+    annotations:
+      description: Runs the E2E tests with 'Venafi Cloud' in name
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-venafi-cloud-credentials: "true"
+      preset-retry-flakey-tests: "true"
+      preset-ginkgo-focus-venafi-cloud: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2


### PR DESCRIPTION
This PR ensures that Venafi Cloud e2e tests are skipped for the default periodics/presubmits against next and previous release branches. Periodic Venafi Cloud e2e tests are run against next and previous release branches every 24hrs and Venafi Cloud presubmit can be triggered manually. This is the same behaviour as we currently have for presubmits and periodics against current master branch (where the Venafi Cloud e2e tests are run once every 24hrs see https://testgrid.k8s.io/jetstack-cert-manager-master#ci-cert-manager-venafi-cloud)



Signed-off-by: irbekrm <irbekrm@gmail.com>