### PR TITLE
Adds '^release-1\.[0-9]+$' as a branch target for the website presubmit verify

### DIFF
--- a/config/jobs/cert-manager/website/cert-manager-website-presubmits.yaml
+++ b/config/jobs/cert-manager/website/cert-manager-website-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
     branches:
     - ^master$
     - ^release-next$
+    - ^release-1\.[0-9]+$
     labels:
       preset-service-account: "true"
     spec:


### PR DESCRIPTION
Signed-off-by: joshvanl <vleeuwenjoshua@gmail.com>

This should enable verify tests for the cert-manager website for all PRs which are targeting a release branch.

/assign @jakexks 


```release-note
NONE
```