### PR TITLE
Fix var name

### DIFF
--- a/images/bazel-tools/build.yaml
+++ b/images/bazel-tools/build.yaml
@@ -9,12 +9,12 @@ variants:
       # Version of Go that is bundled in the BASE_IMAGE
       GO_VERSION: "1.17"
       NODE_VERSION: "10.24.0~dfsg-1~deb10u1"
-      # This DOCKER_TAG is the Docker tag that corresponds to the Node version
+      # This NODE_DOCKER_TAG is the Docker tag that corresponds to the Node version
       # we use. We don't use the Node version directly because it is not a valid
       # Docker tag.
       NODE_DOCKER_TAG: "10.24.0"
 
 # Image names to be tagged and pushed
 images:
-- ${_REGISTRY}/${_NAME}:${_DATE_STAMP}-${_GIT_REF}-${DOCKER_TAG}
+- ${_REGISTRY}/${_NAME}:${_DATE_STAMP}-${_GIT_REF}-${NODE_DOCKER_TAG}
 - ${_REGISTRY}/${_NAME}:bazel${BAZEL_VERSION}-go${GO_VERSION}-node${NODE_DOCKER_TAG}


### PR DESCRIPTION
Fixes var name from non-existant `DOCKER_TAG` to `NODE_DOCKER_TAG`. 

I don't understand how this worked before as I don't see when that got changed and we did get one successful build with those tags https://console.cloud.google.com/gcr/images/jetstack-build-infra-images/eu/bazel-tools@sha256:e02dbe9ed1f043e2a7274a2e53e17a20b3b25a69ece447d2d0c0b77a65468794/details?authuser=2&project=jetstack-build-infra-images 
Perhaps it still had the old var set somehow after this change https://github.com/jetstack/testing/pull/590/commits/13768d9c7b189f51444052b81743c49ba46f7069.


Signed-off-by: irbekrm <irbekrm@gmail.com>