### PR TITLE
Venafi TPP tests run separately

### DIFF
--- a/config/jobs/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager-periodics.yaml
@@ -52,7 +52,6 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
-    preset-venafi-tpp-credentials: "true"
     preset-disable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
   annotations:
@@ -116,7 +115,6 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
-    preset-venafi-tpp-credentials: "true"
     preset-disable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
   spec:
@@ -175,7 +173,6 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
-    preset-venafi-tpp-credentials: "true"
     preset-disable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
   spec:
@@ -234,7 +231,6 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
-    preset-venafi-tpp-credentials: "true"
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
   spec:
@@ -293,7 +289,6 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
-    preset-venafi-tpp-credentials: "true"
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
   spec:
@@ -352,7 +347,6 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
-    preset-venafi-tpp-credentials: "true"
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
   spec:
@@ -411,7 +405,6 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
-    preset-venafi-tpp-credentials: "true"
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
   spec:
@@ -451,10 +444,10 @@ periodics:
       - name: ndots
         value: "1"
 
-# This test runs Venafi Cloud tests once every 24hrs.
+# This test runs Venafi (VaaS and TPP) tests once every 12hrs.
 # This is the only CI test job that runs those.
-- name: ci-cert-manager-venafi-cloud
-  interval: 24h
+- name: ci-cert-manager-venafi
+  interval: 12h
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -465,14 +458,15 @@ periodics:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-master
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs Venafi Cloud e2e tests against Kubernetes v1.22 cluster
+    description: Runs Venafi (VaaS and TPP) e2e tests against Kubernetes v1.22 cluster
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
     preset-bazel-remote-cache-enabled: "true"
     preset-bazel-scratch-dir: "true"
     preset-venafi-cloud-credentials: "true"
-    preset-ginkgo-focus-venafi-cloud: "true"
+    preset-venafi-tpp-credentials: "true"
+    preset-ginkgo-focus-venafi: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1

--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -238,7 +238,6 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
       preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
-      preset-venafi-tpp-credentials: "true"
       preset-retry-flakey-tests: "true"
       preset-disable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
@@ -299,7 +298,6 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
       preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
-      preset-venafi-tpp-credentials: "true"
       preset-retry-flakey-tests: "true"
       preset-disable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
@@ -360,7 +358,6 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
       preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
-      preset-venafi-tpp-credentials: "true"
       preset-retry-flakey-tests: "true"
       preset-disable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
@@ -421,7 +418,6 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
       preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
-      preset-venafi-tpp-credentials: "true"
       preset-retry-flakey-tests: "true"
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
@@ -482,7 +478,6 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
       preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
-      preset-venafi-tpp-credentials: "true"
       preset-retry-flakey-tests: "true"
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
@@ -543,7 +538,6 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
       preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
-      preset-venafi-tpp-credentials: "true"
       preset-retry-flakey-tests: "true"
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
@@ -605,7 +599,6 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
       preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
-      preset-venafi-tpp-credentials: "true"
       preset-retry-flakey-tests: "true"
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
@@ -708,14 +701,14 @@ presubmits:
         - name: ndots
           value: "1"
 
-  # An E2E test job to allow us to manually trigger the Venafi TPP E2E tests
+  # An E2E test job to allow us to manually trigger the Venafi  TPP E2E tests
   # with the following GitHub comment:
   #
-  #  /test pull-cert-manager-e2e-v1-21-feature-issuers-venafi-tpp
+  #  /test pull-cert-manager-issuers-venafi-tpp
   #
   # See https://github.com/jetstack/cert-manager/issues/3555
   #
-  - name: pull-cert-manager-e2e-v1-22-feature-issuers-venafi-tpp
+  - name: pull-cert-manager-issuers-venafi-tpp
     always_run: false
     optional: true
     max_concurrency: 4
@@ -772,11 +765,11 @@ presubmits:
   # An E2E test job to allow us to manually trigger the Venafi Cloud E2E tests
   # with the following GitHub comment:
   #
-  #  /test pull-cert-manager-e2e-v1-21-feature-issuers-venafi-cloud
+  #  /test pull-cert-manager-issuers-venafi-cloud
   #
-  # The regular presubmit jobs do not run Venafi Cloud e2e tests.
+  # The regular presubmit jobs do not run Venafi e2e tests.
   #
-  - name: pull-cert-manager-e2e-v1-21-feature-issuers-venafi-cloud
+  - name: pull-cert-manager-e2e-issuers-venafi-cloud
     always_run: false
     optional: true
     max_concurrency: 4
@@ -784,7 +777,7 @@ presubmits:
     decorate: true
     branches: []
     annotations:
-      description: Runs the E2E tests with 'Venafi TPP' in name
+      description: Runs the E2E tests with 'Venafi Cloud' in name
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"

--- a/config/jobs/cert-manager/config.yaml
+++ b/config/jobs/cert-manager/config.yaml
@@ -93,14 +93,16 @@ presets:
   - name: FEATURE_GATES
     value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
 
-# Specific cert-manager e2e test suites can be skipped for all e2e tests here by setting
-# GINKGO_SKIP value
-# i.e 'Venafi Cloud|Gateway' will skip all Venafi Cloud and Gateway tests.
+# Specific cert-manager e2e test suites can be skipped for all e2e tests here by
+# setting GINKGO_SKIP value i.e 'Venafi Cloud|Gateway' will skip all Venafi
+# Cloud and Gateway tests. Currently we skip all Venafi (VaaS and TPP) tests
+# because they rely on external services being up and we don't want PRs and
+# regular periodics to fail due to external service failures.
 - labels:
     preset-ginkgo-skip-default: "true"
   env:
   - name: GINKGO_SKIP
-    value: "Venafi Cloud"
+    value: "Venafi"
 
 - labels:
     preset-ginkgo-focus-http01-ingress: "true"
@@ -109,6 +111,12 @@ presets:
     value: "Gateway"
   - name: GINKGO_FOCUS
     value: "Public ACME Server HTTP01 Issuer"
+
+- labels:
+    preset-ginkgo-focus-venafi: "true"
+  env:
+  - name: GINKGO_FOCUS
+    value: 'Venafi'
 
 - labels:
     preset-ginkgo-focus-venafi-tpp: "true"

--- a/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
+++ b/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
@@ -52,7 +52,6 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
-    preset-venafi-tpp-credentials: "true"
     preset-disable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
   annotations:
@@ -116,7 +115,6 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
-    preset-venafi-tpp-credentials: "true"
     preset-disable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
   spec:
@@ -175,7 +173,6 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
-    preset-venafi-tpp-credentials: "true"
     preset-disable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
   spec:
@@ -234,7 +231,6 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
-    preset-venafi-tpp-credentials: "true"
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
   spec:
@@ -293,7 +289,6 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
-    preset-venafi-tpp-credentials: "true"
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
   spec:
@@ -352,7 +347,6 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
-    preset-venafi-tpp-credentials: "true"
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
   spec:
@@ -411,7 +405,6 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
-    preset-venafi-tpp-credentials: "true"
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
   spec:
@@ -451,9 +444,9 @@ periodics:
       - name: ndots
         value: "1"
 
-# This test runs Venafi Cloud tests once every 24hrs. This is the only CI test
+# This test runs Venafi (VaaS and TPP) tests once every 12hrs. This is the only CI test
 # job that runs those periodically against release-1.6.
-- name: ci-cert-manager-next-venafi-cloud
+- name: ci-cert-manager-next-venafi
   interval: 24h
   agent: kubernetes
   decorate: true
@@ -472,7 +465,8 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
     preset-bazel-scratch-dir: "true"
     preset-venafi-cloud-credentials: "true"
-    preset-ginkgo-focus-venafi-cloud: "true"
+    preset-venafi-tpp-credentials: "true"
+    preset-ginkgo-focus-venafi: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1

--- a/config/jobs/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
+++ b/config/jobs/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
@@ -83,7 +83,6 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
-    preset-venafi-tpp-credentials: "true"
     preset-disable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
   annotations:
@@ -147,7 +146,6 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
-    preset-venafi-tpp-credentials: "true"
     preset-disable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
   spec:
@@ -206,7 +204,6 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
-    preset-venafi-tpp-credentials: "true"
     preset-disable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
   spec:
@@ -265,7 +262,6 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
-    preset-venafi-tpp-credentials: "true"
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
   spec:
@@ -324,7 +320,6 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
-    preset-venafi-tpp-credentials: "true"
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
   spec:
@@ -383,7 +378,6 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
-    preset-venafi-tpp-credentials: "true"
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
   spec:
@@ -442,7 +436,6 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
-    preset-venafi-tpp-credentials: "true"
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
   spec:
@@ -482,9 +475,9 @@ periodics:
       - name: ndots
         value: "1"
 
-# This test runs Venafi Cloud tests once every 24hrs. This is the only CI test
+# This test runs Venafi (VaaS and TPP) tests once every 12hrs. This is the only CI test
 # job that runs those periodically against release-previous.
-- name: ci-cert-manager-previous-venafi-cloud
+- name: ci-cert-manager-previous-venafi
   interval: 24h
   agent: kubernetes
   decorate: true
@@ -503,7 +496,8 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
     preset-bazel-scratch-dir: "true"
     preset-venafi-cloud-credentials: "true"
-    preset-ginkgo-focus-venafi-cloud: "true"
+    preset-venafi-tpp-credentials: "true"
+    preset-ginkgo-focus-venafi: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2

--- a/config/jobs/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
+++ b/config/jobs/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
@@ -150,7 +150,6 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
       preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
-      preset-venafi-tpp-credentials: "true"
       preset-retry-flakey-tests: "true"
       preset-disable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
@@ -208,7 +207,6 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
       preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
-      preset-venafi-tpp-credentials: "true"
       preset-retry-flakey-tests: "true"
       preset-disable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
@@ -266,7 +264,6 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
       preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
-      preset-venafi-tpp-credentials: "true"
       preset-retry-flakey-tests: "true"
       preset-disable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
@@ -324,7 +321,6 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
       preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
-      preset-venafi-tpp-credentials: "true"
       preset-retry-flakey-tests: "true"
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
@@ -382,7 +378,6 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
       preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
-      preset-venafi-tpp-credentials: "true"
       preset-retry-flakey-tests: "true"
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
@@ -440,7 +435,6 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
       preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
-      preset-venafi-tpp-credentials: "true"
       preset-retry-flakey-tests: "true"
       preset-disable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
@@ -498,7 +492,6 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
       preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
-      preset-venafi-tpp-credentials: "true"
       preset-retry-flakey-tests: "true"
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
@@ -542,11 +535,11 @@ presubmits:
   # An E2E test job to allow us to manually trigger the Venafi Cloud E2E tests
   # with the following GitHub comment:
   #
-  #  /test pull-cert-manager-e2e-v1-22-feature-issuers-venafi-cloud
+  #  /test pull-cert-manager-e2e-issuers-venafi-cloud-previous
   #
   # The regular presubmit jobs do not run Venafi Cloud e2e tests.
   #
-  - name: pull-cert-manager-e2e-v1-22-feature-issuers-venafi-cloud
+  - name: pull-cert-manager-e2e-issuers-venafi-cloud-previous
     always_run: false
     optional: true
     max_concurrency: 4
@@ -564,6 +557,68 @@ presubmits:
       preset-venafi-cloud-credentials: "true"
       preset-retry-flakey-tests: "true"
       preset-ginkgo-focus-venafi-cloud: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2
+        args:
+        - runner
+        - devel/ci-run-e2e.sh
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        env:
+        - name: K8S_VERSION
+          value: "1.22"
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+
+  # An E2E test job to allow us to manually trigger the Venafi TPP E2E tests
+  # with the following GitHub comment:
+  #
+  #  /test pull-cert-manager-e2e-issuers-venafi-tpp-previous
+  #
+  # The regular presubmit jobs do not run Venafi TPP e2e tests.
+  #
+  - name: pull-cert-manager-e2e-issuers-venafi-tpp-previous
+    always_run: false
+    optional: true
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    branches:
+    - release-1.5
+    annotations:
+      description: Runs the E2E tests with 'Venafi TPP' in name
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-venafi-tpp-credentials: "true"
+      preset-retry-flakey-tests: "true"
+      preset-ginkgo-focus-venafi-tpp: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210323-ad5071a-3.7.2


### PR DESCRIPTION
This PR ensures that Venafi TPP tests don't run together with the other tests so TPP instance failure doen't mean PR are blocked.

TPP tests now run once every 12hrs as well as can be run optionally.

Signed-off-by: irbekrm <irbekrm@gmail.com>