### PR TITLE
Builds kind image with kube 1.23

### DIFF
--- a/images/kind/build.sh
+++ b/images/kind/build.sh
@@ -20,7 +20,7 @@ set -o pipefail
 
 # Tag to check out in k/k repo. Kind will build Kubernetes binaries from that
 # tag and include in the built KIND image.
-KUBERNETES_VERSION=v1.22.0
+KUBERNETES_VERSION=v1.23.0-alpha.3
 # Version of the kind CLI to use to build the kind image.
 KIND_BASE_VERSION=v0.11.1
 


### PR DESCRIPTION
This PR builds a kind image from kube `v1.23.0-alpha.3` tag.

Kubernetes v1.23.0 will be released on 23rd of November ([release docs](https://www.kubernetes.dev/resources/release/)).
It would be good if this version was supported by both the 'current' and 'previous' cert-manager versions, once it's released, so it might make sense to start running some periodics against it now to catch any potential issues (I've built kind with kube 1.23 by hand and installed cert-manager which worked, but haven't done any other testing).

Next steps if this PR gets merged and an image built will be to add the kube version + image SHA [here](https://github.com/jetstack/cert-manager/blob/master/devel/cluster/create-kind.sh#L33-L55), then add some periodics that build against this version.


Signed-off-by: irbekrm <irbekrm@gmail.com>