### PR TITLE
bump kube version for our custom kind image

### DIFF
--- a/images/kind/build.sh
+++ b/images/kind/build.sh
@@ -20,7 +20,7 @@ set -o pipefail
 
 # Tag to check out in k/k repo. Kind will build Kubernetes binaries from that
 # tag and include in the built KIND image.
-KUBERNETES_VERSION=v1.23.0-alpha.3
+KUBERNETES_VERSION=v1.23.0-alpha.4
 # Version of the kind CLI to use to build the kind image.
 KIND_BASE_VERSION=v0.11.1
 


### PR DESCRIPTION
The latest kube 1.23 release now is 1.23-alpha.4, this PR builds a kind image for that version.

Once this gets merged, I will add a cert-manager e2e test using this kind image.

Signed-off-by: irbekrm <irbekrm@gmail.com>