### PR TITLE
Adds periodic and optional presubmit to e2e test cert-manager on kube 1.23

### DIFF
--- a/config/jobs/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager-periodics.yaml
@@ -327,6 +327,68 @@ periodics:
       - name: ndots
         value: "1"
 
+# This test runs cert-manager e2e tests against kube 1.23 alpha.4 release twice
+# a day. Change it to run every 2 hours like all other tests once kube 1.23 is
+# released and we no longer use alpha release.
+- name: ci-cert-manager-e2e-v1-23
+  interval: 12h
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: jetstack
+    repo: cert-manager
+    base_ref: master
+  annotations:
+    testgrid-create-test-group: 'true'
+    testgrid-dashboards: jetstack-cert-manager-master
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    description: Runs the end-to-end test suite against a Kubernetes v1.23 cluster
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-cloudflare-credentials: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+      args:
+      - runner
+      - devel/ci-run-e2e.sh
+      resources:
+        requests:
+          cpu: 3500m
+          memory: 12Gi
+      env:
+      - name: K8S_VERSION
+        value: "1.23"
+      securityContext:
+        privileged: true
+        capabilities:
+          add: ["SYS_ADMIN"]
+      volumeMounts:
+      - mountPath: /lib/modules
+        name: modules
+        readOnly: true
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    volumes:
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+
+
 # This test runs Venafi (VaaS and TPP) tests once every 12hrs.
 # This is the only CI test job that runs those.
 - name: ci-cert-manager-venafi

--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -518,8 +518,68 @@ presubmits:
         - name: ndots
           value: "1"
 
+  - name: pull-cert-manager-e2e-v1-23
+    context: pull-cert-manager-e2e-v1-23
+    always_run: false
+    optional: true
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    branches:
+    - master
+    - release-1.7
+    annotations:
+      testgrid-create-test-group: 'true'
+      testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
+      description: Runs the end-to-end test suite against a Kubernetes v1.23 cluster
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-cloudflare-credentials: "true"
+      preset-retry-flakey-tests: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+        args:
+        - runner
+        - devel/ci-run-e2e.sh
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        env:
+        - name: K8S_VERSION
+          value: "1.23"
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+
   # Verifies upgrade from the latest published release with both Helm chart and
-  # static manifests. This is an optional test.
+  # static manifests.
   - name: pull-cert-manager-upgrade
     # Run always
     always_run: true


### PR DESCRIPTION
This PR adds a periodic (once every 12 hrs) and an optional presubmit that run cert-manager e2e test on Kubernetes 1.23 (using a kind image built with Kubernetes1.23 alpha release). This is so that we can start testing cert-manager 1.7 against Kubernetes 1.23 as they will both be [released on 7th December](https://www.kubernetes.dev/resources/release/)

Signed-off-by: irbekrm <irbekrm@gmail.com>