### PR TITLE
Adds ExperimentalSecretApplySecretTemplateControllerMinKubernetesVTODO to cert-manager feature gate env vars

### DIFF
--- a/config/jobs/cert-manager/config.yaml
+++ b/config/jobs/cert-manager/config.yaml
@@ -85,13 +85,13 @@ presets:
     preset-disable-all-feature-gates: "true"
   env:
   - name: FEATURE_GATES
-    value: "ExperimentalCertificateSigningRequestControllers=false,ExperimentalGatewayAPISupport=false"
+    value: "ExperimentalCertificateSigningRequestControllers=false,ExperimentalGatewayAPISupport=false,ExperimentalSecretApplySecretTemplateControllerMinKubernetesVTODO=true"
 
 - labels:
     preset-enable-all-feature-gates: "true"
   env:
   - name: FEATURE_GATES
-    value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true"
+    value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true,ExperimentalSecretApplySecretTemplateControllerMinKubernetesVTODO=true"
 
 # Specific cert-manager e2e test suites can be skipped for all e2e tests here by
 # setting GINKGO_SKIP value i.e 'Venafi Cloud|Gateway' will skip all Venafi


### PR DESCRIPTION
Currently set to `true` in both feature groups to test which Kubernetes versions work with this feature.

The name currently has `vTODO` until we find out what is the minimum Kubernetes version this works with.

```release-note
NONE
``` 