### PR TITLE
Changes the cert-manager presubmit config for feature gates to use AllAlpha=[true,false]

### DIFF
--- a/config/jobs/cert-manager/config.yaml
+++ b/config/jobs/cert-manager/config.yaml
@@ -85,13 +85,13 @@ presets:
     preset-disable-all-feature-gates: "true"
   env:
   - name: FEATURE_GATES
-    value: "ExperimentalCertificateSigningRequestControllers=false,ExperimentalGatewayAPISupport=false,ExperimentalSecretApplySecretTemplateControllerMinKubernetesVTODO=true"
+    value: "AllAlpha=false"
 
 - labels:
     preset-enable-all-feature-gates: "true"
   env:
   - name: FEATURE_GATES
-    value: "ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true,ExperimentalSecretApplySecretTemplateControllerMinKubernetesVTODO=true"
+    value: "AllAlpha=true"
 
 # Specific cert-manager e2e test suites can be skipped for all e2e tests here by
 # setting GINKGO_SKIP value i.e 'Venafi Cloud|Gateway' will skip all Venafi


### PR DESCRIPTION
See https://github.com/jetstack/testing/pull/611#issuecomment-984790023

Change feature gate options to "all" so will always work, regardless of what features are registered on target PRs.

Signed-off-by: joshvanl <vleeuwenjoshua@gmail.com>