### PR TITLE
Makes kubernetes 1.23 the default version to run e2e tests against

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -64,7 +64,7 @@ branch-protection:
             - pull-cert-manager-bazel
             - pull-cert-manager-deps
             - pull-cert-manager-chart
-            - pull-cert-manager-e2e-v1-22
+            - pull-cert-manager-e2e-v1-23
 sinker:
   resync_period: 1h
   max_prowjob_age: 48h

--- a/config/jobs/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager-periodics.yaml
@@ -327,11 +327,8 @@ periodics:
       - name: ndots
         value: "1"
 
-# This test runs cert-manager e2e tests against kube 1.23 alpha.4 release twice
-# a day. Change it to run every 2 hours like all other tests once kube 1.23 is
-# released and we no longer use alpha release.
 - name: ci-cert-manager-e2e-v1-23
-  interval: 12h
+  interval: 2h
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -424,7 +421,7 @@ periodics:
           memory: 12Gi
       env:
       - name: K8S_VERSION
-        value: "1.22"
+        value: "1.23"
       securityContext:
         privileged: true
         capabilities:
@@ -483,7 +480,7 @@ periodics:
           memory: 12Gi
       env:
       - name: K8S_VERSION
-        value: "1.22"
+        value: "1.23"
       securityContext:
         privileged: true
         capabilities:

--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -459,9 +459,8 @@ presubmits:
 
   - name: pull-cert-manager-e2e-v1-22
     context: pull-cert-manager-e2e-v1-22
-    # This is the default e2e test for all PRs.
-    always_run: true
-    optional: false
+    always_run: false
+    optional: true
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -518,10 +517,11 @@ presubmits:
         - name: ndots
           value: "1"
 
+    # This is the default e2e test for all PRs.
   - name: pull-cert-manager-e2e-v1-23
     context: pull-cert-manager-e2e-v1-23
-    always_run: false
-    optional: true
+    always_run: true
+    optional: false
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -615,7 +615,7 @@ presubmits:
         env:
         # Used by https://github.com/jetstack/cert-manager/blob/master/devel/cluster/create-kind.sh
         - name: K8S_VERSION
-          value: "1.22"
+          value: "1.23"
         securityContext:
           privileged: true
           capabilities:
@@ -676,7 +676,7 @@ presubmits:
             memory: 12Gi
         env:
         - name: K8S_VERSION
-          value: "1.22"
+          value: "1.23"
         securityContext:
           privileged: true
           capabilities:
@@ -737,7 +737,7 @@ presubmits:
             memory: 12Gi
         env:
         - name: K8S_VERSION
-          value: "1.22"
+          value: "1.23"
         securityContext:
           privileged: true
           capabilities:

--- a/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
+++ b/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
@@ -418,7 +418,7 @@ periodics:
           memory: 12Gi
       env:
       - name: K8S_VERSION
-        value: "1.22"
+        value: "1.23"
       securityContext:
         privileged: true
         capabilities:
@@ -476,7 +476,7 @@ periodics:
           memory: 12Gi
       env:
       - name: K8S_VERSION
-        value: "1.22"
+        value: "1.23"
       securityContext:
         privileged: true
         capabilities:


### PR DESCRIPTION
This PR:
- makes Kubernetes 1.23 the default version to run e2e presubmit tests against
- makes 1.23 periodics run at the same interval as other periodics (2h)
- makes venafi periodics run against Kubernetes 1.23


Signed-off-by: irbekrm <irbekrm@gmail.com>