### PR TITLE
preset-disable-all-with-enable-certificate-addition-output-formats-feature-gates

### DIFF
--- a/config/jobs/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager-periodics.yaml
@@ -56,7 +56,7 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
-    preset-disable-all-feature-gates: "true"
+    preset-disable-all-output-formats-enable-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
   spec:
     containers:

--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -238,7 +238,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
       preset-retry-flakey-tests: "true"
-      preset-disable-all-feature-gates: "true"
+      preset-disable-all-output-formats-enable-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
     spec:
       containers:

--- a/config/jobs/cert-manager/config.yaml
+++ b/config/jobs/cert-manager/config.yaml
@@ -88,6 +88,12 @@ presets:
     value: "AllAlpha=false"
 
 - labels:
+    preset-disable-all-output-formats-enable-feature-gates: "true"
+  env:
+  - name: FEATURE_GATES
+    value: "AllAlpha=false,AdditionalCertificateOutputFormats=true"
+
+- labels:
     preset-enable-all-feature-gates: "true"
   env:
   - name: FEATURE_GATES


### PR DESCRIPTION
Currently, Additional Output Format tests on cert-manager are being skipped on Kubernetes versions targeting v1.18 since it is a Alpha feature gate. This feature should work fine however on kube v1.18.

Adds preset option in cert-manger for disabling all feature, but enabling Certificates Additional Output Formats. Sets for presubmit and periodics for cert-manager.

/assign @irbekrm 


Signed-off-by: joshvanl <vleeuwenjoshua@gmail.com>