### PR TITLE
use go 1.17 for website job

### DIFF
--- a/config/jobs/cert-manager/website/cert-manager-website-presubmits.yaml
+++ b/config/jobs/cert-manager/website/cert-manager-website-presubmits.yaml
@@ -15,7 +15,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: "eu.gcr.io/jetstack-build-infra-images/golang-nodejs:20210923-fe8699b-1.16.6"
+      - image: "eu.gcr.io/jetstack-build-infra-images/golang-nodejs:20210923-fe8699b-1.17"
         args:
         - ./scripts/verify-release
         resources:


### PR DESCRIPTION
Needed for: https://github.com/cert-manager/website/pull/800

We need to use the same go version as cert-manager, which is 1.17

Signed-off-by: Joakim Ahrlin <joakim.ahrlin@gmail.com>