### PR TITLE
Don't restrict which release branches can run presubmits

### DIFF
--- a/config/jobs/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
+++ b/config/jobs/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
@@ -9,6 +9,7 @@ presubmits:
     decorate: true
     branches:
     - release-1.6
+    - release-1.5
     annotations:
       testgrid-create-test-group: 'false'
     labels:
@@ -42,6 +43,7 @@ presubmits:
     decorate: true
     branches:
     - release-1.6
+    - release-1.5
     annotations:
       testgrid-create-test-group: 'false'
       description: Runs 'bazel test --jobs=1 //...' using the 'experimental' Bazel version
@@ -78,6 +80,7 @@ presubmits:
     decorate: true
     branches:
     - release-1.6
+    - release-1.5
     annotations:
       testgrid-create-test-group: 'false'
       description: Verifies the Helm chart passes linting checks
@@ -113,6 +116,7 @@ presubmits:
     decorate: true
     branches:
     - release-1.6
+    - release-1.5
     annotations:
       testgrid-create-test-group: 'false'
       description: Verifies dependency related files are up to date
@@ -145,6 +149,7 @@ presubmits:
     decorate: true
     branches:
     - release-1.6
+    - release-1.5
     annotations:
       testgrid-create-test-group: 'false'
       description: Runs the end-to-end test suite against a Kubernetes v1.17 cluster
@@ -203,6 +208,7 @@ presubmits:
     decorate: true
     branches:
     - release-1.6
+    - release-1.5
     annotations:
       testgrid-create-test-group: 'false'
       description: Runs the end-to-end test suite against a Kubernetes v1.18 cluster
@@ -261,6 +267,7 @@ presubmits:
     decorate: true
     branches:
     - release-1.6
+    - release-1.5
     annotations:
       testgrid-create-test-group: 'false'
       description: Runs the end-to-end test suite against a Kubernetes v1.19 cluster
@@ -319,6 +326,7 @@ presubmits:
     decorate: true
     branches:
     - release-1.6
+    - release-1.5
     annotations:
       testgrid-create-test-group: 'false'
       description: Runs the end-to-end test suite against a Kubernetes v1.20 cluster
@@ -377,6 +385,7 @@ presubmits:
     decorate: true
     branches:
     - release-1.6
+    - release-1.5
     annotations:
       testgrid-create-test-group: 'false'
       description: Runs the end-to-end test suite against a Kubernetes v1.21 cluster
@@ -436,6 +445,7 @@ presubmits:
     decorate: true
     branches:
     - release-1.6
+    - release-1.5
     annotations:
       testgrid-create-test-group: 'false'
       description: Runs the end-to-end test suite against a Kubernetes v1.22 cluster
@@ -500,6 +510,7 @@ presubmits:
     decorate: true
     branches:
     - release-1.6
+    - release-1.5
     annotations:
       description: Runs the E2E tests with 'Venafi TPP' in name
     labels:
@@ -562,6 +573,7 @@ presubmits:
     decorate: true
     branches:
     - release-1.6
+    - release-1.5
     annotations:
       description: Runs the E2E tests with 'Venafi Cloud' in name
     labels:


### PR DESCRIPTION
It is useful for patching the non-current releases to be able to run tests on the Kubernetes versions that this old version supported. It does not make sense to limit which branches can run the optional tests anyways.

For example, given that `release-1.7` is the next release, we should still be able to open PRs on release-1.5 and release-1.6 since we still support them.

I also forced the 1.23 not to appear in the GitHub required checks when a PR targetting release-1.5 is opened, since cert-manager 1.5 does not support 1.23.

Signed-off-by: Maël Valais <mael@vls.dev>