### PR TITLE
Bump prow configuration after cert-manager 1.7 release

### DIFF
--- a/config/jobs/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.7
+    - release-1.8
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
@@ -46,7 +46,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.7
+    - release-1.8
     annotations:
       testgrid-create-test-group: 'false'
       description: Runs 'bazel test --jobs=1 //...'
@@ -81,7 +81,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.7
+    - release-1.8
     annotations:
       testgrid-create-test-group: 'false'
       description: Runs 'bazel test --jobs=1 //...'
@@ -117,7 +117,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.7
+    - release-1.8
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
@@ -155,7 +155,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.7
+    - release-1.8
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
@@ -192,7 +192,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.7
+    - release-1.8
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
@@ -226,7 +226,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.7
+    - release-1.8
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
@@ -286,7 +286,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.7
+    - release-1.8
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
@@ -346,7 +346,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.7
+    - release-1.8
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
@@ -406,7 +406,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.7
+    - release-1.8
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
@@ -466,7 +466,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.7
+    - release-1.8
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
@@ -527,7 +527,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.7
+    - release-1.8
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
@@ -592,7 +592,7 @@ presubmits:
     decorate: true
     branches:
     - master
-    - release-1.7
+    - release-1.8
     annotations:
       description: Runs cert-manager upgrade from latest published release
     labels:

--- a/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
+++ b/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
@@ -1,502 +1,505 @@
-periodics:
+# These tests are disable until 1.8.0-alpha.0
+# Why? Because there's no point testing the release-1.8 branch until we release 1.8.0-alpha.0
+#
+# periodics:
 
-- name: ci-cert-manager-next-bazel
-  interval: 2h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: jetstack
-    repo: cert-manager
-    base_ref: release-1.7
-  labels:
-    preset-service-account: "true"
-    preset-bazel-remote-cache-enabled: "true"
-    preset-bazel-scratch-dir: "true"
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-next
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs 'bazel test --jobs=1 //...'
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-      args:
-      - runner
-      - bazel
-      - test
-      - --jobs=1
-      - //...
-      resources:
-        requests:
-          cpu: 2
-          memory: 4Gi
-    dnsConfig:
-      options:
-        - name: ndots
-          value: "1"
+# - name: ci-cert-manager-next-bazel
+#   interval: 2h
+#   agent: kubernetes
+#   decorate: true
+#   extra_refs:
+#   - org: jetstack
+#     repo: cert-manager
+#     base_ref: release-1.7
+#   labels:
+#     preset-service-account: "true"
+#     preset-bazel-remote-cache-enabled: "true"
+#     preset-bazel-scratch-dir: "true"
+#   annotations:
+#     testgrid-create-test-group: 'true'
+#     testgrid-dashboards: jetstack-cert-manager-next
+#     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+#     description: Runs 'bazel test --jobs=1 //...'
+#   spec:
+#     containers:
+#     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+#       args:
+#       - runner
+#       - bazel
+#       - test
+#       - --jobs=1
+#       - //...
+#       resources:
+#         requests:
+#           cpu: 2
+#           memory: 4Gi
+#     dnsConfig:
+#       options:
+#         - name: ndots
+#           value: "1"
 
-- name: ci-cert-manager-next-e2e-v1-18
-  interval: 2h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: jetstack
-    repo: cert-manager
-    base_ref: release-1.7
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-next
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs the end-to-end test suite against a Kubernetes v1.18 cluster
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-bazel-remote-cache-enabled: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-cloudflare-credentials: "true"
-    preset-disable-all-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-      args:
-      - runner
-      - devel/ci-run-e2e.sh
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 12Gi
-      env:
-      - name: K8S_VERSION
-        value: "1.18"
-      securityContext:
-        privileged: true
-        capabilities:
-          add: ["SYS_ADMIN"]
-      volumeMounts:
-      - mountPath: /lib/modules
-        name: modules
-        readOnly: true
-      - mountPath: /sys/fs/cgroup
-        name: cgroup
-    volumes:
-    - name: modules
-      hostPath:
-        path: /lib/modules
-        type: Directory
-    - name: cgroup
-      hostPath:
-        path: /sys/fs/cgroup
-        type: Directory
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
+# - name: ci-cert-manager-next-e2e-v1-18
+#   interval: 2h
+#   agent: kubernetes
+#   decorate: true
+#   extra_refs:
+#   - org: jetstack
+#     repo: cert-manager
+#     base_ref: release-1.7
+#   annotations:
+#     testgrid-create-test-group: 'true'
+#     testgrid-dashboards: jetstack-cert-manager-next
+#     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+#     description: Runs the end-to-end test suite against a Kubernetes v1.18 cluster
+#   labels:
+#     preset-service-account: "true"
+#     preset-dind-enabled: "true"
+#     preset-bazel-remote-cache-enabled: "true"
+#     preset-bazel-scratch-dir: "true"
+#     preset-cloudflare-credentials: "true"
+#     preset-disable-all-feature-gates: "true"
+#     preset-ginkgo-skip-default: "true"
+#   spec:
+#     containers:
+#     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+#       args:
+#       - runner
+#       - devel/ci-run-e2e.sh
+#       resources:
+#         requests:
+#           cpu: 3500m
+#           memory: 12Gi
+#       env:
+#       - name: K8S_VERSION
+#         value: "1.18"
+#       securityContext:
+#         privileged: true
+#         capabilities:
+#           add: ["SYS_ADMIN"]
+#       volumeMounts:
+#       - mountPath: /lib/modules
+#         name: modules
+#         readOnly: true
+#       - mountPath: /sys/fs/cgroup
+#         name: cgroup
+#     volumes:
+#     - name: modules
+#       hostPath:
+#         path: /lib/modules
+#         type: Directory
+#     - name: cgroup
+#       hostPath:
+#         path: /sys/fs/cgroup
+#         type: Directory
+#     dnsConfig:
+#       options:
+#       - name: ndots
+#         value: "1"
 
-- name: ci-cert-manager-next-e2e-v1-19
-  interval: 2h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: jetstack
-    repo: cert-manager
-    base_ref: release-1.7
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-next
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs the end-to-end test suite against a Kubernetes v1.19 cluster
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-bazel-remote-cache-enabled: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-cloudflare-credentials: "true"
-    preset-enable-all-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-      args:
-      - runner
-      - devel/ci-run-e2e.sh
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 12Gi
-      env:
-      - name: K8S_VERSION
-        value: "1.19"
-      securityContext:
-        privileged: true
-        capabilities:
-          add: ["SYS_ADMIN"]
-      volumeMounts:
-      - mountPath: /lib/modules
-        name: modules
-        readOnly: true
-      - mountPath: /sys/fs/cgroup
-        name: cgroup
-    volumes:
-    - name: modules
-      hostPath:
-        path: /lib/modules
-        type: Directory
-    - name: cgroup
-      hostPath:
-        path: /sys/fs/cgroup
-        type: Directory
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
+# - name: ci-cert-manager-next-e2e-v1-19
+#   interval: 2h
+#   agent: kubernetes
+#   decorate: true
+#   extra_refs:
+#   - org: jetstack
+#     repo: cert-manager
+#     base_ref: release-1.7
+#   annotations:
+#     testgrid-create-test-group: 'true'
+#     testgrid-dashboards: jetstack-cert-manager-next
+#     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+#     description: Runs the end-to-end test suite against a Kubernetes v1.19 cluster
+#   labels:
+#     preset-service-account: "true"
+#     preset-dind-enabled: "true"
+#     preset-bazel-remote-cache-enabled: "true"
+#     preset-bazel-scratch-dir: "true"
+#     preset-cloudflare-credentials: "true"
+#     preset-enable-all-feature-gates: "true"
+#     preset-ginkgo-skip-default: "true"
+#   spec:
+#     containers:
+#     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+#       args:
+#       - runner
+#       - devel/ci-run-e2e.sh
+#       resources:
+#         requests:
+#           cpu: 3500m
+#           memory: 12Gi
+#       env:
+#       - name: K8S_VERSION
+#         value: "1.19"
+#       securityContext:
+#         privileged: true
+#         capabilities:
+#           add: ["SYS_ADMIN"]
+#       volumeMounts:
+#       - mountPath: /lib/modules
+#         name: modules
+#         readOnly: true
+#       - mountPath: /sys/fs/cgroup
+#         name: cgroup
+#     volumes:
+#     - name: modules
+#       hostPath:
+#         path: /lib/modules
+#         type: Directory
+#     - name: cgroup
+#       hostPath:
+#         path: /sys/fs/cgroup
+#         type: Directory
+#     dnsConfig:
+#       options:
+#       - name: ndots
+#         value: "1"
 
-- name: ci-cert-manager-next-e2e-v1-20
-  interval: 2h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: jetstack
-    repo: cert-manager
-    base_ref: release-1.7
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-next
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs the end-to-end test suite against a Kubernetes v1.20 cluster
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-bazel-remote-cache-enabled: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-cloudflare-credentials: "true"
-    preset-enable-all-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-      args:
-      - runner
-      - devel/ci-run-e2e.sh
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 12Gi
-      env:
-      - name: K8S_VERSION
-        value: "1.20"
-      securityContext:
-        privileged: true
-        capabilities:
-          add: ["SYS_ADMIN"]
-      volumeMounts:
-      - mountPath: /lib/modules
-        name: modules
-        readOnly: true
-      - mountPath: /sys/fs/cgroup
-        name: cgroup
-    volumes:
-    - name: modules
-      hostPath:
-        path: /lib/modules
-        type: Directory
-    - name: cgroup
-      hostPath:
-        path: /sys/fs/cgroup
-        type: Directory
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
+# - name: ci-cert-manager-next-e2e-v1-20
+#   interval: 2h
+#   agent: kubernetes
+#   decorate: true
+#   extra_refs:
+#   - org: jetstack
+#     repo: cert-manager
+#     base_ref: release-1.7
+#   annotations:
+#     testgrid-create-test-group: 'true'
+#     testgrid-dashboards: jetstack-cert-manager-next
+#     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+#     description: Runs the end-to-end test suite against a Kubernetes v1.20 cluster
+#   labels:
+#     preset-service-account: "true"
+#     preset-dind-enabled: "true"
+#     preset-bazel-remote-cache-enabled: "true"
+#     preset-bazel-scratch-dir: "true"
+#     preset-cloudflare-credentials: "true"
+#     preset-enable-all-feature-gates: "true"
+#     preset-ginkgo-skip-default: "true"
+#   spec:
+#     containers:
+#     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+#       args:
+#       - runner
+#       - devel/ci-run-e2e.sh
+#       resources:
+#         requests:
+#           cpu: 3500m
+#           memory: 12Gi
+#       env:
+#       - name: K8S_VERSION
+#         value: "1.20"
+#       securityContext:
+#         privileged: true
+#         capabilities:
+#           add: ["SYS_ADMIN"]
+#       volumeMounts:
+#       - mountPath: /lib/modules
+#         name: modules
+#         readOnly: true
+#       - mountPath: /sys/fs/cgroup
+#         name: cgroup
+#     volumes:
+#     - name: modules
+#       hostPath:
+#         path: /lib/modules
+#         type: Directory
+#     - name: cgroup
+#       hostPath:
+#         path: /sys/fs/cgroup
+#         type: Directory
+#     dnsConfig:
+#       options:
+#       - name: ndots
+#         value: "1"
 
-- name: ci-cert-manager-next-e2e-v1-21
-  interval: 2h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: jetstack
-    repo: cert-manager
-    base_ref: release-1.7
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-next
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs the end-to-end test suite against a Kubernetes v1.21 cluster
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-bazel-remote-cache-enabled: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-cloudflare-credentials: "true"
-    preset-enable-all-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-      args:
-      - runner
-      - devel/ci-run-e2e.sh
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 12Gi
-      env:
-      - name: K8S_VERSION
-        value: "1.21"
-      securityContext:
-        privileged: true
-        capabilities:
-          add: ["SYS_ADMIN"]
-      volumeMounts:
-      - mountPath: /lib/modules
-        name: modules
-        readOnly: true
-      - mountPath: /sys/fs/cgroup
-        name: cgroup
-    volumes:
-    - name: modules
-      hostPath:
-        path: /lib/modules
-        type: Directory
-    - name: cgroup
-      hostPath:
-        path: /sys/fs/cgroup
-        type: Directory
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
+# - name: ci-cert-manager-next-e2e-v1-21
+#   interval: 2h
+#   agent: kubernetes
+#   decorate: true
+#   extra_refs:
+#   - org: jetstack
+#     repo: cert-manager
+#     base_ref: release-1.7
+#   annotations:
+#     testgrid-create-test-group: 'true'
+#     testgrid-dashboards: jetstack-cert-manager-next
+#     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+#     description: Runs the end-to-end test suite against a Kubernetes v1.21 cluster
+#   labels:
+#     preset-service-account: "true"
+#     preset-dind-enabled: "true"
+#     preset-bazel-remote-cache-enabled: "true"
+#     preset-bazel-scratch-dir: "true"
+#     preset-cloudflare-credentials: "true"
+#     preset-enable-all-feature-gates: "true"
+#     preset-ginkgo-skip-default: "true"
+#   spec:
+#     containers:
+#     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+#       args:
+#       - runner
+#       - devel/ci-run-e2e.sh
+#       resources:
+#         requests:
+#           cpu: 3500m
+#           memory: 12Gi
+#       env:
+#       - name: K8S_VERSION
+#         value: "1.21"
+#       securityContext:
+#         privileged: true
+#         capabilities:
+#           add: ["SYS_ADMIN"]
+#       volumeMounts:
+#       - mountPath: /lib/modules
+#         name: modules
+#         readOnly: true
+#       - mountPath: /sys/fs/cgroup
+#         name: cgroup
+#     volumes:
+#     - name: modules
+#       hostPath:
+#         path: /lib/modules
+#         type: Directory
+#     - name: cgroup
+#       hostPath:
+#         path: /sys/fs/cgroup
+#         type: Directory
+#     dnsConfig:
+#       options:
+#       - name: ndots
+#         value: "1"
 
-- name: ci-cert-manager-next-e2e-v1-22
-  interval: 2h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: jetstack
-    repo: cert-manager
-    base_ref: release-1.7
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-next
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs the end-to-end test suite against a Kubernetes v1.22 cluster
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-bazel-remote-cache-enabled: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-cloudflare-credentials: "true"
-    preset-enable-all-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-      args:
-      - runner
-      - devel/ci-run-e2e.sh
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 12Gi
-      env:
-      - name: K8S_VERSION
-        value: "1.22"
-      securityContext:
-        privileged: true
-        capabilities:
-          add: ["SYS_ADMIN"]
-      volumeMounts:
-      - mountPath: /lib/modules
-        name: modules
-        readOnly: true
-      - mountPath: /sys/fs/cgroup
-        name: cgroup
-    volumes:
-    - name: modules
-      hostPath:
-        path: /lib/modules
-        type: Directory
-    - name: cgroup
-      hostPath:
-        path: /sys/fs/cgroup
-        type: Directory
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
+# - name: ci-cert-manager-next-e2e-v1-22
+#   interval: 2h
+#   agent: kubernetes
+#   decorate: true
+#   extra_refs:
+#   - org: jetstack
+#     repo: cert-manager
+#     base_ref: release-1.7
+#   annotations:
+#     testgrid-create-test-group: 'true'
+#     testgrid-dashboards: jetstack-cert-manager-next
+#     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+#     description: Runs the end-to-end test suite against a Kubernetes v1.22 cluster
+#   labels:
+#     preset-service-account: "true"
+#     preset-dind-enabled: "true"
+#     preset-bazel-remote-cache-enabled: "true"
+#     preset-bazel-scratch-dir: "true"
+#     preset-cloudflare-credentials: "true"
+#     preset-enable-all-feature-gates: "true"
+#     preset-ginkgo-skip-default: "true"
+#   spec:
+#     containers:
+#     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+#       args:
+#       - runner
+#       - devel/ci-run-e2e.sh
+#       resources:
+#         requests:
+#           cpu: 3500m
+#           memory: 12Gi
+#       env:
+#       - name: K8S_VERSION
+#         value: "1.22"
+#       securityContext:
+#         privileged: true
+#         capabilities:
+#           add: ["SYS_ADMIN"]
+#       volumeMounts:
+#       - mountPath: /lib/modules
+#         name: modules
+#         readOnly: true
+#       - mountPath: /sys/fs/cgroup
+#         name: cgroup
+#     volumes:
+#     - name: modules
+#       hostPath:
+#         path: /lib/modules
+#         type: Directory
+#     - name: cgroup
+#       hostPath:
+#         path: /sys/fs/cgroup
+#         type: Directory
+#     dnsConfig:
+#       options:
+#       - name: ndots
+#         value: "1"
 
-- name: ci-cert-manager-next-e2e-v1-23
-  interval: 2h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: jetstack
-    repo: cert-manager
-    base_ref: release-1.7
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-next
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs the end-to-end test suite against a Kubernetes v1.23 cluster
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-bazel-remote-cache-enabled: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-cloudflare-credentials: "true"
-    preset-enable-all-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-      args:
-      - runner
-      - devel/ci-run-e2e.sh
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 12Gi
-      env:
-      - name: K8S_VERSION
-        value: "1.23"
-      securityContext:
-        privileged: true
-        capabilities:
-          add: ["SYS_ADMIN"]
-      volumeMounts:
-      - mountPath: /lib/modules
-        name: modules
-        readOnly: true
-      - mountPath: /sys/fs/cgroup
-        name: cgroup
-    volumes:
-    - name: modules
-      hostPath:
-        path: /lib/modules
-        type: Directory
-    - name: cgroup
-      hostPath:
-        path: /sys/fs/cgroup
-        type: Directory
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
+# - name: ci-cert-manager-next-e2e-v1-23
+#   interval: 2h
+#   agent: kubernetes
+#   decorate: true
+#   extra_refs:
+#   - org: jetstack
+#     repo: cert-manager
+#     base_ref: release-1.7
+#   annotations:
+#     testgrid-create-test-group: 'true'
+#     testgrid-dashboards: jetstack-cert-manager-next
+#     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+#     description: Runs the end-to-end test suite against a Kubernetes v1.23 cluster
+#   labels:
+#     preset-service-account: "true"
+#     preset-dind-enabled: "true"
+#     preset-bazel-remote-cache-enabled: "true"
+#     preset-bazel-scratch-dir: "true"
+#     preset-cloudflare-credentials: "true"
+#     preset-enable-all-feature-gates: "true"
+#     preset-ginkgo-skip-default: "true"
+#   spec:
+#     containers:
+#     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+#       args:
+#       - runner
+#       - devel/ci-run-e2e.sh
+#       resources:
+#         requests:
+#           cpu: 3500m
+#           memory: 12Gi
+#       env:
+#       - name: K8S_VERSION
+#         value: "1.23"
+#       securityContext:
+#         privileged: true
+#         capabilities:
+#           add: ["SYS_ADMIN"]
+#       volumeMounts:
+#       - mountPath: /lib/modules
+#         name: modules
+#         readOnly: true
+#       - mountPath: /sys/fs/cgroup
+#         name: cgroup
+#     volumes:
+#     - name: modules
+#       hostPath:
+#         path: /lib/modules
+#         type: Directory
+#     - name: cgroup
+#       hostPath:
+#         path: /sys/fs/cgroup
+#         type: Directory
+#     dnsConfig:
+#       options:
+#       - name: ndots
+#         value: "1"
 
-# This test runs Venafi (VaaS and TPP) tests once every 24hrs.
-# This is the only CI test job that runs those.
-- name: ci-cert-manager-next-venafi
-  interval: 24h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: jetstack
-    repo: cert-manager
-    base_ref: release-1.7
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-master
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs Venafi (VaaS and TPP) e2e tests against Kubernetes v1.22 cluster
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-bazel-remote-cache-enabled: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-venafi-cloud-credentials: "true"
-    preset-venafi-tpp-credentials: "true"
-    preset-ginkgo-focus-venafi: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-      args:
-      - runner
-      - devel/ci-run-e2e.sh
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 12Gi
-      env:
-      - name: K8S_VERSION
-        value: "1.23"
-      securityContext:
-        privileged: true
-        capabilities:
-          add: ["SYS_ADMIN"]
-      volumeMounts:
-      - mountPath: /lib/modules
-        name: modules
-        readOnly: true
-      - mountPath: /sys/fs/cgroup
-        name: cgroup
-    volumes:
-    - name: modules
-      hostPath:
-        path: /lib/modules
-        type: Directory
-    - name: cgroup
-      hostPath:
-        path: /sys/fs/cgroup
-        type: Directory
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
+# # This test runs Venafi (VaaS and TPP) tests once every 24hrs.
+# # This is the only CI test job that runs those.
+# - name: ci-cert-manager-next-venafi
+#   interval: 24h
+#   agent: kubernetes
+#   decorate: true
+#   extra_refs:
+#   - org: jetstack
+#     repo: cert-manager
+#     base_ref: release-1.7
+#   annotations:
+#     testgrid-create-test-group: 'true'
+#     testgrid-dashboards: jetstack-cert-manager-master
+#     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+#     description: Runs Venafi (VaaS and TPP) e2e tests against Kubernetes v1.22 cluster
+#   labels:
+#     preset-service-account: "true"
+#     preset-dind-enabled: "true"
+#     preset-bazel-remote-cache-enabled: "true"
+#     preset-bazel-scratch-dir: "true"
+#     preset-venafi-cloud-credentials: "true"
+#     preset-venafi-tpp-credentials: "true"
+#     preset-ginkgo-focus-venafi: "true"
+#   spec:
+#     containers:
+#     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+#       args:
+#       - runner
+#       - devel/ci-run-e2e.sh
+#       resources:
+#         requests:
+#           cpu: 3500m
+#           memory: 12Gi
+#       env:
+#       - name: K8S_VERSION
+#         value: "1.23"
+#       securityContext:
+#         privileged: true
+#         capabilities:
+#           add: ["SYS_ADMIN"]
+#       volumeMounts:
+#       - mountPath: /lib/modules
+#         name: modules
+#         readOnly: true
+#       - mountPath: /sys/fs/cgroup
+#         name: cgroup
+#     volumes:
+#     - name: modules
+#       hostPath:
+#         path: /lib/modules
+#         type: Directory
+#     - name: cgroup
+#       hostPath:
+#         path: /sys/fs/cgroup
+#         type: Directory
+#     dnsConfig:
+#       options:
+#       - name: ndots
+#         value: "1"
 
-- name: ci-cert-manager-next-upgrade
-  interval: 8h
-  agent: kubernetes
-  decorate: true
-  # extra refs specify what repo should be cloned
-  extra_refs:
-  - org: jetstack
-    repo: cert-manager
-    base_ref: release-1.7
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-master
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs cert-manager upgrade test every 8 hours
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-bazel-remote-cache-enabled: "true"
-    preset-bazel-scratch-dir: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-      args:
-      - runner
-      - make
-      - cluster
-      - verify_upgrade
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 12Gi
-      env:
-      - name: K8S_VERSION
-        value: "1.23"
-      securityContext:
-        privileged: true
-        capabilities:
-          add: ["SYS_ADMIN"]
-      volumeMounts:
-      - mountPath: /lib/modules
-        name: modules
-        readOnly: true
-      - mountPath: /sys/fs/cgroup
-        name: cgroup
-    volumes:
-    - name: modules
-      hostPath:
-        path: /lib/modules
-        type: Directory
-    - name: cgroup
-      hostPath:
-        path: /sys/fs/cgroup
-        type: Directory
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
+# - name: ci-cert-manager-next-upgrade
+#   interval: 8h
+#   agent: kubernetes
+#   decorate: true
+#   # extra refs specify what repo should be cloned
+#   extra_refs:
+#   - org: jetstack
+#     repo: cert-manager
+#     base_ref: release-1.7
+#   annotations:
+#     testgrid-create-test-group: 'true'
+#     testgrid-dashboards: jetstack-cert-manager-master
+#     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+#     description: Runs cert-manager upgrade test every 8 hours
+#   labels:
+#     preset-service-account: "true"
+#     preset-dind-enabled: "true"
+#     preset-bazel-remote-cache-enabled: "true"
+#     preset-bazel-scratch-dir: "true"
+#   spec:
+#     containers:
+#     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+#       args:
+#       - runner
+#       - make
+#       - cluster
+#       - verify_upgrade
+#       resources:
+#         requests:
+#           cpu: 3500m
+#           memory: 12Gi
+#       env:
+#       - name: K8S_VERSION
+#         value: "1.23"
+#       securityContext:
+#         privileged: true
+#         capabilities:
+#           add: ["SYS_ADMIN"]
+#       volumeMounts:
+#       - mountPath: /lib/modules
+#         name: modules
+#         readOnly: true
+#       - mountPath: /sys/fs/cgroup
+#         name: cgroup
+#     volumes:
+#     - name: modules
+#       hostPath:
+#         path: /lib/modules
+#         type: Directory
+#     - name: cgroup
+#       hostPath:
+#         path: /sys/fs/cgroup
+#         type: Directory
+#     dnsConfig:
+#       options:
+#       - name: ndots
+#         value: "1"

--- a/config/jobs/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
+++ b/config/jobs/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
@@ -38,64 +38,6 @@ periodics:
 # Re-add bazel-experimental periodics once Bazel v5.0.0 is released and we have
 # a bazelbuild image with that https://github.com/bazelbuild/bazel/releases
 
-- name: ci-cert-manager-previous-e2e-v1-17
-  interval: 2h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: jetstack
-    repo: cert-manager
-    base_ref: release-1.7
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs the end-to-end test suite against a Kubernetes v1.17 cluster
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-bazel-remote-cache-enabled: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-cloudflare-credentials: "true"
-    preset-disable-all-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-      args:
-      - runner
-      - devel/ci-run-e2e.sh
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 12Gi
-      env:
-      - name: K8S_VERSION
-        value: "1.17"
-      securityContext:
-        privileged: true
-        capabilities:
-          add: ["SYS_ADMIN"]
-      volumeMounts:
-      - mountPath: /lib/modules
-        name: modules
-        readOnly: true
-      - mountPath: /sys/fs/cgroup
-        name: cgroup
-    volumes:
-    - name: modules
-      hostPath:
-        path: /lib/modules
-        type: Directory
-    - name: cgroup
-      hostPath:
-        path: /sys/fs/cgroup
-        type: Directory
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
-
 - name: ci-cert-manager-previous-e2e-v1-18
   interval: 2h
   agent: kubernetes
@@ -386,6 +328,64 @@ periodics:
       - name: ndots
         value: "1"
 
+- name: ci-cert-manager-previous-e2e-v1-23
+  interval: 2h
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: jetstack
+    repo: cert-manager
+    base_ref: release-1.7
+  annotations:
+    testgrid-create-test-group: 'true'
+    testgrid-dashboards: jetstack-cert-manager-previous
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    description: Runs the end-to-end test suite against a Kubernetes v1.23 cluster
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-cloudflare-credentials: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+      args:
+      - runner
+      - devel/ci-run-e2e.sh
+      resources:
+        requests:
+          cpu: 3500m
+          memory: 12Gi
+      env:
+      - name: K8S_VERSION
+        value: "1.23"
+      securityContext:
+        privileged: true
+        capabilities:
+          add: ["SYS_ADMIN"]
+      volumeMounts:
+      - mountPath: /lib/modules
+        name: modules
+        readOnly: true
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    volumes:
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+
 # This test runs Venafi (VaaS and TPP) tests once every 24hrs. This is the only CI test
 # job that runs those periodically against release-previous.
 - name: ci-cert-manager-previous-venafi
@@ -400,7 +400,7 @@ periodics:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs Venafi (VaaS and TPP) e2e tests against Kubernetes v1.22 cluster
+    description: Runs Venafi (VaaS and TPP) e2e tests against Kubernetes v1.23 cluster
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
@@ -421,7 +421,7 @@ periodics:
           memory: 12Gi
       env:
       - name: K8S_VERSION
-        value: "1.22"
+        value: "1.23"
       securityContext:
         privileged: true
         capabilities:
@@ -480,7 +480,7 @@ periodics:
           memory: 12Gi
       env:
       - name: K8S_VERSION
-        value: "1.22"
+        value: "1.23"
       securityContext:
         privileged: true
         capabilities:

--- a/config/jobs/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
+++ b/config/jobs/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.6
+    base_ref: release-1.7
   labels:
     preset-service-account: "true"
     preset-bazel-remote-cache-enabled: "true"
@@ -45,7 +45,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.6
+    base_ref: release-1.7
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
@@ -103,7 +103,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.6
+    base_ref: release-1.7
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
@@ -161,7 +161,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.6
+    base_ref: release-1.7
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
@@ -219,7 +219,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.6
+    base_ref: release-1.7
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
@@ -277,7 +277,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.6
+    base_ref: release-1.7
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
@@ -335,7 +335,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.6
+    base_ref: release-1.7
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
@@ -395,7 +395,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.6
+    base_ref: release-1.7
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
@@ -455,7 +455,7 @@ periodics:
   extra_refs:
   - org: jetstack
     repo: cert-manager
-    base_ref: release-1.6
+    base_ref: release-1.7
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous

--- a/config/jobs/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
+++ b/config/jobs/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
@@ -8,8 +8,8 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
+    - release-1.7
     - release-1.6
-    - release-1.5
     annotations:
       testgrid-create-test-group: 'false'
     labels:
@@ -42,8 +42,8 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
+    - release-1.7
     - release-1.6
-    - release-1.5
     annotations:
       testgrid-create-test-group: 'false'
       description: Runs 'bazel test --jobs=1 //...' using the 'experimental' Bazel version
@@ -79,8 +79,8 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
+    - release-1.7
     - release-1.6
-    - release-1.5
     annotations:
       testgrid-create-test-group: 'false'
       description: Verifies the Helm chart passes linting checks
@@ -115,8 +115,8 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
+    - release-1.7
     - release-1.6
-    - release-1.5
     annotations:
       testgrid-create-test-group: 'false'
       description: Verifies dependency related files are up to date
@@ -148,8 +148,8 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
+    - release-1.7
     - release-1.6
-    - release-1.5
     annotations:
       testgrid-create-test-group: 'false'
       description: Runs the end-to-end test suite against a Kubernetes v1.17 cluster
@@ -207,8 +207,8 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
+    - release-1.7
     - release-1.6
-    - release-1.5
     annotations:
       testgrid-create-test-group: 'false'
       description: Runs the end-to-end test suite against a Kubernetes v1.18 cluster
@@ -266,8 +266,8 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
+    - release-1.7
     - release-1.6
-    - release-1.5
     annotations:
       testgrid-create-test-group: 'false'
       description: Runs the end-to-end test suite against a Kubernetes v1.19 cluster
@@ -325,8 +325,8 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
+    - release-1.7
     - release-1.6
-    - release-1.5
     annotations:
       testgrid-create-test-group: 'false'
       description: Runs the end-to-end test suite against a Kubernetes v1.20 cluster
@@ -384,8 +384,8 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
+    - release-1.7
     - release-1.6
-    - release-1.5
     annotations:
       testgrid-create-test-group: 'false'
       description: Runs the end-to-end test suite against a Kubernetes v1.21 cluster
@@ -444,8 +444,8 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
+    - release-1.7
     - release-1.6
-    - release-1.5
     annotations:
       testgrid-create-test-group: 'false'
       description: Runs the end-to-end test suite against a Kubernetes v1.22 cluster
@@ -509,8 +509,8 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
+    - release-1.7
     - release-1.6
-    - release-1.5
     annotations:
       description: Runs the E2E tests with 'Venafi TPP' in name
     labels:
@@ -572,8 +572,8 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
+    - release-1.7
     - release-1.6
-    - release-1.5
     annotations:
       description: Runs the E2E tests with 'Venafi Cloud' in name
     labels:

--- a/config/jobs/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
+++ b/config/jobs/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
@@ -140,15 +140,16 @@ presubmits:
           - name: ndots
             value: "1"
 
+  # 1.7 requires at least K8S 1.18 so this will be run only for the release-1.6
+  # branch.
   - name: pull-cert-manager-e2e-v1-17
     context: pull-cert-manager-e2e-v1-17
-    always_run: false
+    always_run: true
     optional: true
     max_concurrency: 4
     agent: kubernetes
     decorate: true
     branches:
-    - release-1.7
     - release-1.6
     annotations:
       testgrid-create-test-group: 'false'
@@ -437,6 +438,65 @@ presubmits:
 
   - name: pull-cert-manager-e2e-v1-22
     context: pull-cert-manager-e2e-v1-22
+    always_run: false
+    optional: true
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    branches:
+    - release-1.7
+    - release-1.6
+    annotations:
+      testgrid-create-test-group: 'false'
+      description: Runs the end-to-end test suite against a Kubernetes v1.21 cluster
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-cloudflare-credentials: "true"
+      preset-retry-flakey-tests: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+        args:
+        - runner
+        - devel/ci-run-e2e.sh
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        env:
+        - name: K8S_VERSION
+          value: "1.22"
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+
+  - name: pull-cert-manager-e2e-v1-23
+    context: pull-cert-manager-e2e-v1-23
     # This is the default e2e test for all PRs.
     always_run: true
     optional: false
@@ -470,7 +530,7 @@ presubmits:
             memory: 12Gi
         env:
         - name: K8S_VERSION
-          value: "1.22"
+          value: "1.23"
         securityContext:
           privileged: true
           capabilities:
@@ -533,7 +593,7 @@ presubmits:
             memory: 12Gi
         env:
         - name: K8S_VERSION
-          value: "1.22"
+          value: "1.23"
         securityContext:
           privileged: true
           capabilities:
@@ -596,7 +656,7 @@ presubmits:
             memory: 12Gi
         env:
         - name: K8S_VERSION
-          value: "1.22"
+          value: "1.23"
         securityContext:
           privileged: true
           capabilities:

--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -68,7 +68,8 @@ repo_milestone:
 
 milestone_applier:
   jetstack/cert-manager:
-    master: v1.7
+    master: v1.8
+    release-1.7: v1.7
     release-1.6: v1.6
     release-1.5: v1.5
     release-1.4: v1.4
@@ -88,9 +89,10 @@ milestone_applier:
   cert-manager/website:
     # cert-manager/website uses master branch for 'current' version and the
     # release-next branch for the 'next' version
-    release-next: v1.7
-    master: v1.6
+    release-next: v1.8
+    master: v1.7
     # Older versions are archived into named release branches
+    release-1.6: v1.6
     release-1.5: v1.5
     release-1.4: v1.4
     release-1.3: v1.3


### PR DESCRIPTION
Based on:

* https://github.com/jetstack/testing/pull/605

But in addition I've
* disabled the release-next periodics (as described in https://cert-manager.io/docs/contributing/release-process/)
* Updated the K8S versions in the release-previous presubmits to match the requirements of both 1.6 and 1.7