### PR TITLE
Test csi-lib with Go 1.17

### DIFF
--- a/config/jobs/cert-manager/csi-lib/cert-manager-csi-lib-presubmits.yaml
+++ b/config/jobs/cert-manager/csi-lib/cert-manager-csi-lib-presubmits.yaml
@@ -13,7 +13,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: golang:1.16.4
+      - image: golang:1.17.6
         args:
         - ./hack/verify-all.sh
         resources:


### PR DESCRIPTION
In upgrading csi-lib to depend on cert-manager 1.7 it dragged in a library which will only compile with Go 1.17

 * https://github.com/cert-manager/csi-lib/pull/19#discussion_r792119518
 * https://github.com/kubernetes-sigs/json/issues/8