### PR TITLE
Re-enable the release-next periodic tests

### DIFF
--- a/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
+++ b/config/jobs/cert-manager/release-next/cert-manager-release-next-periodics.yaml
@@ -1,505 +1,505 @@
-# These tests are disable until 1.8.0-alpha.0
-# Why? Because there's no point testing the release-1.8 branch until we release 1.8.0-alpha.0
+# These tests are configured to only run weekly for now.
+# Why? Because there's no point testing the release-1.8 branch until we do the first 1.8 release: 1.8.0-alpha.0
+# See Step 13.3 in https://cert-manager.io/docs/contributing/release-process/
 #
-# periodics:
+periodics:
+- name: ci-cert-manager-next-bazel
+  interval: 168h # 1 week
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: jetstack
+    repo: cert-manager
+    base_ref: release-1.8
+  labels:
+    preset-service-account: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-bazel-scratch-dir: "true"
+  annotations:
+    testgrid-create-test-group: 'true'
+    testgrid-dashboards: jetstack-cert-manager-next
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    description: Runs 'bazel test --jobs=1 //...'
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+      args:
+      - runner
+      - bazel
+      - test
+      - --jobs=1
+      - //...
+      resources:
+        requests:
+          cpu: 2
+          memory: 4Gi
+    dnsConfig:
+      options:
+        - name: ndots
+          value: "1"
 
-# - name: ci-cert-manager-next-bazel
-#   interval: 2h
-#   agent: kubernetes
-#   decorate: true
-#   extra_refs:
-#   - org: jetstack
-#     repo: cert-manager
-#     base_ref: release-1.7
-#   labels:
-#     preset-service-account: "true"
-#     preset-bazel-remote-cache-enabled: "true"
-#     preset-bazel-scratch-dir: "true"
-#   annotations:
-#     testgrid-create-test-group: 'true'
-#     testgrid-dashboards: jetstack-cert-manager-next
-#     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-#     description: Runs 'bazel test --jobs=1 //...'
-#   spec:
-#     containers:
-#     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-#       args:
-#       - runner
-#       - bazel
-#       - test
-#       - --jobs=1
-#       - //...
-#       resources:
-#         requests:
-#           cpu: 2
-#           memory: 4Gi
-#     dnsConfig:
-#       options:
-#         - name: ndots
-#           value: "1"
+- name: ci-cert-manager-next-e2e-v1-18
+  interval: 168h # 1 week
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: jetstack
+    repo: cert-manager
+    base_ref: release-1.8
+  annotations:
+    testgrid-create-test-group: 'true'
+    testgrid-dashboards: jetstack-cert-manager-next
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    description: Runs the end-to-end test suite against a Kubernetes v1.18 cluster
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-cloudflare-credentials: "true"
+    preset-disable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+      args:
+      - runner
+      - devel/ci-run-e2e.sh
+      resources:
+        requests:
+          cpu: 3500m
+          memory: 12Gi
+      env:
+      - name: K8S_VERSION
+        value: "1.18"
+      securityContext:
+        privileged: true
+        capabilities:
+          add: ["SYS_ADMIN"]
+      volumeMounts:
+      - mountPath: /lib/modules
+        name: modules
+        readOnly: true
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    volumes:
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
 
-# - name: ci-cert-manager-next-e2e-v1-18
-#   interval: 2h
-#   agent: kubernetes
-#   decorate: true
-#   extra_refs:
-#   - org: jetstack
-#     repo: cert-manager
-#     base_ref: release-1.7
-#   annotations:
-#     testgrid-create-test-group: 'true'
-#     testgrid-dashboards: jetstack-cert-manager-next
-#     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-#     description: Runs the end-to-end test suite against a Kubernetes v1.18 cluster
-#   labels:
-#     preset-service-account: "true"
-#     preset-dind-enabled: "true"
-#     preset-bazel-remote-cache-enabled: "true"
-#     preset-bazel-scratch-dir: "true"
-#     preset-cloudflare-credentials: "true"
-#     preset-disable-all-feature-gates: "true"
-#     preset-ginkgo-skip-default: "true"
-#   spec:
-#     containers:
-#     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-#       args:
-#       - runner
-#       - devel/ci-run-e2e.sh
-#       resources:
-#         requests:
-#           cpu: 3500m
-#           memory: 12Gi
-#       env:
-#       - name: K8S_VERSION
-#         value: "1.18"
-#       securityContext:
-#         privileged: true
-#         capabilities:
-#           add: ["SYS_ADMIN"]
-#       volumeMounts:
-#       - mountPath: /lib/modules
-#         name: modules
-#         readOnly: true
-#       - mountPath: /sys/fs/cgroup
-#         name: cgroup
-#     volumes:
-#     - name: modules
-#       hostPath:
-#         path: /lib/modules
-#         type: Directory
-#     - name: cgroup
-#       hostPath:
-#         path: /sys/fs/cgroup
-#         type: Directory
-#     dnsConfig:
-#       options:
-#       - name: ndots
-#         value: "1"
+- name: ci-cert-manager-next-e2e-v1-19
+  interval: 168h # 1 week
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: jetstack
+    repo: cert-manager
+    base_ref: release-1.8
+  annotations:
+    testgrid-create-test-group: 'true'
+    testgrid-dashboards: jetstack-cert-manager-next
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    description: Runs the end-to-end test suite against a Kubernetes v1.19 cluster
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-cloudflare-credentials: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+      args:
+      - runner
+      - devel/ci-run-e2e.sh
+      resources:
+        requests:
+          cpu: 3500m
+          memory: 12Gi
+      env:
+      - name: K8S_VERSION
+        value: "1.19"
+      securityContext:
+        privileged: true
+        capabilities:
+          add: ["SYS_ADMIN"]
+      volumeMounts:
+      - mountPath: /lib/modules
+        name: modules
+        readOnly: true
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    volumes:
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
 
-# - name: ci-cert-manager-next-e2e-v1-19
-#   interval: 2h
-#   agent: kubernetes
-#   decorate: true
-#   extra_refs:
-#   - org: jetstack
-#     repo: cert-manager
-#     base_ref: release-1.7
-#   annotations:
-#     testgrid-create-test-group: 'true'
-#     testgrid-dashboards: jetstack-cert-manager-next
-#     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-#     description: Runs the end-to-end test suite against a Kubernetes v1.19 cluster
-#   labels:
-#     preset-service-account: "true"
-#     preset-dind-enabled: "true"
-#     preset-bazel-remote-cache-enabled: "true"
-#     preset-bazel-scratch-dir: "true"
-#     preset-cloudflare-credentials: "true"
-#     preset-enable-all-feature-gates: "true"
-#     preset-ginkgo-skip-default: "true"
-#   spec:
-#     containers:
-#     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-#       args:
-#       - runner
-#       - devel/ci-run-e2e.sh
-#       resources:
-#         requests:
-#           cpu: 3500m
-#           memory: 12Gi
-#       env:
-#       - name: K8S_VERSION
-#         value: "1.19"
-#       securityContext:
-#         privileged: true
-#         capabilities:
-#           add: ["SYS_ADMIN"]
-#       volumeMounts:
-#       - mountPath: /lib/modules
-#         name: modules
-#         readOnly: true
-#       - mountPath: /sys/fs/cgroup
-#         name: cgroup
-#     volumes:
-#     - name: modules
-#       hostPath:
-#         path: /lib/modules
-#         type: Directory
-#     - name: cgroup
-#       hostPath:
-#         path: /sys/fs/cgroup
-#         type: Directory
-#     dnsConfig:
-#       options:
-#       - name: ndots
-#         value: "1"
+- name: ci-cert-manager-next-e2e-v1-20
+  interval: 168h # 1 week
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: jetstack
+    repo: cert-manager
+    base_ref: release-1.8
+  annotations:
+    testgrid-create-test-group: 'true'
+    testgrid-dashboards: jetstack-cert-manager-next
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    description: Runs the end-to-end test suite against a Kubernetes v1.20 cluster
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-cloudflare-credentials: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+      args:
+      - runner
+      - devel/ci-run-e2e.sh
+      resources:
+        requests:
+          cpu: 3500m
+          memory: 12Gi
+      env:
+      - name: K8S_VERSION
+        value: "1.20"
+      securityContext:
+        privileged: true
+        capabilities:
+          add: ["SYS_ADMIN"]
+      volumeMounts:
+      - mountPath: /lib/modules
+        name: modules
+        readOnly: true
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    volumes:
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
 
-# - name: ci-cert-manager-next-e2e-v1-20
-#   interval: 2h
-#   agent: kubernetes
-#   decorate: true
-#   extra_refs:
-#   - org: jetstack
-#     repo: cert-manager
-#     base_ref: release-1.7
-#   annotations:
-#     testgrid-create-test-group: 'true'
-#     testgrid-dashboards: jetstack-cert-manager-next
-#     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-#     description: Runs the end-to-end test suite against a Kubernetes v1.20 cluster
-#   labels:
-#     preset-service-account: "true"
-#     preset-dind-enabled: "true"
-#     preset-bazel-remote-cache-enabled: "true"
-#     preset-bazel-scratch-dir: "true"
-#     preset-cloudflare-credentials: "true"
-#     preset-enable-all-feature-gates: "true"
-#     preset-ginkgo-skip-default: "true"
-#   spec:
-#     containers:
-#     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-#       args:
-#       - runner
-#       - devel/ci-run-e2e.sh
-#       resources:
-#         requests:
-#           cpu: 3500m
-#           memory: 12Gi
-#       env:
-#       - name: K8S_VERSION
-#         value: "1.20"
-#       securityContext:
-#         privileged: true
-#         capabilities:
-#           add: ["SYS_ADMIN"]
-#       volumeMounts:
-#       - mountPath: /lib/modules
-#         name: modules
-#         readOnly: true
-#       - mountPath: /sys/fs/cgroup
-#         name: cgroup
-#     volumes:
-#     - name: modules
-#       hostPath:
-#         path: /lib/modules
-#         type: Directory
-#     - name: cgroup
-#       hostPath:
-#         path: /sys/fs/cgroup
-#         type: Directory
-#     dnsConfig:
-#       options:
-#       - name: ndots
-#         value: "1"
+- name: ci-cert-manager-next-e2e-v1-21
+  interval: 168h # 1 week
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: jetstack
+    repo: cert-manager
+    base_ref: release-1.8
+  annotations:
+    testgrid-create-test-group: 'true'
+    testgrid-dashboards: jetstack-cert-manager-next
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    description: Runs the end-to-end test suite against a Kubernetes v1.21 cluster
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-cloudflare-credentials: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+      args:
+      - runner
+      - devel/ci-run-e2e.sh
+      resources:
+        requests:
+          cpu: 3500m
+          memory: 12Gi
+      env:
+      - name: K8S_VERSION
+        value: "1.21"
+      securityContext:
+        privileged: true
+        capabilities:
+          add: ["SYS_ADMIN"]
+      volumeMounts:
+      - mountPath: /lib/modules
+        name: modules
+        readOnly: true
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    volumes:
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
 
-# - name: ci-cert-manager-next-e2e-v1-21
-#   interval: 2h
-#   agent: kubernetes
-#   decorate: true
-#   extra_refs:
-#   - org: jetstack
-#     repo: cert-manager
-#     base_ref: release-1.7
-#   annotations:
-#     testgrid-create-test-group: 'true'
-#     testgrid-dashboards: jetstack-cert-manager-next
-#     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-#     description: Runs the end-to-end test suite against a Kubernetes v1.21 cluster
-#   labels:
-#     preset-service-account: "true"
-#     preset-dind-enabled: "true"
-#     preset-bazel-remote-cache-enabled: "true"
-#     preset-bazel-scratch-dir: "true"
-#     preset-cloudflare-credentials: "true"
-#     preset-enable-all-feature-gates: "true"
-#     preset-ginkgo-skip-default: "true"
-#   spec:
-#     containers:
-#     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-#       args:
-#       - runner
-#       - devel/ci-run-e2e.sh
-#       resources:
-#         requests:
-#           cpu: 3500m
-#           memory: 12Gi
-#       env:
-#       - name: K8S_VERSION
-#         value: "1.21"
-#       securityContext:
-#         privileged: true
-#         capabilities:
-#           add: ["SYS_ADMIN"]
-#       volumeMounts:
-#       - mountPath: /lib/modules
-#         name: modules
-#         readOnly: true
-#       - mountPath: /sys/fs/cgroup
-#         name: cgroup
-#     volumes:
-#     - name: modules
-#       hostPath:
-#         path: /lib/modules
-#         type: Directory
-#     - name: cgroup
-#       hostPath:
-#         path: /sys/fs/cgroup
-#         type: Directory
-#     dnsConfig:
-#       options:
-#       - name: ndots
-#         value: "1"
+- name: ci-cert-manager-next-e2e-v1-22
+  interval: 168h # 1 week
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: jetstack
+    repo: cert-manager
+    base_ref: release-1.8
+  annotations:
+    testgrid-create-test-group: 'true'
+    testgrid-dashboards: jetstack-cert-manager-next
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    description: Runs the end-to-end test suite against a Kubernetes v1.22 cluster
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-cloudflare-credentials: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+      args:
+      - runner
+      - devel/ci-run-e2e.sh
+      resources:
+        requests:
+          cpu: 3500m
+          memory: 12Gi
+      env:
+      - name: K8S_VERSION
+        value: "1.22"
+      securityContext:
+        privileged: true
+        capabilities:
+          add: ["SYS_ADMIN"]
+      volumeMounts:
+      - mountPath: /lib/modules
+        name: modules
+        readOnly: true
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    volumes:
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
 
-# - name: ci-cert-manager-next-e2e-v1-22
-#   interval: 2h
-#   agent: kubernetes
-#   decorate: true
-#   extra_refs:
-#   - org: jetstack
-#     repo: cert-manager
-#     base_ref: release-1.7
-#   annotations:
-#     testgrid-create-test-group: 'true'
-#     testgrid-dashboards: jetstack-cert-manager-next
-#     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-#     description: Runs the end-to-end test suite against a Kubernetes v1.22 cluster
-#   labels:
-#     preset-service-account: "true"
-#     preset-dind-enabled: "true"
-#     preset-bazel-remote-cache-enabled: "true"
-#     preset-bazel-scratch-dir: "true"
-#     preset-cloudflare-credentials: "true"
-#     preset-enable-all-feature-gates: "true"
-#     preset-ginkgo-skip-default: "true"
-#   spec:
-#     containers:
-#     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-#       args:
-#       - runner
-#       - devel/ci-run-e2e.sh
-#       resources:
-#         requests:
-#           cpu: 3500m
-#           memory: 12Gi
-#       env:
-#       - name: K8S_VERSION
-#         value: "1.22"
-#       securityContext:
-#         privileged: true
-#         capabilities:
-#           add: ["SYS_ADMIN"]
-#       volumeMounts:
-#       - mountPath: /lib/modules
-#         name: modules
-#         readOnly: true
-#       - mountPath: /sys/fs/cgroup
-#         name: cgroup
-#     volumes:
-#     - name: modules
-#       hostPath:
-#         path: /lib/modules
-#         type: Directory
-#     - name: cgroup
-#       hostPath:
-#         path: /sys/fs/cgroup
-#         type: Directory
-#     dnsConfig:
-#       options:
-#       - name: ndots
-#         value: "1"
+- name: ci-cert-manager-next-e2e-v1-23
+  interval: 168h # 1 week
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: jetstack
+    repo: cert-manager
+    base_ref: release-1.8
+  annotations:
+    testgrid-create-test-group: 'true'
+    testgrid-dashboards: jetstack-cert-manager-next
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    description: Runs the end-to-end test suite against a Kubernetes v1.23 cluster
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-cloudflare-credentials: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+      args:
+      - runner
+      - devel/ci-run-e2e.sh
+      resources:
+        requests:
+          cpu: 3500m
+          memory: 12Gi
+      env:
+      - name: K8S_VERSION
+        value: "1.23"
+      securityContext:
+        privileged: true
+        capabilities:
+          add: ["SYS_ADMIN"]
+      volumeMounts:
+      - mountPath: /lib/modules
+        name: modules
+        readOnly: true
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    volumes:
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
 
-# - name: ci-cert-manager-next-e2e-v1-23
-#   interval: 2h
-#   agent: kubernetes
-#   decorate: true
-#   extra_refs:
-#   - org: jetstack
-#     repo: cert-manager
-#     base_ref: release-1.7
-#   annotations:
-#     testgrid-create-test-group: 'true'
-#     testgrid-dashboards: jetstack-cert-manager-next
-#     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-#     description: Runs the end-to-end test suite against a Kubernetes v1.23 cluster
-#   labels:
-#     preset-service-account: "true"
-#     preset-dind-enabled: "true"
-#     preset-bazel-remote-cache-enabled: "true"
-#     preset-bazel-scratch-dir: "true"
-#     preset-cloudflare-credentials: "true"
-#     preset-enable-all-feature-gates: "true"
-#     preset-ginkgo-skip-default: "true"
-#   spec:
-#     containers:
-#     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-#       args:
-#       - runner
-#       - devel/ci-run-e2e.sh
-#       resources:
-#         requests:
-#           cpu: 3500m
-#           memory: 12Gi
-#       env:
-#       - name: K8S_VERSION
-#         value: "1.23"
-#       securityContext:
-#         privileged: true
-#         capabilities:
-#           add: ["SYS_ADMIN"]
-#       volumeMounts:
-#       - mountPath: /lib/modules
-#         name: modules
-#         readOnly: true
-#       - mountPath: /sys/fs/cgroup
-#         name: cgroup
-#     volumes:
-#     - name: modules
-#       hostPath:
-#         path: /lib/modules
-#         type: Directory
-#     - name: cgroup
-#       hostPath:
-#         path: /sys/fs/cgroup
-#         type: Directory
-#     dnsConfig:
-#       options:
-#       - name: ndots
-#         value: "1"
+# This test runs Venafi (VaaS and TPP) tests
+# This is the only CI test job that runs those.
+- name: ci-cert-manager-next-venafi
+  interval: 168h # 1 week
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: jetstack
+    repo: cert-manager
+    base_ref: release-1.8
+  annotations:
+    testgrid-create-test-group: 'true'
+    testgrid-dashboards: jetstack-cert-manager-master
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    description: Runs Venafi (VaaS and TPP) e2e tests against Kubernetes v1.22 cluster
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-venafi-cloud-credentials: "true"
+    preset-venafi-tpp-credentials: "true"
+    preset-ginkgo-focus-venafi: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+      args:
+      - runner
+      - devel/ci-run-e2e.sh
+      resources:
+        requests:
+          cpu: 3500m
+          memory: 12Gi
+      env:
+      - name: K8S_VERSION
+        value: "1.23"
+      securityContext:
+        privileged: true
+        capabilities:
+          add: ["SYS_ADMIN"]
+      volumeMounts:
+      - mountPath: /lib/modules
+        name: modules
+        readOnly: true
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    volumes:
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
 
-# # This test runs Venafi (VaaS and TPP) tests once every 24hrs.
-# # This is the only CI test job that runs those.
-# - name: ci-cert-manager-next-venafi
-#   interval: 24h
-#   agent: kubernetes
-#   decorate: true
-#   extra_refs:
-#   - org: jetstack
-#     repo: cert-manager
-#     base_ref: release-1.7
-#   annotations:
-#     testgrid-create-test-group: 'true'
-#     testgrid-dashboards: jetstack-cert-manager-master
-#     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-#     description: Runs Venafi (VaaS and TPP) e2e tests against Kubernetes v1.22 cluster
-#   labels:
-#     preset-service-account: "true"
-#     preset-dind-enabled: "true"
-#     preset-bazel-remote-cache-enabled: "true"
-#     preset-bazel-scratch-dir: "true"
-#     preset-venafi-cloud-credentials: "true"
-#     preset-venafi-tpp-credentials: "true"
-#     preset-ginkgo-focus-venafi: "true"
-#   spec:
-#     containers:
-#     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-#       args:
-#       - runner
-#       - devel/ci-run-e2e.sh
-#       resources:
-#         requests:
-#           cpu: 3500m
-#           memory: 12Gi
-#       env:
-#       - name: K8S_VERSION
-#         value: "1.23"
-#       securityContext:
-#         privileged: true
-#         capabilities:
-#           add: ["SYS_ADMIN"]
-#       volumeMounts:
-#       - mountPath: /lib/modules
-#         name: modules
-#         readOnly: true
-#       - mountPath: /sys/fs/cgroup
-#         name: cgroup
-#     volumes:
-#     - name: modules
-#       hostPath:
-#         path: /lib/modules
-#         type: Directory
-#     - name: cgroup
-#       hostPath:
-#         path: /sys/fs/cgroup
-#         type: Directory
-#     dnsConfig:
-#       options:
-#       - name: ndots
-#         value: "1"
-
-# - name: ci-cert-manager-next-upgrade
-#   interval: 8h
-#   agent: kubernetes
-#   decorate: true
-#   # extra refs specify what repo should be cloned
-#   extra_refs:
-#   - org: jetstack
-#     repo: cert-manager
-#     base_ref: release-1.7
-#   annotations:
-#     testgrid-create-test-group: 'true'
-#     testgrid-dashboards: jetstack-cert-manager-master
-#     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-#     description: Runs cert-manager upgrade test every 8 hours
-#   labels:
-#     preset-service-account: "true"
-#     preset-dind-enabled: "true"
-#     preset-bazel-remote-cache-enabled: "true"
-#     preset-bazel-scratch-dir: "true"
-#   spec:
-#     containers:
-#     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-#       args:
-#       - runner
-#       - make
-#       - cluster
-#       - verify_upgrade
-#       resources:
-#         requests:
-#           cpu: 3500m
-#           memory: 12Gi
-#       env:
-#       - name: K8S_VERSION
-#         value: "1.23"
-#       securityContext:
-#         privileged: true
-#         capabilities:
-#           add: ["SYS_ADMIN"]
-#       volumeMounts:
-#       - mountPath: /lib/modules
-#         name: modules
-#         readOnly: true
-#       - mountPath: /sys/fs/cgroup
-#         name: cgroup
-#     volumes:
-#     - name: modules
-#       hostPath:
-#         path: /lib/modules
-#         type: Directory
-#     - name: cgroup
-#       hostPath:
-#         path: /sys/fs/cgroup
-#         type: Directory
-#     dnsConfig:
-#       options:
-#       - name: ndots
-#         value: "1"
+- name: ci-cert-manager-next-upgrade
+  interval: 168h # 1 week
+  agent: kubernetes
+  decorate: true
+  # extra refs specify what repo should be cloned
+  extra_refs:
+  - org: jetstack
+    repo: cert-manager
+    base_ref: release-1.8
+  annotations:
+    testgrid-create-test-group: 'true'
+    testgrid-dashboards: jetstack-cert-manager-master
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    description: Runs cert-manager upgrade test.
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-bazel-scratch-dir: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+      args:
+      - runner
+      - make
+      - cluster
+      - verify_upgrade
+      resources:
+        requests:
+          cpu: 3500m
+          memory: 12Gi
+      env:
+      - name: K8S_VERSION
+        value: "1.23"
+      securityContext:
+        privileged: true
+        capabilities:
+          add: ["SYS_ADMIN"]
+      volumeMounts:
+      - mountPath: /lib/modules
+        name: modules
+        readOnly: true
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    volumes:
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"


### PR DESCRIPTION
I commented out the release-next periodic tests in #620 but that seems to have broken the Kubernetes testgrid.
So I re-enable it but with a 1week interval.

Documented in:
 * https://github.com/cert-manager/website/pull/827

Fixes:
 * https://github.com/kubernetes/test-infra/pull/25035