### PR TITLE
Simplify the branches list

### DIFF
--- a/config/jobs/cert-manager/webhook-example/cert-manager-webhook-example-presubmits.yaml
+++ b/config/jobs/cert-manager/webhook-example/cert-manager-webhook-example-presubmits.yaml
@@ -8,7 +8,7 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
-    - ^master$
+    - master
     spec:
       containers:
       - image: golang:1.17-buster


### PR DESCRIPTION
Ostensibly for consistency with other cert-manager jobs, e.g.

https://github.com/jetstack/testing/blob/d903cb91142155db80ab23b3f36afdae11331aed/config/jobs/cert-manager/csi-lib/cert-manager-csi-lib-presubmits.yaml#L10-L11

But really this is a pointless and hopefully non-breaking change designed to trigger the config-updater plugin to redeploy the job-config.
It failed to do so for #625.

It may even be worse, since the branches are supposed to be a Regexp, but it's not clear from the docs whether they are a regexp match or a search:
 * https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md#how-to-configure-new-jobs


