### PR TITLE
Disable branch protection bot on pca issuer repo

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -53,6 +53,8 @@ branch-protection:
             contexts:
             - pull-cert-manager-trust-verify
             - pull-cert-manager-trust-smoke
+        aws-privateca-issuer:
+          protect: false
 sinker:
   resync_period: 1h
   max_prowjob_age: 48h


### PR DESCRIPTION
This follows a request from the team at Amazon!

This was suggested by James M [on slack](https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1645361947733549?thread_ts=1645283061.671489&cid=CDEQJ0Q8M).