### PR TITLE
Explicitly specify transfigure version

### DIFF
--- a/config/jobs/testing/testing-presubmits.yaml
+++ b/config/jobs/testing/testing-presubmits.yaml
@@ -90,7 +90,7 @@ presubmits:
       testgrid-create-test-group: "false"
     spec:
       containers:
-      - image: gcr.io/k8s-prow/transfigure
+      - image: gcr.io/k8s-prow/transfigure:v20210601-16a04c27e3
         command:
         - /transfigure.sh
         args:


### PR DESCRIPTION
Transfigure is actually deprecated and the structure of the component seems to have changed, so that our `pull-testing-check-testgrid-config` jobs are now failing (the tests failed because they pulled the latest version due to us not specifying version explicitly)

Richard is working on replacing transfigure with config-merger in https://github.com/jetstack/testing/pull/630, so this PR is just a quick fix so we can keep using the last know version of transfigure till the proper fix gets implented.

Signed-off-by: irbekrm <irbekrm@gmail.com>