### PR TITLE
Add optional presubmit jobs "make-test" and "make-e2e-v1-23"

### DIFF
--- a/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
@@ -59,7 +59,7 @@ presubmits:
         # TODO: change to a custom image that embeds the system tools we need
         # (jq, make, bash, Go, etc). Tracked at
         # https://github.com/cert-manager/cert-manager/issues/4939.
-      - image: 1.17.8-alpine@sha256:e2e68a9cdd5da82458652fdac3908a3a270686b38039f2829855398e2e06019d
+      - image: docker.io/library/golang:1.17.8-alpine@sha256:e2e68a9cdd5da82458652fdac3908a3a270686b38039f2829855398e2e06019d
         args:
         - runner
         - make
@@ -642,7 +642,7 @@ presubmits:
         # TODO: change to a custom image that embeds the system tools we need
         # (jq, make, bash, Go, etc). Tracked at
         # https://github.com/cert-manager/cert-manager/issues/4939.
-      - image: 1.17.8-alpine@sha256:e2e68a9cdd5da82458652fdac3908a3a270686b38039f2829855398e2e06019d
+      - image: docker.io/library/golang:1.17.8-alpine@sha256:e2e68a9cdd5da82458652fdac3908a3a270686b38039f2829855398e2e06019d
         args:
         - runner
         - make/ci.sh 1.23

--- a/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
@@ -36,6 +36,38 @@ presubmits:
           - name: ndots
             value: "1"
 
+  - name: pull-cert-manager-make-test
+    always_run: false
+    optional: true
+    context: pull-cert-manager-make-test
+    max_concurrency: 8
+    agent: kubernetes
+    decorate: true
+    branches:
+    - master
+    - release-1.8
+    annotations:
+      testgrid-create-test-group: 'true'
+      testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
+      description: Runs 'bazel test --jobs=1 //...'
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: 1.17.8-alpine@sha256:e2e68a9cdd5da82458652fdac3908a3a270686b38039f2829855398e2e06019d
+        args:
+        - runner
+        - make
+        - test
+        resources:
+          requests:
+            cpu: 2
+            memory: 4Gi
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+
   - name: pull-cert-manager-bazel-nocache
     description: Run cert-manager unit tests with Bazel remote-caching disabled
     always_run: false
@@ -554,6 +586,63 @@ presubmits:
         env:
         - name: K8S_VERSION
           value: "1.23"
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+
+  - name: pull-cert-manager-make-e2e-v1-23
+    context: pull-cert-manager-make-e2e-v1-23
+    always_run: false
+    optional: true
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    branches:
+    - master
+    - release-1.8
+    annotations:
+      testgrid-create-test-group: 'true'
+      testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
+      description: Runs the end-to-end test suite against a Kubernetes v1.23 cluster
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-cloudflare-credentials: "true"
+      preset-retry-flakey-tests: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+    spec:
+      containers:
+      - image: 1.17.8-alpine@sha256:e2e68a9cdd5da82458652fdac3908a3a270686b38039f2829855398e2e06019d
+        args:
+        - runner
+        - make/ci.sh --k8s-version 1.23
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
         securityContext:
           privileged: true
           capabilities:

--- a/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
@@ -61,7 +61,6 @@ presubmits:
         # https://github.com/cert-manager/cert-manager/issues/4939.
       - image: docker.io/library/golang:1.17.8-alpine@sha256:e2e68a9cdd5da82458652fdac3908a3a270686b38039f2829855398e2e06019d
         args:
-        - runner
         - make
         - test-ci
         resources:
@@ -644,7 +643,6 @@ presubmits:
         # https://github.com/cert-manager/cert-manager/issues/4939.
       - image: docker.io/library/golang:1.17.8-alpine@sha256:e2e68a9cdd5da82458652fdac3908a3a270686b38039f2829855398e2e06019d
         args:
-        - runner
         - make/ci.sh 1.23
         resources:
           requests:

--- a/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
@@ -51,7 +51,7 @@ presubmits:
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
-      description: Runs 'bazel test --jobs=1 //...'
+      description: Runs 'make test-ci'
     labels:
       preset-service-account: "true"
     spec:
@@ -630,6 +630,7 @@ presubmits:
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
+      description: Runs 'make e2e-ci K8S_VERSION=1.23'
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"

--- a/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
@@ -63,7 +63,7 @@ presubmits:
         args:
         - runner
         - make
-        - test
+        - test-ci
         resources:
           requests:
             cpu: 2

--- a/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
@@ -638,7 +638,7 @@ presubmits:
       - image: 1.17.8-alpine@sha256:e2e68a9cdd5da82458652fdac3908a3a270686b38039f2829855398e2e06019d
         args:
         - runner
-        - make/ci.sh --k8s-version 1.23
+        - make/ci.sh 1.23
         resources:
           requests:
             cpu: 3500m

--- a/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
@@ -37,9 +37,11 @@ presubmits:
             value: "1"
 
   - name: pull-cert-manager-make-test
+    context: pull-cert-manager-make-test
+    # TODO: set to "always_run: true" and "optional: false" as soon as
+    # https://github.com/cert-manager/cert-manager/pull/4914 is merged.
     always_run: false
     optional: true
-    context: pull-cert-manager-make-test
     max_concurrency: 8
     agent: kubernetes
     decorate: true
@@ -54,6 +56,9 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
+        # TODO: change to a custom image that embeds the system tools we need
+        # (jq, make, bash, Go, etc). Tracked at
+        # https://github.com/cert-manager/cert-manager/issues/4939.
       - image: 1.17.8-alpine@sha256:e2e68a9cdd5da82458652fdac3908a3a270686b38039f2829855398e2e06019d
         args:
         - runner
@@ -612,6 +617,8 @@ presubmits:
 
   - name: pull-cert-manager-make-e2e-v1-23
     context: pull-cert-manager-make-e2e-v1-23
+    # TODO: set to "always_run: true" and "optional: false" as soon as
+    # https://github.com/cert-manager/cert-manager/pull/4914 is merged.
     always_run: false
     optional: true
     max_concurrency: 4
@@ -635,6 +642,9 @@ presubmits:
       preset-ginkgo-skip-default: "true"
     spec:
       containers:
+        # TODO: change to a custom image that embeds the system tools we need
+        # (jq, make, bash, Go, etc). Tracked at
+        # https://github.com/cert-manager/cert-manager/issues/4939.
       - image: 1.17.8-alpine@sha256:e2e68a9cdd5da82458652fdac3908a3a270686b38039f2829855398e2e06019d
         args:
         - runner

--- a/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
@@ -630,12 +630,9 @@ presubmits:
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
-      description: Runs the end-to-end test suite against a Kubernetes v1.23 cluster
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
       preset-retry-flakey-tests: "true"
       preset-enable-all-feature-gates: "true"

--- a/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
@@ -56,13 +56,14 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-        # TODO: change to a custom image that embeds the system tools we need
-        # (jq, make, bash, Go, etc). Tracked at
+        # TODO: remove the "apk add" command and change to a custom image that
+        # embeds the system tools we need (jq, make, bash, Go, etc). Tracked at
         # https://github.com/cert-manager/cert-manager/issues/4939.
       - image: docker.io/library/golang:1.17.8-alpine@sha256:e2e68a9cdd5da82458652fdac3908a3a270686b38039f2829855398e2e06019d
         args:
-        - make
-        - test-ci
+        - sh
+        - -c
+        - apk add bash make curl python3 perl jq git docker && make test-ci
         resources:
           requests:
             cpu: 2
@@ -638,12 +639,14 @@ presubmits:
       preset-ginkgo-skip-default: "true"
     spec:
       containers:
-        # TODO: change to a custom image that embeds the system tools we need
-        # (jq, make, bash, Go, etc). Tracked at
+        # TODO: remove "apk add" and change to a custom image that embeds the
+        # system tools we need (jq, make, bash, Go, etc). Tracked at
         # https://github.com/cert-manager/cert-manager/issues/4939.
       - image: docker.io/library/golang:1.17.8-alpine@sha256:e2e68a9cdd5da82458652fdac3908a3a270686b38039f2829855398e2e06019d
         args:
-        - make/ci.sh 1.23
+        - sh
+        - -c
+        - apk add bash make curl python3 perl jq git docker && make e2e-ci K8S_VERSION=1.23
         resources:
           requests:
             cpu: 3500m


### PR DESCRIPTION
| This PR is part of the effort 'moving away from Bazel' tracked in https://github.com/cert-manager/cert-manager/pull/4712 |
|--|

I am working on `make e2e` in https://github.com/cert-manager/cert-manager/pull/4914. I need to test that the unit tests, integration tests and end-to-end tests are passing with the new Make flow.

We will keep both Bazel and Make presubmits until the move is complete.

In this PR I added two Make presubmits to test that everything works and with the goal of releasing 1.8.0-alpha.0. Right now, these two presubmits are "optional" to avoid disruption in other PRs until https://github.com/cert-manager/cert-manager/pull/4914 is merged. That means that these two new presubmits have to be manually triggered with:

  /test pull-cert-manager-make-test
  /test pull-cert-manager-make-e2e-v1-23

Signed-off-by: Maël Valais <mael@vls.dev>