### PR TITLE
Presubmits: apk add tar and grep into the busybox alpine images

### DIFF
--- a/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
@@ -56,14 +56,16 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-        # TODO: remove the "apk add" command and change to a custom image that
-        # embeds the system tools we need (jq, make, bash, Go, etc). Tracked at
+        # TODO: remove the "apk add" command and change to a custom image
+        # that embeds the system tools we need (jq, make, bash, Go, etc).
+        # Note that grep and tar have been added because BusyBox's grep
+        # lacks --null-data and tar lacks --append. Tracked at
         # https://github.com/cert-manager/cert-manager/issues/4939.
       - image: docker.io/library/golang:1.17.8-alpine@sha256:e2e68a9cdd5da82458652fdac3908a3a270686b38039f2829855398e2e06019d
         args:
         - sh
         - -c
-        - apk add bash make curl python3 perl jq git docker && make test-ci
+        - apk add bash make curl python3 perl jq git docker tar grep && make test-ci
         resources:
           requests:
             cpu: 2
@@ -640,14 +642,16 @@ presubmits:
       preset-ginkgo-skip-default: "true"
     spec:
       containers:
-        # TODO: remove "apk add" and change to a custom image that embeds the
-        # system tools we need (jq, make, bash, Go, etc). Tracked at
+        # TODO: remove the "apk add" command and change to a custom image
+        # that embeds the system tools we need (jq, make, bash, Go, etc).
+        # Note that grep and tar have been added because BusyBox's grep
+        # lacks --null-data and tar lacks --append. Tracked at
         # https://github.com/cert-manager/cert-manager/issues/4939.
       - image: docker.io/library/golang:1.17.8-alpine@sha256:e2e68a9cdd5da82458652fdac3908a3a270686b38039f2829855398e2e06019d
         args:
         - sh
         - -c
-        - apk add bash make curl python3 perl jq git docker && make e2e-ci K8S_VERSION=1.23
+        - apk add bash make curl python3 perl jq git docker tar grep && make e2e-ci K8S_VERSION=1.23
         resources:
           requests:
             cpu: 3500m


### PR DESCRIPTION
grep and tar in BusyBox are lacking some features that we need:

- BusyBox's `grep` lacks `--null-data`,
- BusyBox's `tar` lacks `--append`.

To test that it works, I have run:

```sh
docker run -it --rm --net=host -v $PWD:/pwd -v /var/run/docker.sock:/var/run/docker.sock \
  -v $HOME/.kube:/root/.kube golang:1.17.8-alpine sh -c \
    "cd /pwd && apk add bash make curl python3 perl jq git docker tar grep && make e2e-ci K8S_VERSION=1.23"
```

and

```
docker run -it --rm --net=host -v $PWD:/pwd -v /var/run/docker.sock:/var/run/docker.sock \
  -v $HOME/.kube:/root/.kube golang:1.17.8-alpine sh -c \
    "cd /pwd && apk add bash make curl python3 perl jq git docker tar grep && make test-ci"
```

I should have tested it before merging #643 😅

cc @SgtCoDFish 