### PR TITLE
Presubmits: another follow-up, remove "sudo" and add "-j"

### DIFF
--- a/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
@@ -64,7 +64,7 @@ presubmits:
         - runner
         - sh
         - -c
-        - sudo apt install jq -y && make test-ci
+        - apt install jq -y && make -j vendor-go test-ci
         resources:
           requests:
             cpu: 2
@@ -649,7 +649,7 @@ presubmits:
         - runner
         - sh
         - -c
-        - sudo apt install jq -y && make e2e-ci K8S_VERSION=1.23
+        - apt install jq -y && make -j vendor-go e2e-ci K8S_VERSION=1.23
         resources:
           requests:
             cpu: 3500m


### PR DESCRIPTION
| This PR is part of the effort 'moving away from Bazel' tracked in https://github.com/cert-manager/cert-manager/pull/4712 |
|--|

This is another follow-up to #643, #645, and https://github.com/jetstack/testing/pull/646. I realized that `sudo` isn't needed, and I sped up the whole thing by adding "-j" that I had forgotten to add.

Sorry!!