### PR TITLE
Presubmits: enable make test-ci and make e2e-ci by default

### DIFF
--- a/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
@@ -38,10 +38,8 @@ presubmits:
 
   - name: pull-cert-manager-make-test
     context: pull-cert-manager-make-test
-    # TODO: set to "always_run: true" and "optional: false" as soon as
-    # https://github.com/cert-manager/cert-manager/pull/4914 is merged.
-    always_run: false
-    optional: true
+    always_run: true
+    optional: false
     max_concurrency: 8
     agent: kubernetes
     decorate: true
@@ -618,10 +616,8 @@ presubmits:
 
   - name: pull-cert-manager-make-e2e-v1-23
     context: pull-cert-manager-make-e2e-v1-23
-    # TODO: set to "always_run: true" and "optional: false" as soon as
-    # https://github.com/cert-manager/cert-manager/pull/4914 is merged.
-    always_run: false
-    optional: true
+    always_run: true
+    optional: false
     max_concurrency: 4
     agent: kubernetes
     decorate: true


### PR DESCRIPTION
| This PR is part of the effort 'moving away from Bazel' tracked in https://github.com/cert-manager/cert-manager/pull/4712 |
|--|

This PR follows up the PR https://github.com/cert-manager/cert-manager/pull/4914 that just got merged. As mentioned in the TODO,

```yaml
# TODO: set to "always_run: true" and "optional: false" as soon as
# https://github.com/cert-manager/cert-manager/pull/4914 is merged.
```

This PR does exactly that.

Note that every open PR on cert-manager/cert-manager ~will have to get rebased in order to pass the two new tests `pull-cert-manager-make-test` and `pull-cert-manager-make-e2e-v1-23`. I will leave a message on each of the 33 open PR.~

@munnerz made me aware of the fact that Prow runs the jobs on the merge commit, which means there is no need to rebase. But each PR (may?) have to get the required test manually triggered with the following:

```
/test pull-cert-manager-make-test
/test pull-cert-manager-make-e2e-v1-23
```

If that's the case, I will trigger these tests on each individual PR.