### PR TITLE
Presubmits: add a cache for make jobs

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -40,6 +40,8 @@ branch-protection:
             - pull-cert-manager-deps
             - pull-cert-manager-chart
             - pull-cert-manager-e2e-v1-23
+            - pull-cert-manager-make-test
+            - pull-cert-manager-make-e2e-v1-23
         website:
           required_status_checks:
             contexts:

--- a/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
@@ -60,13 +60,35 @@ presubmits:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
         args:
         - runner
-        - sh
+        - bash
         - -c
-        - apt install jq -y && make -j vendor-go test-ci
+        - |
+          apt-get install jq -y >/dev/null
+          make -j vendor-go test-ci
         resources:
           requests:
             cpu: 2
             memory: 4Gi
+        volumeMounts:
+        - mountPath: /root/.cache/go-build
+          name: gocache
+        - mountPath: /home/prow/go/pkg/mod
+          name: gopkgmod
+        - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
+          name: bindownloaded
+      volumes:
+      - name: gocache
+        hostPath:
+          path: /tmp/gocache
+          type: DirectoryOrCreate
+      - name: gopkgmod
+        hostPath:
+          path: /tmp/gopkgmod
+          type: DirectoryOrCreate
+      - name: bindownloaded
+        hostPath:
+          path: /tmp/bindownloaded
+          type: DirectoryOrCreate
       dnsConfig:
         options:
           - name: ndots
@@ -643,9 +665,11 @@ presubmits:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
         args:
         - runner
-        - sh
+        - bash
         - -c
-        - apt install jq -y && make -j vendor-go e2e-ci K8S_VERSION=1.23
+        - |
+          apt-get install jq -y >/dev/null
+          make -j vendor-go e2e-ci K8S_VERSION=1.23
         resources:
           requests:
             cpu: 3500m
@@ -660,6 +684,12 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /root/.cache/go-build
+          name: gocache
+        - mountPath: /home/prow/go/pkg/mod
+          name: gopkgmod
+        - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
+          name: bindownloaded
       volumes:
       - name: modules
         hostPath:
@@ -669,6 +699,18 @@ presubmits:
         hostPath:
           path: /sys/fs/cgroup
           type: Directory
+      - name: gocache
+        hostPath:
+          path: /tmp/gocache
+          type: DirectoryOrCreate
+      - name: gopkgmod
+        hostPath:
+          path: /tmp/gopkgmod
+          type: DirectoryOrCreate
+      - name: bindownloaded
+        hostPath:
+          path: /tmp/bindownloaded
+          type: DirectoryOrCreate
       dnsConfig:
         options:
         - name: ndots


### PR DESCRIPTION
This PR goes hand-in-hand with https://github.com/cert-manager/cert-manager/pull/4983.

I propose to add a caching mechanism to the "make" jobs using a `hostPath` directory, for these three directories:

- `GOCACHE` which contains the Go test cache and build cache,
- `GOPATH/pkg/mod` which contains the module cache,
- `bin/downloaded` which contains the pre-downloaded containers and tools.

In order for the last item (bin/downloaded) to work, I had to work around things in https://github.com/cert-manager/cert-manager/pull/4983, since binaries cannot be run from a directory mounted using `hostPath` on GKE.

This cache decreases the job duration by 5 minutes, as shown in the table in https://github.com/cert-manager/cert-manager/pull/4983.

This cache needs to be warmed up on every node. When a node gets spun up, the first job (or jobs, it works fine with two concurrent jobs) will create the cache.

🚧 This PR also adds `pull-cert-manager-make-test` and `pull-cert-manager-make-e2e-v1-23` to the set of required GitHub checks. 🚧 

## Re-running easily Prow jobs without committing to `jetstack/testing`

I have been testing this configuration over and over thanks to [`mkpj`](https://github.com/kubernetes/test-infra/blob/f035280f9c9ebaaf8850d63403aab87afac76388/prow/build_test_update.md#running-a-prowjob-locally). Thanks to `mkpj`, I don't need to commit to jetstack/testing in order to submit tweaked Prow jobs. Here is how I use it. First, install it:

```sh
git clone https://github.com/kubernetes/test-infra /tmp/test-infra --depth=1
(cd /tmp/test-infra && go install ./prow/cmd/mkpj)
```

Make sure you have access to the cluster `jetstack-build-infra-workers-gke`:

```sh
gcloud container clusters get-credentials jetstack-build-infra-workers-gke --project jetstack-build-infra-gke --region europe-west1
```

Run `mkpj` to create a ProwJob YAML manifest, and then apply it:

```sh
# From the cert-manager repository.
mkpj --job pull-cert-manager-make-e2e-v1-23 \
  --config-path ~/code/jetstack/testing/config/config.yaml \
  --job-config-path ~/code/jetstack/testing/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml \
  --pull-number 4968 --pull-sha $(git rev-parse HEAD) >/tmp/mkpj.yaml \
  && kubectl apply -f /tmp/mkpj.yaml --context gke_jetstack-build-infra_europe-west1-b_github-build-infra \
  && sleep 5s \
  && kubectl get -f /tmp/mkpj.yaml --context gke_jetstack-build-infra_europe-west1-b_github-build-infra -ojsonpath='{.status.url}'; echo
```

That should give you the URL of the Prow job. Now, you can stream the logs:

```sh
kubectl --context gke_jetstack-build-infra-gke_europe-west1_jetstack-build-infra-workers-gke \
  -n test-pods logs $(yq eval '.metadata.name' /tmp/mkpj.yaml) -c test --follow
```

You can get a progress bar to see when the job will end:

```sh
kubectl --context gke_jetstack-build-infra-gke_europe-west1_jetstack-build-infra-workers-gke \
  -n test-pods logs $(yq eval '.metadata.name' /tmp/mkpj.yaml) -c test --follow --tail=-1 \
  | pv -s "$(curl -sS https://storage.googleapis.com/jetstack-logs/pr-logs/pull/cert-manager_cert-manager/4968/pull-cert-manager-make-e2e-v1-23/1506974361645486080/build-log.txt | wc -c)" >/dev/null
```

![Peek 2022-03-24 16-15](https://user-images.githubusercontent.com/2195781/159949855-b4176e71-0dde-4768-aed1-aa6512bd447d.gif)

Finally, to exec into the pod with the right PATH:

```sh
kubectl --context gke_jetstack-build-infra-gke_europe-west1_jetstack-build-infra-workers-gke \
  -n test-pods exec -it $(yq eval '.metadata.name' /tmp/mkpj.yaml) -c test -- \
  bash -c 'export PATH=$PWD/bin/tools:$PATH && bash'
```

