### PR TITLE
Remove required_status_checks for make, for now

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -40,8 +40,9 @@ branch-protection:
             - pull-cert-manager-deps
             - pull-cert-manager-chart
             - pull-cert-manager-e2e-v1-23
-            - pull-cert-manager-make-test
-            - pull-cert-manager-make-e2e-v1-23
+            # TODO: re-enable these when they can pass on backport branches
+            # - pull-cert-manager-make-test
+            # - pull-cert-manager-make-e2e-v1-23
         website:
           required_status_checks:
             contexts:


### PR DESCRIPTION
These required_status_checks apply for every branch, which breaks
backports when the job cannot run and succeed. Since the make flow
wasn't available on older branches it cannot pass on those branches.

We remove them for now until the required_status_checks are made
specific to branches where they can succeed. We'll have the opposite
problem to this down the road - we'll want to remove the bazel checks,
but release-1.9 probably won't have bazel.