### PR TITLE
make-dind is a new image for rootless dind-enabled Prow jobs

### DIFF
--- a/images/make-dind/Dockerfile
+++ b/images/make-dind/Dockerfile
@@ -1,0 +1,15 @@
+FROM debian
+
+# Usage:
+#
+#   nerdctl build -t local/make-dind -f images/make-dind/Dockerfile ./images/make-dind
+#   nerdctl run -it --privileged -v /tmp:/tmp --tmpfs /var/lib/containerd local/make-dind bash
+
+RUN apt update \
+    && apt install curl bash make curl python3 perl jq git tar grep iptables -y \
+    && curl -sSL https://github.com/containerd/nerdctl/releases/download/v0.17.1/nerdctl-full-0.17.1-linux-amd64.tar.gz | tar zx -C / \
+    && mkdir -p /opt/cni/bin \
+    && curl -sSL https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-amd64-v1.1.1.tgz | tar xz -C /opt/cni/bin
+COPY docker-entrypoint.sh /
+VOLUME /var/lib/containerd
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/images/make-dind/Dockerfile
+++ b/images/make-dind/Dockerfile
@@ -7,9 +7,14 @@ FROM debian
 
 RUN apt update \
     && apt install curl bash make curl python3 perl jq git tar grep iptables -y \
-    && curl -sSL https://github.com/containerd/nerdctl/releases/download/v0.17.1/nerdctl-full-0.17.1-linux-amd64.tar.gz | tar zx -C / \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -sSL https://github.com/containerd/nerdctl/releases/download/v1.2.1/nerdctl-full-1.2.1-linux-amd64.tar.gz | tar zx -C / \
+    && ln -s /bin/nerdctl /bin/docker \
     && mkdir -p /opt/cni/bin \
-    && curl -sSL https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-amd64-v1.1.1.tgz | tar xz -C /opt/cni/bin
+    && curl -sSL https://github.com/containernetworking/plugins/releases/download/v1.2.0/cni-plugins-linux-amd64-v1.2.0.tgz | tar xz -C /opt/cni/bin
+
 COPY docker-entrypoint.sh /
+COPY containerd-cni.conflist.json /etc/cni/net.d/containerd-cni.conflist
+COPY containerd.toml /etc/containerd/config.toml
 VOLUME /var/lib/containerd
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/images/make-dind/containerd-cni.conflist.json
+++ b/images/make-dind/containerd-cni.conflist.json
@@ -1,0 +1,34 @@
+{
+  "cniVersion": "1.0.0",
+  "name": "bridge",
+  "deviceID": "0",
+  "plugins": [
+    {
+      "type": "bridge",
+      "bridge": "cni0",
+      "isGateway": true,
+      "ipMasq": true,
+      "promiscMode": true,
+      "ipam": {
+        "type": "host-local",
+        "ranges": [
+          [
+            {
+              "subnet": "10.88.0.0/16"
+            }
+          ],
+          [
+            {
+              "subnet": "2001:4860:4860::/64"
+            }
+          ]
+        ],
+        "routes": [{ "dst": "0.0.0.0/0" }, { "dst": "::/0" }]
+      }
+    },
+    {
+      "type": "portmap",
+      "capabilities": { "portMappings": true }
+    }
+  ]
+}

--- a/images/make-dind/containerd.toml
+++ b/images/make-dind/containerd.toml
@@ -1,0 +1,10 @@
+version = 2
+
+[plugins]
+  [plugins."io.containerd.grpc.v1.cri"]
+    disable_apparmor = true
+    restrict_oom_score_adj = true
+    disable_hugetlb_controller = true
+    [plugins."io.containerd.grpc.v1.cri".containerd]
+      # Rootless overlayfs requires kernel >= 5.11 && !selinux
+      snapshotter = "overlayfs"

--- a/images/make-dind/docker-entrypoint.sh
+++ b/images/make-dind/docker-entrypoint.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+# Inspired from: https://github.com/containerd/containerd/blob/v1.6.1/contrib/Dockerfile.test.d/cri-in-userns/docker-entrypoint.sh
+
+set -eu -o pipefail
+
+# Check 4294967295 to detect UserNS (https://github.com/opencontainers/runc/blob/v1.0.0/libcontainer/userns/userns_linux.go#L29-L32)
+if grep -Eq "0[[:space:]]+0[[:space:]]+4294967295" /proc/self/uid_map; then
+    echo >&2 "ERROR: Needs to be executed in UserNS (i.e., rootless Docker/Podman/nerdctl)"
+    exit 1
+fi
+
+if [ ! -f "/sys/fs/cgroup/cgroup.controllers" ]; then
+    echo >&2 "ERROR: Needs cgroup v2: https://rootlesscontaine.rs/getting-started/common/cgroup2/#enabling-cgroup-v2"
+    exit 1
+fi
+
+for f in cpu memory pids; do
+    if ! grep -qw "$f" "/sys/fs/cgroup/cgroup.controllers"; then
+        echo >&2 "ERROR: Needs cgroup v2 controller ${f} to be delegated: https://rootlesscontaine.rs/getting-started/common/cgroup2/#enabling-cpu-cpuset-and-io-delegation"
+        exit 1
+    fi
+done
+
+echo >&2 "Enabling cgroup v2 nesting"
+# https://github.com/moby/moby/blob/v20.10.7/hack/dind#L28-L38
+mkdir -p /sys/fs/cgroup/init
+xargs -rn1 </sys/fs/cgroup/cgroup.procs >/sys/fs/cgroup/init/cgroup.procs || :
+sed -e 's/ / +/g' -e 's/^/+/' </sys/fs/cgroup/cgroup.controllers \
+    >/sys/fs/cgroup/cgroup.subtree_control
+
+set -x
+echo >&2 "Running containerd in background"
+containerd &
+
+echo >&2 "Waiting for containerd"
+until ctr plugins list; do sleep 3; done
+
+exec "$@"


### PR DESCRIPTION
See https://github.com/jetstack/testing/issues/656

To test it yourself locally, you will have to configure your CRI so that it runs as non-root:

- **Nerdctl:** read https://github.com/containerd/nerdctl/blob/main/docs/rootless.md
- **Docker:** https://rootlesscontaine.rs/getting-started/docker

Then, build the dind image (choose the correct command):

```bash
nerdctl build -t local/make-dind -f images/make-dind/Dockerfile ./images/make-dind
docker build -t local/make-dind -f images/make-dind/Dockerfile ./images/make-dind
```

Finally, run the image:

```
nerdctl run -it --privileged -v /tmp:/tmp --tmpfs /var/lib/containerd local/make-dind bash
docker run -it --privileged -v /tmp:/tmp --tmpfs /var/lib/containerd local/make-dind bash
```

You should get a prompt. Try to run a container:

```bash
nerdctl run alpine ls
```

> ⚠️ The following warning can be ignored:
> ```
> WARN[0002] default network named "bridge" does not have an internal nerdctl ID or nerdctl-managed config file, it was most likely NOT created by nerdctl 
> ```

Why `--privileged` when we want a rootless container? The container requires a number of capabilities to configure cgroups for the child containers and such.