### PR TITLE
Disable SSA feature for Kubernetes 1.19 - 1.21

### DIFF
--- a/config/jobs/cert-manager/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager/cert-manager-periodics.yaml
@@ -114,7 +114,7 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
-    preset-enable-all-feature-gates: "true"
+    preset-enable-all-feature-gates-disable-ssa: "true"
     preset-ginkgo-skip-default: "true"
   spec:
     containers:
@@ -172,7 +172,7 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
-    preset-enable-all-feature-gates: "true"
+    preset-enable-all-feature-gates-disable-ssa: "true"
     preset-ginkgo-skip-default: "true"
   spec:
     containers:
@@ -230,7 +230,7 @@ periodics:
     preset-bazel-remote-cache-enabled: "true"
     preset-bazel-scratch-dir: "true"
     preset-cloudflare-credentials: "true"
-    preset-enable-all-feature-gates: "true"
+    preset-enable-all-feature-gates-disable-ssa: "true"
     preset-ginkgo-skip-default: "true"
   spec:
     containers:

--- a/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
@@ -356,7 +356,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
       preset-retry-flakey-tests: "true"
-      preset-enable-all-feature-gates: "true"
+      preset-enable-all-feature-gates-disable-ssa: "true"
       preset-ginkgo-skip-default: "true"
     spec:
       containers:
@@ -416,7 +416,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
       preset-retry-flakey-tests: "true"
-      preset-enable-all-feature-gates: "true"
+      preset-enable-all-feature-gates-disable-ssa: "true"
       preset-ginkgo-skip-default: "true"
     spec:
       containers:
@@ -476,7 +476,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
       preset-retry-flakey-tests: "true"
-      preset-enable-all-feature-gates: "true"
+      preset-enable-all-feature-gates-disable-ssa: "true"
       preset-ginkgo-skip-default: "true"
     spec:
       containers:

--- a/config/jobs/cert-manager/config.yaml
+++ b/config/jobs/cert-manager/config.yaml
@@ -100,6 +100,12 @@ presets:
     value: "AllAlpha=true"
 
 - labels:
+    preset-enable-all-feature-gates-disable-ssa: "true"
+  env:
+  - name: FEATURE_GATES
+    value: "AllAlpha=true,ServerSideApply=false"
+
+- labels:
     preset-disable-all-alpha-beta-feature-gates: "true"
   env:
   - name: FEATURE_GATES


### PR DESCRIPTION
Disables server-side apply feature for kube 1.19 - 1.21

See https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1649145566523839 for context

In long term, we should investigate the error, however it would probably take a while and in short term it is more valuable to see the e2e tests pass.

Signed-off-by: irbekrm <irbekrm@gmail.com>