### PR TITLE
1.8 test jobs

### DIFF
--- a/config/jobs/cert-manager/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager/cert-manager-periodics.yaml
@@ -562,7 +562,6 @@ periodics:
         - name: ndots
           value: "1"
 
-
 - name: ci-cert-manager-upgrade
   interval: 8h
   agent: kubernetes

--- a/config/jobs/cert-manager/cert-manager/release-next/cert-manager-release-next-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-next/cert-manager-release-next-periodics.yaml
@@ -1,8 +1,8 @@
-# We don't need periodically testing the release-next breanch (e.g., the
-# "release-1.9" branch) until we release the first alpha (e.g.,
-# "1.9.0-alpha.0"). Since we can't "deactivate" the release-next periodics
-# jobs until we have an alpha (there is no "skip" field on the ProwJob
-# object), we just remove all of the jobs from this file. That's why the
-# below array is empty. See Step 13.3 in
-# https://cert-manager.io/docs/contributing/release-process/
+# We don't need to periodically test the release-next branch
+# (e.g., the "release-1.9" branch when release-1.8 is the latest version)
+# until we release the first alpha (e.g. "1.9.0-alpha.0").
+# Since we can't "deactivate" the release-next periodic jobs (there is no "skip"
+# field on the ProwJob object), we just remove all of the jobs from this file and leave
+# an empty array.
+# See step 13.3 in https://cert-manager.io/docs/contributing/release-process/
 periodics: []

--- a/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
   extra_refs:
   - org: cert-manager
     repo: cert-manager
-    base_ref: release-1.7
+    base_ref: release-1.8 # still required on 1.8 because some tests were only present in bazel
   labels:
     preset-service-account: "true"
     preset-bazel-remote-cache-enabled: "true"
@@ -35,66 +35,134 @@ periodics:
         - name: ndots
           value: "1"
 
-# Re-add bazel-experimental periodics once Bazel v5.0.0 is released and we have
-# a bazelbuild image with that https://github.com/bazelbuild/bazel/releases
-
-- name: ci-cert-manager-previous-e2e-v1-18
+- name: ci-cert-manager-previous-make-test
   interval: 2h
   agent: kubernetes
   decorate: true
   extra_refs:
   - org: cert-manager
     repo: cert-manager
-    base_ref: release-1.7
+    base_ref: release-1.8
+  labels:
+    preset-service-account: "true"
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
+    description: Runs 'make test-ci'
+  spec:
+    containers:
+      # TODO: change to a custom image that embeds the system tools we
+      # need (jq, make, bash, Go, etc) but without Bazel. Tracked at
+      # https://github.com/cert-manager/cert-manager/issues/4939.
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+        args:
+          - runner
+          - bash
+          - -c
+          - |
+            apt-get install jq -y >/dev/null
+            make -j vendor-go test-ci
+        resources:
+          requests:
+            cpu: 2
+            memory: 4Gi
+        volumeMounts:
+          - mountPath: /root/.cache/go-build
+            name: gocache
+          - mountPath: /home/prow/go/pkg/mod
+            name: gopkgmod
+          - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
+            name: bindownloaded
+    volumes:
+      - name: gocache
+        hostPath:
+          path: /tmp/gocache
+          type: DirectoryOrCreate
+      - name: gopkgmod
+        hostPath:
+          path: /tmp/gopkgmod
+          type: DirectoryOrCreate
+      - name: bindownloaded
+        hostPath:
+          path: /tmp/bindownloaded
+          type: DirectoryOrCreate
+    dnsConfig:
+      options:
+        - name: ndots
+          value: "1"
+
+- name: ci-cert-manager-upgrade-previous
+  interval: 8h
+  agent: kubernetes
+  decorate: true
+  # extra refs specify what repo should be cloned
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.8
+  annotations:
+    testgrid-create-test-group: 'true'
+    testgrid-dashboards: jetstack-cert-manager-master
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs the end-to-end test suite against a Kubernetes v1.18 cluster
+    description: Runs cert-manager upgrade test
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
-    preset-bazel-remote-cache-enabled: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-cloudflare-credentials: "true"
-    preset-disable-all-alpha-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-      args:
-      - runner
-      - devel/ci-run-e2e.sh
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 12Gi
-      env:
-      - name: K8S_VERSION
-        value: "1.18"
-      securityContext:
-        privileged: true
-        capabilities:
-          add: ["SYS_ADMIN"]
-      volumeMounts:
-      - mountPath: /lib/modules
-        name: modules
-        readOnly: true
-      - mountPath: /sys/fs/cgroup
-        name: cgroup
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+        args:
+        - runner
+        - make
+        - cluster
+        - verify_upgrade
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+          - mountPath: /lib/modules
+            name: modules
+            readOnly: true
+          - mountPath: /sys/fs/cgroup
+            name: cgroup
+          - mountPath: /root/.cache/go-build
+            name: gocache
+          - mountPath: /home/prow/go/pkg/mod
+            name: gopkgmod
+          - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
+            name: bindownloaded
     volumes:
-    - name: modules
-      hostPath:
-        path: /lib/modules
-        type: Directory
-    - name: cgroup
-      hostPath:
-        path: /sys/fs/cgroup
-        type: Directory
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      - name: gocache
+        hostPath:
+          path: /tmp/gocache
+          type: DirectoryOrCreate
+      - name: gopkgmod
+        hostPath:
+          path: /tmp/gopkgmod
+          type: DirectoryOrCreate
+      - name: bindownloaded
+        hostPath:
+          path: /tmp/bindownloaded
+          type: DirectoryOrCreate
     dnsConfig:
       options:
-      - name: ndots
-        value: "1"
+        - name: ndots
+          value: "1"
+
+### E2E tests against all supported Kubernetes versions with all cert-manager alpha/beta feature gates enabled ###
 
 - name: ci-cert-manager-previous-e2e-v1-19
   interval: 2h
@@ -103,7 +171,7 @@ periodics:
   extra_refs:
   - org: cert-manager
     repo: cert-manager
-    base_ref: release-1.7
+    base_ref: release-1.8
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
@@ -122,14 +190,15 @@ periodics:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
       args:
       - runner
-      - devel/ci-run-e2e.sh
+      - bash
+      - -c
+      - |
+        apt-get install jq -y >/dev/null
+        make -j vendor-go e2e-ci K8S_VERSION=1.19
       resources:
         requests:
           cpu: 3500m
           memory: 12Gi
-      env:
-      - name: K8S_VERSION
-        value: "1.19"
       securityContext:
         privileged: true
         capabilities:
@@ -161,7 +230,7 @@ periodics:
   extra_refs:
   - org: cert-manager
     repo: cert-manager
-    base_ref: release-1.7
+    base_ref: release-1.8
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
@@ -180,14 +249,15 @@ periodics:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
       args:
       - runner
-      - devel/ci-run-e2e.sh
+      - bash
+      - -c
+      - |
+        apt-get install jq -y >/dev/null
+        make -j vendor-go e2e-ci K8S_VERSION=1.20
       resources:
         requests:
           cpu: 3500m
           memory: 12Gi
-      env:
-      - name: K8S_VERSION
-        value: "1.20"
       securityContext:
         privileged: true
         capabilities:
@@ -219,7 +289,7 @@ periodics:
   extra_refs:
   - org: cert-manager
     repo: cert-manager
-    base_ref: release-1.7
+    base_ref: release-1.8
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
@@ -238,14 +308,15 @@ periodics:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
       args:
       - runner
-      - devel/ci-run-e2e.sh
+      - bash
+      - -c
+      - |
+        apt-get install jq -y >/dev/null
+        make -j vendor-go e2e-ci K8S_VERSION=1.21
       resources:
         requests:
           cpu: 3500m
           memory: 12Gi
-      env:
-      - name: K8S_VERSION
-        value: "1.21"
       securityContext:
         privileged: true
         capabilities:
@@ -277,7 +348,7 @@ periodics:
   extra_refs:
   - org: cert-manager
     repo: cert-manager
-    base_ref: release-1.7
+    base_ref: release-1.8
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
@@ -296,14 +367,15 @@ periodics:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
       args:
       - runner
-      - devel/ci-run-e2e.sh
+      - bash
+      - -c
+      - |
+        apt-get install jq -y >/dev/null
+        make -j vendor-go e2e-ci K8S_VERSION=1.22
       resources:
         requests:
           cpu: 3500m
           memory: 12Gi
-      env:
-      - name: K8S_VERSION
-        value: "1.22"
       securityContext:
         privileged: true
         capabilities:
@@ -335,7 +407,7 @@ periodics:
   extra_refs:
   - org: cert-manager
     repo: cert-manager
-    base_ref: release-1.7
+    base_ref: release-1.8
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
@@ -354,14 +426,15 @@ periodics:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
       args:
       - runner
-      - devel/ci-run-e2e.sh
+      - bash
+      - -c
+      - |
+        apt-get install jq -y >/dev/null
+        make -j vendor-go e2e-ci K8S_VERSION=1.23
       resources:
         requests:
           cpu: 3500m
           memory: 12Gi
-      env:
-      - name: K8S_VERSION
-        value: "1.23"
       securityContext:
         privileged: true
         capabilities:
@@ -386,8 +459,402 @@ periodics:
       - name: ndots
         value: "1"
 
-# This test runs Venafi (VaaS and TPP) tests once every 24hrs. This is the only CI test
-# job that runs those periodically against release-previous.
+### E2E tests against all supported Kubernetes versions with all cert-manager alpha/beta feature gates disabled ###
+
+- name: ci-cert-manager-e2e-feature-gates-disabled-v1-19-previous
+  interval: 24h
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.8
+  annotations:
+    testgrid-create-test-group: 'true'
+    testgrid-dashboards: jetstack-cert-manager-master
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    description: Runs the end-to-end test suite against a Kubernetes v1.19 cluster with all feature gates disabled
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-cloudflare-credentials: "true"
+    preset-disable-all-alpha-beta-feature-gates: "true"
+    preset-retry-flakey-tests: "true"
+  spec:
+    containers:
+      # TODO: change to a custom image that embeds the system tools we
+      # need (jq, make, bash, Go, etc) but without Bazel. Tracked at
+      # https://github.com/cert-manager/cert-manager/issues/4939.
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+        args:
+        - runner
+        - bash
+        - -c
+        - |
+          apt-get install jq -y >/dev/null
+          make -j vendor-go e2e-ci K8S_VERSION=1.19
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+          - mountPath: /lib/modules
+            name: modules
+            readOnly: true
+          - mountPath: /sys/fs/cgroup
+            name: cgroup
+          - mountPath: /root/.cache/go-build
+            name: gocache
+          - mountPath: /home/prow/go/pkg/mod
+            name: gopkgmod
+          - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
+            name: bindownloaded
+    volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      - name: gocache
+        hostPath:
+          path: /tmp/gocache
+          type: DirectoryOrCreate
+      - name: gopkgmod
+        hostPath:
+          path: /tmp/gopkgmod
+          type: DirectoryOrCreate
+      - name: bindownloaded
+        hostPath:
+          path: /tmp/bindownloaded
+          type: DirectoryOrCreate
+    dnsConfig:
+      options:
+        - name: ndots
+          value: "1"
+
+- name: ci-cert-manager-e2e-feature-gates-disabled-v1-20-previous
+  interval: 24h
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.8
+  annotations:
+    testgrid-create-test-group: 'true'
+    testgrid-dashboards: jetstack-cert-manager-master
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    description: Runs the end-to-end test suite against a Kubernetes v1.20 cluster with all feature gates disabled
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-cloudflare-credentials: "true"
+    preset-disable-all-alpha-beta-feature-gates: "true"
+    preset-retry-flakey-tests: "true"
+  spec:
+    containers:
+      # TODO: change to a custom image that embeds the system tools we
+      # need (jq, make, bash, Go, etc) but without Bazel. Tracked at
+      # https://github.com/cert-manager/cert-manager/issues/4939.
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+        args:
+        - runner
+        - bash
+        - -c
+        - |
+          apt-get install jq -y >/dev/null
+          make -j vendor-go e2e-ci K8S_VERSION=1.20
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+          - mountPath: /lib/modules
+            name: modules
+            readOnly: true
+          - mountPath: /sys/fs/cgroup
+            name: cgroup
+          - mountPath: /root/.cache/go-build
+            name: gocache
+          - mountPath: /home/prow/go/pkg/mod
+            name: gopkgmod
+          - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
+            name: bindownloaded
+    volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      - name: gocache
+        hostPath:
+          path: /tmp/gocache
+          type: DirectoryOrCreate
+      - name: gopkgmod
+        hostPath:
+          path: /tmp/gopkgmod
+          type: DirectoryOrCreate
+      - name: bindownloaded
+        hostPath:
+          path: /tmp/bindownloaded
+          type: DirectoryOrCreate
+    dnsConfig:
+      options:
+        - name: ndots
+          value: "1"
+
+- name: ci-cert-manager-e2e-feature-gates-disabled-v1-21-previous
+  interval: 24h
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.8
+  annotations:
+    testgrid-create-test-group: 'true'
+    testgrid-dashboards: jetstack-cert-manager-master
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    description: Runs the end-to-end test suite against a Kubernetes v1.21 cluster with all feature gates disabled
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-cloudflare-credentials: "true"
+    preset-disable-all-alpha-beta-feature-gates: "true"
+    preset-retry-flakey-tests: "true"
+  spec:
+    containers:
+      # TODO: change to a custom image that embeds the system tools we
+      # need (jq, make, bash, Go, etc) but without Bazel. Tracked at
+      # https://github.com/cert-manager/cert-manager/issues/4939.
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+        args:
+        - runner
+        - bash
+        - -c
+        - |
+          apt-get install jq -y >/dev/null
+          make -j vendor-go e2e-ci K8S_VERSION=1.21
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+          - mountPath: /lib/modules
+            name: modules
+            readOnly: true
+          - mountPath: /sys/fs/cgroup
+            name: cgroup
+          - mountPath: /root/.cache/go-build
+            name: gocache
+          - mountPath: /home/prow/go/pkg/mod
+            name: gopkgmod
+          - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
+            name: bindownloaded
+    volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      - name: gocache
+        hostPath:
+          path: /tmp/gocache
+          type: DirectoryOrCreate
+      - name: gopkgmod
+        hostPath:
+          path: /tmp/gopkgmod
+          type: DirectoryOrCreate
+      - name: bindownloaded
+        hostPath:
+          path: /tmp/bindownloaded
+          type: DirectoryOrCreate
+    dnsConfig:
+      options:
+        - name: ndots
+          value: "1"
+
+- name: ci-cert-manager-e2e-feature-gates-disabled-v1-22-previous
+  interval: 24h
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.8
+  annotations:
+    testgrid-create-test-group: 'true'
+    testgrid-dashboards: jetstack-cert-manager-master
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    description: Runs the end-to-end test suite against a Kubernetes v1.22 cluster with all feature gates disabled
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-cloudflare-credentials: "true"
+    preset-disable-all-alpha-beta-feature-gates: "true"
+    preset-retry-flakey-tests: "true"
+  spec:
+    containers:
+      # TODO: change to a custom image that embeds the system tools we
+      # need (jq, make, bash, Go, etc) but without Bazel. Tracked at
+      # https://github.com/cert-manager/cert-manager/issues/4939.
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+        args:
+          - runner
+          - bash
+          - -c
+          - |
+            apt-get install jq -y >/dev/null
+            make -j vendor-go e2e-ci K8S_VERSION=1.22
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+          - mountPath: /lib/modules
+            name: modules
+            readOnly: true
+          - mountPath: /sys/fs/cgroup
+            name: cgroup
+          - mountPath: /root/.cache/go-build
+            name: gocache
+          - mountPath: /home/prow/go/pkg/mod
+            name: gopkgmod
+          - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
+            name: bindownloaded
+    volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      - name: gocache
+        hostPath:
+          path: /tmp/gocache
+          type: DirectoryOrCreate
+      - name: gopkgmod
+        hostPath:
+          path: /tmp/gopkgmod
+          type: DirectoryOrCreate
+      - name: bindownloaded
+        hostPath:
+          path: /tmp/bindownloaded
+          type: DirectoryOrCreate
+    dnsConfig:
+      options:
+        - name: ndots
+          value: "1"
+
+- name: ci-cert-manager-e2e-feature-gates-disabled-v1-23-previous
+  interval: 24h
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.8
+  annotations:
+    testgrid-create-test-group: 'true'
+    testgrid-dashboards: jetstack-cert-manager-master
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    description: Runs the end-to-end test suite against a Kubernetes v1.23 cluster with all feature gates disabled
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-cloudflare-credentials: "true"
+    preset-disable-all-alpha-beta-feature-gates: "true"
+    preset-retry-flakey-tests: "true"
+  spec:
+    containers:
+      # TODO: change to a custom image that embeds the system tools we
+      # need (jq, make, bash, Go, etc) but without Bazel. Tracked at
+      # https://github.com/cert-manager/cert-manager/issues/4939.
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+        args:
+          - runner
+          - bash
+          - -c
+          - |
+            apt-get install jq -y >/dev/null
+            make -j vendor-go e2e-ci K8S_VERSION=1.23
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+          - mountPath: /lib/modules
+            name: modules
+            readOnly: true
+          - mountPath: /sys/fs/cgroup
+            name: cgroup
+          - mountPath: /root/.cache/go-build
+            name: gocache
+          - mountPath: /home/prow/go/pkg/mod
+            name: gopkgmod
+          - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
+            name: bindownloaded
+    volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      - name: gocache
+        hostPath:
+          path: /tmp/gocache
+          type: DirectoryOrCreate
+      - name: gopkgmod
+        hostPath:
+          path: /tmp/gopkgmod
+          type: DirectoryOrCreate
+      - name: bindownloaded
+        hostPath:
+          path: /tmp/bindownloaded
+          type: DirectoryOrCreate
+    dnsConfig:
+      options:
+        - name: ndots
+          value: "1"
+
+##### E2E tests that don't run as part of normal test run #####
+
+# This test runs Venafi (VaaS and TPP) tests.
+# This is the only CI test job that runs those.
 - name: ci-cert-manager-previous-venafi
   interval: 24h
   agent: kubernetes
@@ -395,112 +862,70 @@ periodics:
   extra_refs:
   - org: cert-manager
     repo: cert-manager
-    base_ref: release-1.7
+    base_ref: release-1.8
   annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs Venafi (VaaS and TPP) e2e tests against Kubernetes v1.23 cluster
+    testgrid-create-test-group: 'false'
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
-    preset-bazel-remote-cache-enabled: "true"
-    preset-bazel-scratch-dir: "true"
     preset-venafi-cloud-credentials: "true"
     preset-venafi-tpp-credentials: "true"
     preset-ginkgo-focus-venafi: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-      args:
-      - runner
-      - devel/ci-run-e2e.sh
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 12Gi
-      env:
-      - name: K8S_VERSION
-        value: "1.23"
-      securityContext:
-        privileged: true
-        capabilities:
-          add: ["SYS_ADMIN"]
-      volumeMounts:
-      - mountPath: /lib/modules
-        name: modules
-        readOnly: true
-      - mountPath: /sys/fs/cgroup
-        name: cgroup
+      # TODO: change to a custom image that embeds the system tools we
+      # need (jq, make, bash, Go, etc) but without Bazel. Tracked at
+      # https://github.com/cert-manager/cert-manager/issues/4939.
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+        args:
+          - runner
+          - bash
+          - -c
+          - |
+            apt-get install jq -y >/dev/null
+            make -j vendor-go e2e-ci K8S_VERSION=1.23
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+          - mountPath: /lib/modules
+            name: modules
+            readOnly: true
+          - mountPath: /sys/fs/cgroup
+            name: cgroup
+          - mountPath: /root/.cache/go-build
+            name: gocache
+          - mountPath: /home/prow/go/pkg/mod
+            name: gopkgmod
+          - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
+            name: bindownloaded
     volumes:
-    - name: modules
-      hostPath:
-        path: /lib/modules
-        type: Directory
-    - name: cgroup
-      hostPath:
-        path: /sys/fs/cgroup
-        type: Directory
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      - name: gocache
+        hostPath:
+          path: /tmp/gocache
+          type: DirectoryOrCreate
+      - name: gopkgmod
+        hostPath:
+          path: /tmp/gopkgmod
+          type: DirectoryOrCreate
+      - name: bindownloaded
+        hostPath:
+          path: /tmp/bindownloaded
+          type: DirectoryOrCreate
     dnsConfig:
       options:
-      - name: ndots
-        value: "1"
-
-
-- name: ci-cert-manager-upgrade-previous
-  interval: 8h
-  agent: kubernetes
-  decorate: true
-  # extra refs specify what repo should be cloned
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: release-1.7
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs cert-manager upgrade test every 8 hours
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-bazel-remote-cache-enabled: "true"
-    preset-bazel-scratch-dir: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-      args:
-      - runner
-      - make
-      - cluster
-      - verify_upgrade
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 12Gi
-      env:
-      - name: K8S_VERSION
-        value: "1.23"
-      securityContext:
-        privileged: true
-        capabilities:
-          add: ["SYS_ADMIN"]
-      volumeMounts:
-      - mountPath: /lib/modules
-        name: modules
-        readOnly: true
-      - mountPath: /sys/fs/cgroup
-        name: cgroup
-    volumes:
-    - name: modules
-      hostPath:
-        path: /lib/modules
-        type: Directory
-    - name: cgroup
-      hostPath:
-        path: /sys/fs/cgroup
-        type: Directory
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
+        - name: ndots
+          value: "1"

--- a/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
@@ -8,8 +8,10 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
+    # release-1.8 is tested via make, but there were still some leftover tests which were bazel-only
+    # as of the release of 1.8, so we need to run bazel test for 1.8 too.
+    - release-1.8
     - release-1.7
-    - release-1.6
     annotations:
       testgrid-create-test-group: 'false'
     labels:
@@ -29,80 +31,6 @@ presubmits:
           requests:
             cpu: 2
             memory: 4Gi
-      dnsConfig:
-        options:
-          - name: ndots
-            value: "1"
-
-  - name: pull-cert-manager-bazel-experimental
-    always_run: false
-    optional: true
-    context: pull-cert-manager-bazel-experimental
-    max_concurrency: 8
-    agent: kubernetes
-    decorate: true
-    branches:
-    - release-1.7
-    - release-1.6
-    annotations:
-      testgrid-create-test-group: 'false'
-      description: Runs 'bazel test --jobs=1 //...' using the 'experimental' Bazel version
-    labels:
-      preset-service-account: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-experimental
-        args:
-        - runner
-        - bazel
-        - test
-        - --jobs=1
-        - //...
-        resources:
-          requests:
-            cpu: 2
-            memory: 4Gi
-      dnsConfig:
-        options:
-          - name: ndots
-            value: "1"
-
-  # Helm chart verification currently requires Docker.
-  # We maintain a standalone presubmit for running this.
-  # See https://github.com/helm/chart-testing/issues/53
-  - name: pull-cert-manager-chart
-    always_run: true
-    context: pull-cert-manager-chart
-    max_concurrency: 8
-    agent: kubernetes
-    decorate: true
-    branches:
-    - release-1.7
-    - release-1.6
-    annotations:
-      testgrid-create-test-group: 'false'
-      description: Verifies the Helm chart passes linting checks
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-        args:
-        - runner
-        - make
-        - verify_chart
-        resources:
-          requests:
-            cpu: 1
-            memory: 1Gi
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
       dnsConfig:
         options:
           - name: ndots
@@ -115,8 +43,10 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
+    # this test is not really valuable for release-1.8 since bazel isn't really used there
+    # still, we might as well run it just in case
+    - release-1.8
     - release-1.7
-    - release-1.6
     annotations:
       testgrid-create-test-group: 'false'
       description: Verifies dependency related files are up to date
@@ -140,65 +70,63 @@ presubmits:
           - name: ndots
             value: "1"
 
-  # cert-manager 1.7 requires at least K8S 1.18 so this will be run only for the release-1.6
-  # branch.
-  - name: pull-cert-manager-e2e-v1-17
-    context: pull-cert-manager-e2e-v1-17
+  - name: pull-cert-manager-make-test
+    context: pull-cert-manager-make-test
     always_run: true
-    optional: true
-    max_concurrency: 4
+    optional: false
+    max_concurrency: 8
     agent: kubernetes
     decorate: true
     branches:
-    - release-1.6
+    # make testing not supported on release-1.7
+    - release-1.8
     annotations:
       testgrid-create-test-group: 'false'
-      description: Runs the end-to-end test suite against a Kubernetes v1.17 cluster
     labels:
       preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-cloudflare-credentials: "true"
-      preset-retry-flakey-tests: "true"
-      preset-disable-all-alpha-feature-gates: "true"
-      preset-ginkgo-skip-default: "true"
     spec:
       containers:
+        # TODO: change to a custom image that embeds the system tools we
+        # need (jq, make, bash, Go, etc) but without Bazel. Tracked at
+        # https://github.com/cert-manager/cert-manager/issues/4939.
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
         args:
         - runner
-        - devel/ci-run-e2e.sh
+        - bash
+        - -c
+        - |
+          apt-get install jq -y >/dev/null
+          make -j vendor-go test-ci
         resources:
           requests:
-            cpu: 3500m
-            memory: 12Gi
-        env:
-        - name: K8S_VERSION
-          value: "1.17"
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
+            cpu: 2
+            memory: 4Gi
         volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
+        - mountPath: /root/.cache/go-build
+          name: gocache
+        - mountPath: /home/prow/go/pkg/mod
+          name: gopkgmod
+        - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
+          name: bindownloaded
       volumes:
-      - name: modules
+      - name: gocache
         hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
+          path: /tmp/gocache
+          type: DirectoryOrCreate
+      - name: gopkgmod
         hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
+          path: /tmp/gopkgmod
+          type: DirectoryOrCreate
+      - name: bindownloaded
+        hostPath:
+          path: /tmp/bindownloaded
+          type: DirectoryOrCreate
       dnsConfig:
         options:
-        - name: ndots
-          value: "1"
+          - name: ndots
+            value: "1"
+
+### E2E tests against all supported Kubernetes versions with all cert-manager alpha/beta feature gates enabled ###
 
   - name: pull-cert-manager-e2e-v1-18
     context: pull-cert-manager-e2e-v1-18
@@ -208,8 +136,8 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
+    # cert-manager 1.8 supports k8s 1.19+, so no need to run against release-1.8 here
     - release-1.7
-    - release-1.6
     annotations:
       testgrid-create-test-group: 'false'
       description: Runs the end-to-end test suite against a Kubernetes v1.18 cluster
@@ -259,6 +187,7 @@ presubmits:
         - name: ndots
           value: "1"
 
+# Run with Bazel for release-1.7 where make was not available
   - name: pull-cert-manager-e2e-v1-19
     context: pull-cert-manager-e2e-v1-19
     always_run: false
@@ -268,7 +197,6 @@ presubmits:
     decorate: true
     branches:
     - release-1.7
-    - release-1.6
     annotations:
       testgrid-create-test-group: 'false'
       description: Runs the end-to-end test suite against a Kubernetes v1.19 cluster
@@ -318,6 +246,66 @@ presubmits:
         - name: ndots
           value: "1"
 
+  - name: pull-cert-manager-e2e-v1-19
+    context: pull-cert-manager-e2e-v1-19
+    always_run: false
+    optional: true
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    branches:
+    - release-1.8
+    annotations:
+      testgrid-create-test-group: 'false'
+      description: Runs the end-to-end test suite against a Kubernetes v1.19 cluster
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-cloudflare-credentials: "true"
+      preset-retry-flakey-tests: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+        args:
+        - runner
+        - bash
+        - -c
+        - |
+          apt-get install jq -y >/dev/null
+          make -j vendor-go e2e-ci K8S_VERSION=1.19
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+
+# Run with Bazel for release-1.7 where make was not available
   - name: pull-cert-manager-e2e-v1-20
     context: pull-cert-manager-e2e-v1-20
     always_run: false
@@ -327,7 +315,6 @@ presubmits:
     decorate: true
     branches:
     - release-1.7
-    - release-1.6
     annotations:
       testgrid-create-test-group: 'false'
       description: Runs the end-to-end test suite against a Kubernetes v1.20 cluster
@@ -377,6 +364,66 @@ presubmits:
         - name: ndots
           value: "1"
 
+  - name: pull-cert-manager-e2e-v1-20
+    context: pull-cert-manager-e2e-v1-20
+    always_run: false
+    optional: true
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    branches:
+    - release-1.8
+    annotations:
+      testgrid-create-test-group: 'false'
+      description: Runs the end-to-end test suite against a Kubernetes v1.20 cluster
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-cloudflare-credentials: "true"
+      preset-retry-flakey-tests: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+        args:
+        - runner
+        - bash
+        - -c
+        - |
+          apt-get install jq -y >/dev/null
+          make -j vendor-go e2e-ci K8S_VERSION=1.20
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+
+# Run with Bazel for release-1.7 where make was not available yet
   - name: pull-cert-manager-e2e-v1-21
     context: pull-cert-manager-e2e-v1-21
     always_run: false
@@ -386,7 +433,6 @@ presubmits:
     decorate: true
     branches:
     - release-1.7
-    - release-1.6
     annotations:
       testgrid-create-test-group: 'false'
       description: Runs the end-to-end test suite against a Kubernetes v1.21 cluster
@@ -436,19 +482,18 @@ presubmits:
         - name: ndots
           value: "1"
 
-
-  - name: pull-cert-manager-e2e-v1-22
-    context: pull-cert-manager-e2e-v1-22
-    always_run: true
-    optional: false # for release-1.6 v1.22 is the latest k8s version supported
+  - name: pull-cert-manager-e2e-v1-21
+    context: pull-cert-manager-e2e-v1-21
+    always_run: false
+    optional: true
     max_concurrency: 4
     agent: kubernetes
     decorate: true
     branches:
-    - release-1.6
+    - release-1.8
     annotations:
       testgrid-create-test-group: 'false'
-      description: Runs the end-to-end test suite against a Kubernetes v1.22 cluster
+      description: Runs the end-to-end test suite against a Kubernetes v1.21 cluster
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -463,14 +508,15 @@ presubmits:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
         args:
         - runner
-        - devel/ci-run-e2e.sh
+        - bash
+        - -c
+        - |
+          apt-get install jq -y >/dev/null
+          make -j vendor-go e2e-ci K8S_VERSION=1.21
         resources:
           requests:
             cpu: 3500m
             memory: 12Gi
-        env:
-        - name: K8S_VERSION
-          value: "1.22"
         securityContext:
           privileged: true
           capabilities:
@@ -495,10 +541,11 @@ presubmits:
         - name: ndots
           value: "1"
 
+# Run with Bazel for release-1.7 where make was not available yet
   - name: pull-cert-manager-e2e-v1-22
     context: pull-cert-manager-e2e-v1-22
     always_run: true
-    optional: true # for release-1.7 testing against v1.22 is optional because v1.23 is the latest version supported
+    optional: true
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -553,10 +600,68 @@ presubmits:
         - name: ndots
           value: "1"
 
+  - name: pull-cert-manager-e2e-v1-22
+    context: pull-cert-manager-e2e-v1-22
+    always_run: false
+    optional: true
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    branches:
+    - release-1.8
+    annotations:
+      testgrid-create-test-group: 'false'
+      description: Runs the end-to-end test suite against a Kubernetes v1.22 cluster
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-cloudflare-credentials: "true"
+      preset-retry-flakey-tests: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+        args:
+        - runner
+        - bash
+        - -c
+        - |
+          apt-get install jq -y >/dev/null
+          make -j vendor-go e2e-ci K8S_VERSION=1.22
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
 
+# Run with Bazel for release-1.7 where make was not available yet
   - name: pull-cert-manager-e2e-v1-23
     context: pull-cert-manager-e2e-v1-23
-    # This is the default e2e test for cert-manager 1.7 but is unsupported for cert-manager 1.6
     always_run: true
     optional: false
     max_concurrency: 4
@@ -613,14 +718,87 @@ presubmits:
         - name: ndots
           value: "1"
 
-  # An E2E test job to allow us to manually trigger the Venafi Cloud E2E tests
-  # with the following GitHub comment:
-  #
-  #  /test pull-cert-manager-e2e-issuers-venafi-cloud-previous
-  #
-  # The regular presubmit jobs do not run Venafi Cloud e2e tests.
-  #
-  - name: pull-cert-manager-e2e-issuers-venafi-cloud-previous
+  - name: pull-cert-manager-e2e-v1-23
+    context: pull-cert-manager-make-e2e-v1-23
+    always_run: true
+    optional: false
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    branches:
+    - release-1.8
+    annotations:
+      testgrid-create-test-group: 'false'
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-cloudflare-credentials: "true"
+      preset-retry-flakey-tests: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+    spec:
+      containers:
+        # TODO: change to a custom image that embeds the system tools we
+        # need (jq, make, bash, Go, etc) but without Bazel. Tracked at
+        # https://github.com/cert-manager/cert-manager/issues/4939.
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+        args:
+        - runner
+        - bash
+        - -c
+        - |
+          apt-get install jq -y >/dev/null
+          make -j vendor-go e2e-ci K8S_VERSION=1.23
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        - mountPath: /root/.cache/go-build
+          name: gocache
+        - mountPath: /home/prow/go/pkg/mod
+          name: gopkgmod
+        - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
+          name: bindownloaded
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      - name: gocache
+        hostPath:
+          path: /tmp/gocache
+          type: DirectoryOrCreate
+      - name: gopkgmod
+        hostPath:
+          path: /tmp/gopkgmod
+          type: DirectoryOrCreate
+      - name: bindownloaded
+        hostPath:
+          path: /tmp/bindownloaded
+          type: DirectoryOrCreate
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+
+### E2E tests against all supported Kubernetes versions with all cert-manager alpha/beta feature gates disabled ###
+
+# Run with Bazel against release-1.7 where make was not available yet
+  - name: pull-cert-manager-e2e-feature-gates-disabled-23
     always_run: false
     optional: true
     max_concurrency: 4
@@ -628,17 +806,17 @@ presubmits:
     decorate: true
     branches:
     - release-1.7
-    - release-1.6
     annotations:
-      description: Runs the E2E tests with 'Venafi TPP' in name
+      description: Runs the E2E tests with all feature gates disabled against Kubernetes 1.23
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
       preset-bazel-remote-cache-enabled: "true"
       preset-bazel-scratch-dir: "true"
-      preset-venafi-tpp-credentials: "true"
+      preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-cloudflare-credentials: "true"
       preset-retry-flakey-tests: "true"
-      preset-ginkgo-focus-venafi-tpp: "true"
+      preset-ginkgo-skip-default: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
@@ -651,8 +829,7 @@ presubmits:
             memory: 12Gi
         env:
         - name: K8S_VERSION
-          value: "1.22" # since this job is rarely run, just use 1.22 for both release-1.6 and release-1.7
-                        # since both support that version of k8s
+          value: "1.23"
         securityContext:
           privileged: true
           capabilities:
@@ -677,6 +854,642 @@ presubmits:
         - name: ndots
           value: "1"
 
+  - name: pull-cert-manager-e2e-feature-gates-disabled-23
+    always_run: false
+    optional: true
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    branches:
+    - release-1.8
+    annotations:
+      description: Runs the E2E tests with all feature gates disabled against Kubernetes 1.23
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-cloudflare-credentials: "true"
+      preset-retry-flakey-tests: "true"
+      preset-ginkgo-skip-default: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+        args:
+        - runner
+        - bash
+        - -c
+        - |
+          apt-get install jq -y >/dev/null
+          make -j vendor-go e2e-ci K8S_VERSION=1.23
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+
+# Run with Bazel for release-1.7 where make was not available yet
+  - name: pull-cert-manager-e2e-feature-gates-disabled-22
+    always_run: false
+    optional: true
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    branches:
+    - release-1.7
+    annotations:
+      description: Runs the E2E tests with all feature gates disabled against Kubernetes 1.22
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-cloudflare-credentials: "true"
+      preset-retry-flakey-tests: "true"
+      preset-ginkgo-skip-default: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+        args:
+        - runner
+        - devel/ci-run-e2e.sh
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        env:
+        - name: K8S_VERSION
+          value: "1.22"
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+
+  - name: pull-cert-manager-e2e-feature-gates-disabled-22
+    always_run: false
+    optional: true
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    branches:
+    - release-1.8
+    annotations:
+      description: Runs the E2E tests with all feature gates disabled against Kubernetes 1.22
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-cloudflare-credentials: "true"
+      preset-retry-flakey-tests: "true"
+      preset-ginkgo-skip-default: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+        args:
+        - runner
+        - bash
+        - -c
+        - |
+          apt-get install jq -y >/dev/null
+          make -j vendor-go e2e-ci K8S_VERSION=1.22
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+
+# Run with Bazel against release-1.7 where make was not available yet
+  - name: pull-cert-manager-e2e-feature-gates-disabled-21
+    always_run: false
+    optional: true
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    branches:
+    - release-1.7
+    annotations:
+      description: Runs the E2E tests with all feature gates disabled against Kubernetes 1.21
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-cloudflare-credentials: "true"
+      preset-retry-flakey-tests: "true"
+      preset-ginkgo-skip-default: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+        args:
+        - runner
+        - devel/ci-run-e2e.sh
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        env:
+        - name: K8S_VERSION
+          value: "1.21"
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+
+  - name: pull-cert-manager-e2e-feature-gates-disabled-21
+    always_run: false
+    optional: true
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    branches:
+    - release-1.8
+    annotations:
+      description: Runs the E2E tests with all feature gates disabled against Kubernetes 1.21
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-cloudflare-credentials: "true"
+      preset-retry-flakey-tests: "true"
+      preset-ginkgo-skip-default: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+        args:
+        - runner
+        - bash
+        - -c
+        - |
+          apt-get install jq -y >/dev/null
+          make -j vendor-go e2e-ci K8S_VERSION=1.21
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+
+# Run with Bazel on release-1.7 where make was not available yet
+  - name: pull-cert-manager-e2e-feature-gates-disabled-20
+    always_run: false
+    optional: true
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    branches:
+    - release-1.7
+    annotations:
+      description: Runs the E2E tests with all feature gates disabled against Kubernetes 1.20
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-cloudflare-credentials: "true"
+      preset-retry-flakey-tests: "true"
+      preset-ginkgo-skip-default: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+        args:
+        - runner
+        - devel/ci-run-e2e.sh
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        env:
+        - name: K8S_VERSION
+          value: "1.20"
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+
+  - name: pull-cert-manager-e2e-feature-gates-disabled-20
+    always_run: false
+    optional: true
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    branches:
+    - release-1.8
+    annotations:
+      description: Runs the E2E tests with all feature gates disabled against Kubernetes 1.20
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-cloudflare-credentials: "true"
+      preset-retry-flakey-tests: "true"
+      preset-ginkgo-skip-default: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+        args:
+        - runner
+        - bash
+        - -c
+        - |
+          apt-get install jq -y >/dev/null
+          make -j vendor-go e2e-ci K8S_VERSION=1.20
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+
+# Run with Bazel for release-1.7 where make was not yet available
+  - name: pull-cert-manager-e2e-feature-gates-disabled-19
+    always_run: false
+    optional: true
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    branches:
+    - release-1.7
+    annotations:
+      description: Runs the E2E tests with all feature gates disabled against Kubernetes 1.19
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-cloudflare-credentials: "true"
+      preset-retry-flakey-tests: "true"
+      preset-ginkgo-skip-default: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+        args:
+        - runner
+        - devel/ci-run-e2e.sh
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        env:
+        - name: K8S_VERSION
+          value: "1.19"
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+
+  - name: pull-cert-manager-e2e-feature-gates-disabled-19
+    always_run: false
+    optional: true
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    branches:
+    - release-1.8
+    annotations:
+      description: Runs the E2E tests with all feature gates disabled against Kubernetes 1.19
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-cloudflare-credentials: "true"
+      preset-retry-flakey-tests: "true"
+      preset-ginkgo-skip-default: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+        args:
+        - runner
+        - bash
+        - -c
+        - |
+          apt-get install jq -y >/dev/null
+          make -j vendor-go e2e-ci K8S_VERSION=1.19
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+
+  - name: pull-cert-manager-e2e-feature-gates-disabled-18
+    always_run: false
+    optional: true
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    branches:
+    # not needed for release-1.8 as cert-manager 1.8 no longer supports Kubernetes 1.8
+    - release-1.7
+    annotations:
+      description: Runs the E2E tests with all feature gates disabled against Kubernetes 1.18
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-cloudflare-credentials: "true"
+      preset-retry-flakey-tests: "true"
+      preset-ginkgo-skip-default: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+        args:
+        - runner
+        - devel/ci-run-e2e.sh
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        env:
+        - name: K8S_VERSION
+          value: "1.18"
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+
+#### E2E tests that are not included in the default test runs ###
+
+  # An E2E test job to allow us to manually trigger the Venafi Cloud E2E tests
+  # with the following GitHub comment:
+  #
+  #  /test pull-cert-manager-e2e-issuers-venafi-cloud-previous
+  #
+  # The regular presubmit jobs do not run Venafi Cloud e2e tests.
+  #
+  - name: pull-cert-manager-e2e-issuers-venafi-cloud-previous
+    always_run: false
+    optional: true
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    branches:
+    - release-1.8
+    - release-1.7
+    annotations:
+      description: Runs the E2E tests with 'Venafi TPP' in name
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-venafi-tpp-credentials: "true"
+      preset-retry-flakey-tests: "true"
+      preset-ginkgo-focus-venafi-tpp: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+        args:
+        - runner
+        - devel/ci-run-e2e.sh
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        env:
+        - name: K8S_VERSION
+          value: "1.23"
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+        
+
   # An E2E test job to allow us to manually trigger the Venafi TPP E2E tests
   # with the following GitHub comment:
   #
@@ -691,8 +1504,8 @@ presubmits:
     agent: kubernetes
     decorate: true
     branches:
+    - release-1.8
     - release-1.7
-    - release-1.6
     annotations:
       description: Runs the E2E tests with 'Venafi Cloud' in name
     labels:
@@ -715,8 +1528,7 @@ presubmits:
             memory: 12Gi
         env:
         - name: K8S_VERSION
-          value: "1.22" # since this job is rarely run, just use 1.22 for both release-1.6 and release-1.7
-                        # since both support that version of k8s
+          value: "1.23"
         securityContext:
           privileged: true
           capabilities:

--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -87,24 +87,6 @@ milestone_applier:
     release-0.10: v0.10
     release-0.9: v0.9
     release-0.8: v0.8
-  cert-manager/website:
-    # cert-manager/website uses master branch for 'current' version and the
-    # release-next branch for the 'next' version
-    release-next: v1.8
-    master: v1.7
-    # Older versions are archived into named release branches
-    release-1.6: v1.6
-    release-1.5: v1.5
-    release-1.4: v1.4
-    release-1.3: v1.3
-    release-1.2: v1.2
-    release-1.1: v1.1
-    release-1.0: v1.0
-    release-0.16: v0.16
-    release-0.15: v0.15
-    release-0.14: v0.14
-    release-0.13: v0.13
-    release-0.12: v0.12
   jetstack/kube-oidc-proxy:
     master: v0.2
     release-0.1: v0.1

--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -68,7 +68,8 @@ repo_milestone:
 
 milestone_applier:
   cert-manager/cert-manager:
-    master: v1.8
+    master: v1.9
+    release-1.8: v1.8
     release-1.7: v1.7
     release-1.6: v1.6
     release-1.5: v1.5


### PR DESCRIPTION
This PR makes the changes necessary to update Prow config post-1.8 release.

This is a little different from the last time we did it i.e https://github.com/jetstack/testing/pull/605 because:
- With the new make functionality being partially available for release-1.8, but not release-1.7 we needed to ensure that make tests run for 1.8, but not 1.7 and that for all tests that aren't yet available to be run with make, there is a bazel alternative being run
- I've also added all the tests that run with feature flags disabled to periodics and optional presubmits against release-1.8 and release-1.7