### PR TITLE
Fix upgrade tests

### DIFF
--- a/config/jobs/cert-manager/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager/cert-manager-periodics.yaml
@@ -588,11 +588,9 @@ periodics:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
         args:
           - runner
-          - bash
-          - -c
-          - |
-            apt-get install jq -y >/dev/null
-            make -j e2e-setup-kind && ./hack/verify-upgrade.sh
+          - make
+          - cluster
+          - verify_upgrade
         resources:
           requests:
             cpu: 3500m


### PR DESCRIPTION

This upgrade periodic test has been failing for a while now https://testgrid.k8s.io/jetstack-cert-manager-master#ci-cert-manager-upgrade

It appears that the new make target to create a cluster runs a check for some tools that may not be needed by the actual tests https://github.com/cert-manager/cert-manager/blob/master/make/tools.mk#L407-L418

I've fixed this by temporarily reverting to the old target as that way we can avoid installing unnecesary deps on every test run.
Long term solution should be to create an image with all the necessary tools embedded [cert-manager#4393](https://github.com/cert-manager/cert-manager/issues/4939), I think this work should be prioritized as by installing tools every time we consume more resources which might be contributing to the recent test flakes.

Signed-off-by: irbekrm <irbekrm@gmail.com>