### PR TITLE
Update cert-manager/approver-policy test runners to use golang v1.18

### DIFF
--- a/config/jobs/cert-manager/approver-policy/cert-manager-approver-policy-presubmits.yaml
+++ b/config/jobs/cert-manager/approver-policy/cert-manager-approver-policy-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
       testgrid-create-test-group: 'false'
     spec:
       containers:
-      - image: golang:1.17
+      - image: golang:1.18
         args:
         - make
         - verify
@@ -31,7 +31,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20220302-b57c609-1.17
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20220503-86fb4cb-1.18
         args:
         - runner
         - make


### PR DESCRIPTION
/assign @irbekrm 