### PR TITLE
Update cert-manager/csi-driver test runners to use go v1.18

### DIFF
--- a/config/jobs/cert-manager/csi-driver/cert-manager-csi-driver-presubmits.yaml
+++ b/config/jobs/cert-manager/csi-driver/cert-manager-csi-driver-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
       testgrid-create-test-group: 'false'
     spec:
       containers:
-      - image: golang:1.17
+      - image: golang:1.18
         args:
         - make
         - verify
@@ -33,7 +33,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20220302-b57c609-1.17
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20220503-86fb4cb-1.18
         args:
         - runner
         - make


### PR DESCRIPTION
/assign @irbekrm 