### PR TITLE
Update cert-manager/csi-driver-spiffe test runners to use go v1.18

### DIFF
--- a/config/jobs/cert-manager/csi-driver-spiffe/cert-manager-csi-driver-spiffe-presubmits.yaml
+++ b/config/jobs/cert-manager/csi-driver-spiffe/cert-manager-csi-driver-spiffe-presubmits.yaml
@@ -13,7 +13,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: golang:1.17
+      - image: golang:1.18
         args:
         - make
         - verify
@@ -36,7 +36,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20220302-b57c609-1.17
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20220503-86fb4cb-1.18
         args:
         - runner
         - make


### PR DESCRIPTION
/assign @irbekrm 