### PR TITLE
Build kind with Kubernetes 1.24

### DIFF
--- a/images/kind/build.sh
+++ b/images/kind/build.sh
@@ -20,9 +20,9 @@ set -o pipefail
 
 # Tag to check out in k/k repo. Kind will build Kubernetes binaries from that
 # tag and include in the built KIND image.
-KUBERNETES_VERSION=v1.23.0-alpha.4
+KUBERNETES_VERSION=v1.24.0
 # Version of the kind CLI to use to build the kind image.
-KIND_BASE_VERSION=v0.11.1
+KIND_BASE_VERSION=v0.12.0
 
 echo "Downloading dependencies..."
 


### PR DESCRIPTION
This PR builds our own kind image with Kubernetes 1.24

We can use this to easily verify that cert-manager works with Kubernetes 1.24 (till kind releases an official image)

Signed-off-by: irbekrm <irbekrm@gmail.com>