### PR TITLE
Pin configurator to a particular version

### DIFF
--- a/config/jobs/testing/testing-presubmits.yaml
+++ b/config/jobs/testing/testing-presubmits.yaml
@@ -91,9 +91,9 @@ presubmits:
       testgrid-create-test-group: "false"
     spec:
       containers:
-      - image: gcr.io/k8s-prow/configurator
+      - image: gcr.io/k8s-prow/configurator:v20220501-de638098ae
         command:
-        - /app/testgrid/cmd/configurator/app.binary
+        - configurator
         args:
         - --yaml=config/testgrid/dashboards.yaml
         - --default=config/testgrid/default.yaml

--- a/config/jobs/testing/testing-trusted.yaml
+++ b/config/jobs/testing/testing-trusted.yaml
@@ -81,9 +81,9 @@ postsubmits:
     spec:
       serviceAccountName: testgrid-updater
       containers:
-      - image: gcr.io/k8s-prow/configurator
+      - image: gcr.io/k8s-prow/configurator:v20220501-de638098ae
         command:
-        - /app/testgrid/cmd/configurator/app.binary
+        - configurator
         args:
         - --yaml=config/testgrid/dashboards.yaml
         - --default=config/testgrid/default.yaml

--- a/config/testgrid/dashboards.yaml
+++ b/config/testgrid/dashboards.yaml
@@ -4,16 +4,12 @@ dashboard_groups:
   dashboard_names:
   - jetstack-cert-manager-master
   - jetstack-cert-manager-previous
-  - jetstack-cert-manager-next
   - jetstack-cert-manager-presubmits-blocking
-  - jetstack-cert-manager-website
   - jetstack-testing-janitors
 
 # Dashboards
 dashboards:
 - name: jetstack-cert-manager-master
 - name: jetstack-cert-manager-previous
-- name: jetstack-cert-manager-next
 - name: jetstack-cert-manager-presubmits-blocking
-- name: jetstack-cert-manager-website
 - name: jetstack-testing-janitors


### PR DESCRIPTION
This PR attempts to pin configurator tool used to validate and upload TestGrid config to the same version that seems to be working for Istio and reference the configurator tool directly. I looked at Istio's ProwJobs [here](https://github.com/istio/test-infra/blob/master/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml#L4-L31) and [here](https://github.com/istio/test-infra/blob/master/prow/cluster/jobs/istio/test-infra/istio.test-infra.master.yaml#L3-L26)

The configurator job failed https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/jetstack_testing/671/pull-testing-check-testgrid-config/1521898589293383680 I think that might have been because we pulled in the latest version and I guess maybe the filesystem of the container has changed.


Signed-off-by: irbekrm <irbekrm@gmail.com>