### PR TITLE
Adds a new presubmit for Kubernetes 1.24

### DIFF
--- a/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
@@ -649,6 +649,85 @@ presubmits:
         - name: ndots
           value: "1"
 
+  - name: pull-cert-manager-make-e2e-v1-24
+    context: pull-cert-manager-make-e2e-v1-24
+    always_run: false
+    optional: true
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    branches:
+    - master
+    annotations:
+      testgrid-create-test-group: 'true'
+      testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
+      description: Runs 'make e2e-ci K8S_VERSION=1.24'
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-cloudflare-credentials: "true"
+      preset-retry-flakey-tests: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+    spec:
+      containers:
+        # TODO: change to a custom image that embeds the system tools we
+        # need (jq, make, bash, Go, etc) but without Bazel. Tracked at
+        # https://github.com/cert-manager/cert-manager/issues/4939.
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+        args:
+        - runner
+        - bash
+        - -c
+        - |
+          apt-get install jq -y >/dev/null
+          make -j vendor-go e2e-ci K8S_VERSION=1.24
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        - mountPath: /root/.cache/go-build
+          name: gocache
+        - mountPath: /home/prow/go/pkg/mod
+          name: gopkgmod
+        - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
+          name: bindownloaded
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      - name: gocache
+        hostPath:
+          path: /tmp/gocache
+          type: DirectoryOrCreate
+      - name: gopkgmod
+        hostPath:
+          path: /tmp/gopkgmod
+          type: DirectoryOrCreate
+      - name: bindownloaded
+        hostPath:
+          path: /tmp/bindownloaded
+          type: DirectoryOrCreate
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+
   # Verifies upgrade from the latest published release with both Helm chart and
   # static manifests.
   - name: pull-cert-manager-upgrade


### PR DESCRIPTION
Adds an optional presubmit for Kubernetes 1.24 (copy-pasted the same for 1.23 and changed some values.

1.24 kind cluster option was already added to cert-manager in https://github.com/cert-manager/cert-manager/pull/5096 , but I _think_ we may need to PR kind cli version bump to cert-manager to have this actually working. If so, it would be good to merge this PR first as then we will be able to run this presubmit against the cert-manager PR that bumps the kind version.

This should allow us to test that the Config Merger stuff works.



Signed-off-by: irbekrm <irbekrm@gmail.com>