### PR TITLE
Adds a semversort tool

### DIFF
--- a/images/bazel-tools/Dockerfile
+++ b/images/bazel-tools/Dockerfile
@@ -19,17 +19,20 @@ FROM ${BASE_IMAGE}
 
 LABEL maintainer="cert-manager-maintainers@googlegroups.com"
 
+COPY semversort.sh /usr/local/bin/semversort
+
 ARG NODE_VERSION
 # install goversion, gcrane, gh cli, jq and node
 RUN go install github.com/rsc/goversion@v1.2.0 && \
     go install github.com/google/go-containerregistry/cmd/gcrane@v0.6.0 && \
-    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
-    apt-get update && \
     apt-get install -y \
-    gh=2.1.0 \
     jq=1.5+dfsg-2+b1 \
-    nodejs=${NODE_VERSION}
+    nodejs=${NODE_VERSION} && \
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
+    apt update && \
+    apt install gh=2.9.0
+
 
 # Add GOPATH/bin to PATH
 ENV PATH=/root/go/bin:$PATH

--- a/images/bazel-tools/semversort.sh
+++ b/images/bazel-tools/semversort.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# +skip_license_check
+
+# Run:
+#    $ semversort 1.0 1.0-rc 1.0-patch 1.0-alpha
+# or in GIT
+#    $ semversort $(git tag)
+# Using pipeline:
+#    $ echo 1.0 1.0-rc 1.0-patch 1.0-alpha | semversort
+#
+# This script is from https://gist.githubusercontent.com/andkirby/54204328823febad9d34422427b1937b/raw/semversort.sh
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+if [ -t 0 ]; then
+  versions_list=$@
+else
+  # catch pipeline output
+  versions_list=$(cat)
+fi
+
+version_weight () {
+  echo -e "$1" | tr ' ' "\n"  | sed -e 's:\+.*$::' | sed -e 's:^v::' | \
+    sed -re 's:^[0-9]+(\.[0-9]+)+$:&-stable:' | \
+    sed -re 's:([^A-Za-z])dev\.?([^A-Za-z]|$):\1.10.\2:g' | \
+    sed -re 's:([^A-Za-z])(alpha|a)\.?([^A-Za-z]|$):\1.20.\3:g' | \
+    sed -re 's:([^A-Za-z])(beta|b)\.?([^A-Za-z]|$):\1.30.\3:g' | \
+    sed -re 's:([^A-Za-z])(rc|RC)\.?([^A-Za-z]|$)?:\1.40.\3:g' | \
+    sed -re 's:([^A-Za-z])stable\.?([^A-Za-z]|$):\1.50.\2:g' | \
+    sed -re 's:([^A-Za-z])pl\.?([^A-Za-z]|$):\1.60.\2:g' | \
+    sed -re 's:([^A-Za-z])(patch|p)\.?([^A-Za-z]|$):\1.70.\3:g' | \
+    sed -r 's:\.{2,}:.:' | \
+    sed -r 's:\.$::' | \
+    sed -r 's:-\.:.:'
+}
+tags_orig=(${versions_list})
+tags_weight=( $(version_weight "${tags_orig[*]}") )
+
+keys=$(for ix in ${!tags_weight[*]}; do
+    printf "%s+%s\n" "${tags_weight[${ix}]}" ${ix}
+done | sort -V | cut -d+ -f2)
+
+for ix in ${keys}; do
+    printf "%s\n" ${tags_orig[${ix}]}
+done


### PR DESCRIPTION
Updates bazel-tools image to add a script that can semantically sort tags.

I would have preferred a (tested) CLI tool, but haven't really found one.

Perhaps we could also use this in cert-manager, see i.e 

This is specifically needed in an internal project, however perhaps we coudl use this elsewhere too to be consistent i.e https://github.com/cert-manager/cert-manager/pull/5104/commits/5f4877443c1612a3bdd7f61d5e63afa611e59246#diff-78e3cf9e2d802b7bfed7e7a17262b4db83e9ff5859f84f1ace9a75169dab33eeR34-R35

Also bumps `gh` version.



Signed-off-by: irbekrm <irbekrm@gmail.com>