### PR TITLE
Adds kube 1.24 periodics

### DIFF
--- a/config/jobs/cert-manager/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager/cert-manager-periodics.yaml
@@ -403,6 +403,7 @@ periodics:
       options:
         - name: ndots
           value: "1"
+
 - name: ci-cert-manager-e2e-v1-23
   interval: 2h
   agent: kubernetes
@@ -435,6 +436,84 @@ periodics:
           - |
             apt-get install jq -y >/dev/null
             make -j vendor-go e2e-ci K8S_VERSION=1.23
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+          - mountPath: /lib/modules
+            name: modules
+            readOnly: true
+          - mountPath: /sys/fs/cgroup
+            name: cgroup
+          - mountPath: /root/.cache/go-build
+            name: gocache
+          - mountPath: /home/prow/go/pkg/mod
+            name: gopkgmod
+          - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
+            name: bindownloaded
+    volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      - name: gocache
+        hostPath:
+          path: /tmp/gocache
+          type: DirectoryOrCreate
+      - name: gopkgmod
+        hostPath:
+          path: /tmp/gopkgmod
+          type: DirectoryOrCreate
+      - name: bindownloaded
+        hostPath:
+          path: /tmp/bindownloaded
+          type: DirectoryOrCreate
+    dnsConfig:
+      options:
+        - name: ndots
+          value: "1"
+
+- name: ci-cert-manager-e2e-v1-24
+  interval: 2h
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: master
+  annotations:
+    testgrid-create-test-group: 'true'
+    testgrid-dashboards: jetstack-cert-manager-master
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    description: Runs the end-to-end test suite against a Kubernetes v1.24 cluster
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-cloudflare-credentials: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+  spec:
+    containers:
+      # TODO: change to a custom image that embeds the system tools we
+      # need (jq, make, bash, Go, etc) but without Bazel. Tracked at
+      # https://github.com/cert-manager/cert-manager/issues/4939.
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+        args:
+          - runner
+          - bash
+          - -c
+          - |
+            apt-get install jq -y >/dev/null
+            make -j vendor-go e2e-ci K8S_VERSION=1.24
         resources:
           requests:
             cpu: 3500m
@@ -1032,6 +1111,84 @@ periodics:
           - |
             apt-get install jq -y >/dev/null
             make -j vendor-go e2e-ci K8S_VERSION=1.23
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+          - mountPath: /lib/modules
+            name: modules
+            readOnly: true
+          - mountPath: /sys/fs/cgroup
+            name: cgroup
+          - mountPath: /root/.cache/go-build
+            name: gocache
+          - mountPath: /home/prow/go/pkg/mod
+            name: gopkgmod
+          - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
+            name: bindownloaded
+    volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      - name: gocache
+        hostPath:
+          path: /tmp/gocache
+          type: DirectoryOrCreate
+      - name: gopkgmod
+        hostPath:
+          path: /tmp/gopkgmod
+          type: DirectoryOrCreate
+      - name: bindownloaded
+        hostPath:
+          path: /tmp/bindownloaded
+          type: DirectoryOrCreate
+    dnsConfig:
+      options:
+        - name: ndots
+          value: "1"
+
+- name: ci-cert-manager-e2e-feature-gates-disabled-v1-24
+  interval: 24h
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: master
+  annotations:
+    testgrid-create-test-group: 'true'
+    testgrid-dashboards: jetstack-cert-manager-master
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    description: Runs the end-to-end test suite against a Kubernetes v1.24 cluster with all feature gates disabled
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-cloudflare-credentials: "true"
+    preset-disable-all-alpha-beta-feature-gates: "true"
+    preset-retry-flakey-tests: "true"
+  spec:
+    containers:
+      # TODO: change to a custom image that embeds the system tools we
+      # need (jq, make, bash, Go, etc) but without Bazel. Tracked at
+      # https://github.com/cert-manager/cert-manager/issues/4939.
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+        args:
+          - runner
+          - bash
+          - -c
+          - |
+            apt-get install jq -y >/dev/null
+            make -j vendor-go e2e-ci K8S_VERSION=1.24
         resources:
           requests:
             cpu: 3500m


### PR DESCRIPTION
This adds kube 1.24 periodic tests.

We need to pick up https://github.com/jetstack/testing/pull/660 - once that is done we could also add these tests for release-1.8  (If we backport https://github.com/cert-manager/cert-manager/pull/5104) and add 1.24 to supported releases for that.

These will pass once https://github.com/cert-manager/cert-manager/pull/5104 gets merged so that should be merged first.

(This PR getting merged should trigger `testing-upload-testgrid-config`, so that should show whether the recent change made to our test infra works and https://github.com/jetstack/testing/issues/676 is fixed)



Signed-off-by: irbekrm <irbekrm@gmail.com>