### PR TITLE
Run make ci-presubmit as well as unit tests

### DIFF
--- a/config/jobs/cert-manager/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager/cert-manager-periodics.yaml
@@ -49,7 +49,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-master
-    description: Runs 'make test-ci'
+    description: Runs unit tests and verification scripts
   spec:
     containers:
       # TODO: change to a custom image that embeds the system tools we
@@ -62,7 +62,7 @@ periodics:
           - -c
           - |
             apt-get install jq -y >/dev/null
-            make -j vendor-go test-ci
+            make -j vendor-go ci-presubmit test-ci
         resources:
           requests:
             cpu: 2

--- a/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
@@ -53,7 +53,7 @@ presubmits:
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
-      description: Runs 'make test-ci'
+      description: Runs unit tests and verification scripts
     labels:
       preset-service-account: "true"
     spec:
@@ -68,7 +68,7 @@ presubmits:
         - -c
         - |
           apt-get install jq -y >/dev/null
-          make -j vendor-go test-ci
+          make -j vendor-go ci-presubmit test-ci
         resources:
           requests:
             cpu: 2


### PR DESCRIPTION
For make to replace bazel we need to run this target, which will do various other verification steps currently run by bazel.