### PR TITLE
Install jq in bazelbuild image

### DIFF
--- a/images/bazelbuild/Dockerfile
+++ b/images/bazelbuild/Dockerfile
@@ -93,6 +93,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     patch \
     openssh-client \
     moreutils \
+    jq \
     && apt-get clean \
     && python -m pip install --upgrade pip setuptools wheel
 


### PR DESCRIPTION
This is required by the new cert-manager make-based build system. Longer term we won't be using the "bazelbuild" image for the make build system, but having support for make-inside-bazel and make-or-bazel using this image will be helpful during the transition.
