### PR TITLE
Run 'previous' tests against kube 1.24

### DIFF
--- a/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
@@ -455,6 +455,124 @@ periodics:
       - name: ndots
         value: "1"
 
+- name: ci-cert-manager-previous-e2e-v1-24
+  interval: 2h
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.8
+  annotations:
+    testgrid-create-test-group: 'true'
+    testgrid-dashboards: jetstack-cert-manager-previous
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    description: Runs the end-to-end test suite against a Kubernetes v1.24 cluster
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-cloudflare-credentials: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+      args:
+      - runner
+      - make
+      - -j
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.24
+      resources:
+        requests:
+          cpu: 3500m
+          memory: 12Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add: ["SYS_ADMIN"]
+      volumeMounts:
+      - mountPath: /lib/modules
+        name: modules
+        readOnly: true
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    volumes:
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+
+# This periodic is here to temporarily test release-1.7 against Kubernetes 1.24
+# to verify that it works as we have not tested with 1.24 coming up to releasing
+# 1.7. Remove this job altogether when removing tests for 1.7
+- name: ci-cert-manager-previous-previous-e2e-v1-24
+  interval: 24h
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.7
+  annotations:
+    testgrid-create-test-group: 'true'
+    testgrid-dashboards: jetstack-cert-manager-previous
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    description: Runs the end-to-end test suite against a Kubernetes v1.24 cluster
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-cloudflare-credentials: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+      args:
+      - runner
+      - devel/ci-run-e2e.sh
+      resources:
+        requests:
+          cpu: 3500m
+          memory: 12Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add: ["SYS_ADMIN"]
+      volumeMounts:
+      - mountPath: /lib/modules
+        name: modules
+        readOnly: true
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    volumes:
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+
+
 ### E2E tests against all supported Kubernetes versions with all cert-manager alpha/beta feature gates disabled ###
 
 - name: ci-cert-manager-e2e-feature-gates-disabled-v1-19-previous
@@ -786,6 +904,161 @@ periodics:
         - vendor-go
         - e2e-ci
         - K8S_VERSION=1.23
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+          - mountPath: /lib/modules
+            name: modules
+            readOnly: true
+          - mountPath: /sys/fs/cgroup
+            name: cgroup
+          - mountPath: /root/.cache/go-build
+            name: gocache
+          - mountPath: /home/prow/go/pkg/mod
+            name: gopkgmod
+          - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
+            name: bindownloaded
+    volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      - name: gocache
+        hostPath:
+          path: /tmp/gocache
+          type: DirectoryOrCreate
+      - name: gopkgmod
+        hostPath:
+          path: /tmp/gopkgmod
+          type: DirectoryOrCreate
+      - name: bindownloaded
+        hostPath:
+          path: /tmp/bindownloaded
+          type: DirectoryOrCreate
+    dnsConfig:
+      options:
+        - name: ndots
+          value: "1"
+
+- name: ci-cert-manager-e2e-feature-gates-disabled-v1-24-previous
+  interval: 24h
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.8
+  annotations:
+    testgrid-create-test-group: 'true'
+    testgrid-dashboards: jetstack-cert-manager-master
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    description: Runs the end-to-end test suite against a Kubernetes v1.24 cluster with all feature gates disabled
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-cloudflare-credentials: "true"
+    preset-disable-all-alpha-beta-feature-gates: "true"
+    preset-retry-flakey-tests: "true"
+  spec:
+    containers:
+      # TODO: change to a custom image that embeds the system tools we
+      # need (jq, make, bash, Go, etc) but without Bazel. Tracked at
+      # https://github.com/cert-manager/cert-manager/issues/4939.
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+        args:
+        - runner
+        - make
+        - -j
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.24
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+          - mountPath: /lib/modules
+            name: modules
+            readOnly: true
+          - mountPath: /sys/fs/cgroup
+            name: cgroup
+          - mountPath: /root/.cache/go-build
+            name: gocache
+          - mountPath: /home/prow/go/pkg/mod
+            name: gopkgmod
+          - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
+            name: bindownloaded
+    volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      - name: gocache
+        hostPath:
+          path: /tmp/gocache
+          type: DirectoryOrCreate
+      - name: gopkgmod
+        hostPath:
+          path: /tmp/gopkgmod
+          type: DirectoryOrCreate
+      - name: bindownloaded
+        hostPath:
+          path: /tmp/bindownloaded
+          type: DirectoryOrCreate
+    dnsConfig:
+      options:
+        - name: ndots
+          value: "1"
+
+# This periodic is here to temporarily test release-1.7 against Kubernetes 1.24
+# to verify that it works as we have not tested with 1.24 coming up to releasing
+# 1.7. Remove this job altogether when removing tests for 1.7
+- name: ci-cert-manager-e2e-feature-gates-disabled-v1-24-previous-prev
+  interval: 24h
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.7
+  annotations:
+    testgrid-create-test-group: 'true'
+    testgrid-dashboards: jetstack-cert-manager-master
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    description: Runs the end-to-end test suite against a Kubernetes v1.24 cluster with all feature gates disabled
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-cloudflare-credentials: "true"
+    preset-disable-all-alpha-beta-feature-gates: "true"
+    preset-retry-flakey-tests: "true"
+  spec:
+    containers:
+      # TODO: change to a custom image that embeds the system tools we
+      # need (jq, make, bash, Go, etc) but without Bazel. Tracked at
+      # https://github.com/cert-manager/cert-manager/issues/4939.
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+        args:
+        - runner
+        - devel/ci-run-e2e.sh
         resources:
           requests:
             cpu: 3500m

--- a/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
@@ -634,6 +634,9 @@ periodics:
       args:
       - runner
       - devel/ci-run-e2e.sh
+      env:
+      - name: K8S_VERSION
+        value: "1.24"
       resources:
         requests:
           cpu: 3500m
@@ -1149,6 +1152,9 @@ periodics:
         args:
         - runner
         - devel/ci-run-e2e.sh
+        env:
+        - name: K8S_VERSION
+          value: "1.24"
         resources:
           requests:
             cpu: 3500m

--- a/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
@@ -126,12 +126,6 @@ periodics:
             readOnly: true
           - mountPath: /sys/fs/cgroup
             name: cgroup
-          - mountPath: /root/.cache/go-build
-            name: gocache
-          - mountPath: /home/prow/go/pkg/mod
-            name: gopkgmod
-          - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-            name: bindownloaded
     volumes:
       - name: modules
         hostPath:
@@ -141,18 +135,6 @@ periodics:
         hostPath:
           path: /sys/fs/cgroup
           type: Directory
-      - name: gocache
-        hostPath:
-          path: /tmp/gocache
-          type: DirectoryOrCreate
-      - name: gopkgmod
-        hostPath:
-          path: /tmp/gopkgmod
-          type: DirectoryOrCreate
-      - name: bindownloaded
-        hostPath:
-          path: /tmp/bindownloaded
-          type: DirectoryOrCreate
     dnsConfig:
       options:
         - name: ndots
@@ -200,12 +182,27 @@ periodics:
         capabilities:
           add: ["SYS_ADMIN"]
       volumeMounts:
+      - mountPath: /root/.cache/go-build
+        name: gocache
+      - mountPath: /home/prow/go/pkg/mod
+        name: gopkgmod
+      - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
+        name: bindownloaded
+      - mountPath: /lib/modules
+        name: modules
+        readOnly: true
       - mountPath: /lib/modules
         name: modules
         readOnly: true
       - mountPath: /sys/fs/cgroup
         name: cgroup
     volumes:
+    - mountPath: /root/.cache/go-build
+      name: gocache
+    - mountPath: /home/prow/go/pkg/mod
+      name: gopkgmod
+    - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
+      name: bindownloaded
     - name: modules
       hostPath:
         path: /lib/modules
@@ -259,12 +256,30 @@ periodics:
         capabilities:
           add: ["SYS_ADMIN"]
       volumeMounts:
+      - mountPath: /root/.cache/go-build
+        name: gocache
+      - mountPath: /home/prow/go/pkg/mod
+        name: gopkgmod
+      - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
+        name: bindownloaded
       - mountPath: /lib/modules
         name: modules
         readOnly: true
       - mountPath: /sys/fs/cgroup
         name: cgroup
     volumes:
+    - name: gocache
+      hostPath:
+        path: /tmp/gocache
+        type: DirectoryOrCreate
+    - name: gopkgmod
+      hostPath:
+        path: /tmp/gopkgmod
+        type: DirectoryOrCreate
+    - name: bindownloaded
+      hostPath:
+        path: /tmp/bindownloaded
+        type: DirectoryOrCreate
     - name: modules
       hostPath:
         path: /lib/modules
@@ -318,12 +333,30 @@ periodics:
         capabilities:
           add: ["SYS_ADMIN"]
       volumeMounts:
+      - mountPath: /root/.cache/go-build
+        name: gocache
+      - mountPath: /home/prow/go/pkg/mod
+        name: gopkgmod
+      - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
+        name: bindownloaded
       - mountPath: /lib/modules
         name: modules
         readOnly: true
       - mountPath: /sys/fs/cgroup
         name: cgroup
     volumes:
+    - name: gocache
+      hostPath:
+        path: /tmp/gocache
+        type: DirectoryOrCreate
+    - name: gopkgmod
+      hostPath:
+        path: /tmp/gopkgmod
+        type: DirectoryOrCreate
+    - name: bindownloaded
+      hostPath:
+        path: /tmp/bindownloaded
+        type: DirectoryOrCreate
     - name: modules
       hostPath:
         path: /lib/modules
@@ -377,12 +410,33 @@ periodics:
         capabilities:
           add: ["SYS_ADMIN"]
       volumeMounts:
+      - mountPath: /root/.cache/go-build
+        name: gocache
+      - mountPath: /home/prow/go/pkg/mod
+        name: gopkgmod
+      - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
+        name: bindownloaded
+      - mountPath: /lib/modules
+        name: modules
+        readOnly: true
       - mountPath: /lib/modules
         name: modules
         readOnly: true
       - mountPath: /sys/fs/cgroup
         name: cgroup
     volumes:
+    - name: gocache
+      hostPath:
+        path: /tmp/gocache
+        type: DirectoryOrCreate
+    - name: gopkgmod
+      hostPath:
+        path: /tmp/gopkgmod
+        type: DirectoryOrCreate
+    - name: bindownloaded
+      hostPath:
+        path: /tmp/bindownloaded
+        type: DirectoryOrCreate
     - name: modules
       hostPath:
         path: /lib/modules
@@ -436,12 +490,30 @@ periodics:
         capabilities:
           add: ["SYS_ADMIN"]
       volumeMounts:
+      - mountPath: /root/.cache/go-build
+        name: gocache
+      - mountPath: /home/prow/go/pkg/mod
+        name: gopkgmod
+      - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
+        name: bindownloaded
       - mountPath: /lib/modules
         name: modules
         readOnly: true
       - mountPath: /sys/fs/cgroup
         name: cgroup
     volumes:
+    - name: gocache
+      hostPath:
+        path: /tmp/gocache
+        type: DirectoryOrCreate
+    - name: gopkgmod
+      hostPath:
+        path: /tmp/gopkgmod
+        type: DirectoryOrCreate
+    - name: bindownloaded
+      hostPath:
+        path: /tmp/bindownloaded
+        type: DirectoryOrCreate
     - name: modules
       hostPath:
         path: /lib/modules
@@ -495,12 +567,30 @@ periodics:
         capabilities:
           add: ["SYS_ADMIN"]
       volumeMounts:
+      - mountPath: /root/.cache/go-build
+        name: gocache
+      - mountPath: /home/prow/go/pkg/mod
+        name: gopkgmod
+      - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
+        name: bindownloaded
       - mountPath: /lib/modules
         name: modules
         readOnly: true
       - mountPath: /sys/fs/cgroup
         name: cgroup
     volumes:
+    - name: gocache
+      hostPath:
+        path: /tmp/gocache
+        type: DirectoryOrCreate
+    - name: gopkgmod
+      hostPath:
+        path: /tmp/gopkgmod
+        type: DirectoryOrCreate
+    - name: bindownloaded
+      hostPath:
+        path: /tmp/bindownloaded
+        type: DirectoryOrCreate
     - name: modules
       hostPath:
         path: /lib/modules
@@ -1073,12 +1163,6 @@ periodics:
             readOnly: true
           - mountPath: /sys/fs/cgroup
             name: cgroup
-          - mountPath: /root/.cache/go-build
-            name: gocache
-          - mountPath: /home/prow/go/pkg/mod
-            name: gopkgmod
-          - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-            name: bindownloaded
     volumes:
       - name: modules
         hostPath:
@@ -1088,18 +1172,6 @@ periodics:
         hostPath:
           path: /sys/fs/cgroup
           type: Directory
-      - name: gocache
-        hostPath:
-          path: /tmp/gocache
-          type: DirectoryOrCreate
-      - name: gopkgmod
-        hostPath:
-          path: /tmp/gopkgmod
-          type: DirectoryOrCreate
-      - name: bindownloaded
-        hostPath:
-          path: /tmp/bindownloaded
-          type: DirectoryOrCreate
     dnsConfig:
       options:
         - name: ndots

--- a/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
@@ -1064,9 +1064,6 @@ periodics:
     preset-retry-flakey-tests: "true"
   spec:
     containers:
-      # TODO: change to a custom image that embeds the system tools we
-      # need (jq, make, bash, Go, etc) but without Bazel. Tracked at
-      # https://github.com/cert-manager/cert-manager/issues/4939.
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
         args:
         - runner
@@ -1145,9 +1142,6 @@ periodics:
     preset-retry-flakey-tests: "true"
   spec:
     containers:
-      # TODO: change to a custom image that embeds the system tools we
-      # need (jq, make, bash, Go, etc) but without Bazel. Tracked at
-      # https://github.com/cert-manager/cert-manager/issues/4939.
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
         args:
         - runner

--- a/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
@@ -282,6 +282,12 @@ presubmits:
           capabilities:
             add: ["SYS_ADMIN"]
         volumeMounts:
+        - mountPath: /root/.cache/go-build
+          name: gocache
+        - mountPath: /home/prow/go/pkg/mod
+          name: gopkgmod
+        - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
+          name: bindownloaded
         - mountPath: /lib/modules
           name: modules
           readOnly: true
@@ -296,6 +302,18 @@ presubmits:
         hostPath:
           path: /sys/fs/cgroup
           type: Directory
+      - name: gocache
+        hostPath:
+          path: /tmp/gocache
+          type: DirectoryOrCreate
+      - name: gopkgmod
+        hostPath:
+          path: /tmp/gopkgmod
+          type: DirectoryOrCreate
+      - name: bindownloaded
+        hostPath:
+          path: /tmp/bindownloaded
+          type: DirectoryOrCreate
       dnsConfig:
         options:
         - name: ndots
@@ -400,12 +418,30 @@ presubmits:
           capabilities:
             add: ["SYS_ADMIN"]
         volumeMounts:
+        - mountPath: /root/.cache/go-build
+          name: gocache
+        - mountPath: /home/prow/go/pkg/mod
+          name: gopkgmod
+        - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
+          name: bindownloaded
         - mountPath: /lib/modules
           name: modules
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
       volumes:
+      - name: gocache
+        hostPath:
+          path: /tmp/gocache
+          type: DirectoryOrCreate
+      - name: gopkgmod
+        hostPath:
+          path: /tmp/gopkgmod
+          type: DirectoryOrCreate
+      - name: bindownloaded
+        hostPath:
+          path: /tmp/bindownloaded
+          type: DirectoryOrCreate
       - name: modules
         hostPath:
           path: /lib/modules
@@ -518,12 +554,30 @@ presubmits:
           capabilities:
             add: ["SYS_ADMIN"]
         volumeMounts:
+        - mountPath: /root/.cache/go-build
+          name: gocache
+        - mountPath: /home/prow/go/pkg/mod
+          name: gopkgmod
+        - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
+          name: bindownloaded
         - mountPath: /lib/modules
           name: modules
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
       volumes:
+      - name: gocache
+        hostPath:
+          path: /tmp/gocache
+          type: DirectoryOrCreate
+      - name: gopkgmod
+        hostPath:
+          path: /tmp/gopkgmod
+          type: DirectoryOrCreate
+      - name: bindownloaded
+        hostPath:
+          path: /tmp/bindownloaded
+          type: DirectoryOrCreate
       - name: modules
         hostPath:
           path: /lib/modules
@@ -636,12 +690,30 @@ presubmits:
           capabilities:
             add: ["SYS_ADMIN"]
         volumeMounts:
+        - mountPath: /root/.cache/go-build
+          name: gocache
+        - mountPath: /home/prow/go/pkg/mod
+          name: gopkgmod
+        - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
+          name: bindownloaded
         - mountPath: /lib/modules
           name: modules
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
       volumes:
+      - name: gocache
+        hostPath:
+          path: /tmp/gocache
+          type: DirectoryOrCreate
+      - name: gopkgmod
+        hostPath:
+          path: /tmp/gopkgmod
+          type: DirectoryOrCreate
+      - name: bindownloaded
+        hostPath:
+          path: /tmp/bindownloaded
+          type: DirectoryOrCreate
       - name: modules
         hostPath:
           path: /lib/modules
@@ -907,12 +979,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-        - mountPath: /root/.cache/go-build
-          name: gocache
-        - mountPath: /home/prow/go/pkg/mod
-          name: gopkgmod
-        - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-          name: bindownloaded
       volumes:
       - name: modules
         hostPath:
@@ -922,18 +988,6 @@ presubmits:
         hostPath:
           path: /sys/fs/cgroup
           type: Directory
-      - name: gocache
-        hostPath:
-          path: /tmp/gocache
-          type: DirectoryOrCreate
-      - name: gopkgmod
-        hostPath:
-          path: /tmp/gopkgmod
-          type: DirectoryOrCreate
-      - name: bindownloaded
-        hostPath:
-          path: /tmp/bindownloaded
-          type: DirectoryOrCreate
       dnsConfig:
         options:
         - name: ndots
@@ -1036,12 +1090,30 @@ presubmits:
           capabilities:
             add: ["SYS_ADMIN"]
         volumeMounts:
+        - mountPath: /root/.cache/go-build
+          name: gocache
+        - mountPath: /home/prow/go/pkg/mod
+          name: gopkgmod
+        - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
+          name: bindownloaded
         - mountPath: /lib/modules
           name: modules
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
       volumes:
+      - name: gocache
+        hostPath:
+          path: /tmp/gocache
+          type: DirectoryOrCreate
+      - name: gopkgmod
+        hostPath:
+          path: /tmp/gopkgmod
+          type: DirectoryOrCreate
+      - name: bindownloaded
+        hostPath:
+          path: /tmp/bindownloaded
+          type: DirectoryOrCreate
       - name: modules
         hostPath:
           path: /lib/modules
@@ -1150,12 +1222,30 @@ presubmits:
           capabilities:
             add: ["SYS_ADMIN"]
         volumeMounts:
+        - mountPath: /root/.cache/go-build
+          name: gocache
+        - mountPath: /home/prow/go/pkg/mod
+          name: gopkgmod
+        - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
+          name: bindownloaded
         - mountPath: /lib/modules
           name: modules
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
       volumes:
+      - name: gocache
+        hostPath:
+          path: /tmp/gocache
+          type: DirectoryOrCreate
+      - name: gopkgmod
+        hostPath:
+          path: /tmp/gopkgmod
+          type: DirectoryOrCreate
+      - name: bindownloaded
+        hostPath:
+          path: /tmp/bindownloaded
+          type: DirectoryOrCreate
       - name: modules
         hostPath:
           path: /lib/modules
@@ -1264,12 +1354,30 @@ presubmits:
           capabilities:
             add: ["SYS_ADMIN"]
         volumeMounts:
+        - mountPath: /root/.cache/go-build
+          name: gocache
+        - mountPath: /home/prow/go/pkg/mod
+          name: gopkgmod
+        - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
+          name: bindownloaded
         - mountPath: /lib/modules
           name: modules
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
       volumes:
+      - name: gocache
+        hostPath:
+          path: /tmp/gocache
+          type: DirectoryOrCreate
+      - name: gopkgmod
+        hostPath:
+          path: /tmp/gopkgmod
+          type: DirectoryOrCreate
+      - name: bindownloaded
+        hostPath:
+          path: /tmp/bindownloaded
+          type: DirectoryOrCreate
       - name: modules
         hostPath:
           path: /lib/modules
@@ -1378,12 +1486,30 @@ presubmits:
           capabilities:
             add: ["SYS_ADMIN"]
         volumeMounts:
+        - mountPath: /root/.cache/go-build
+          name: gocache
+        - mountPath: /home/prow/go/pkg/mod
+          name: gopkgmod
+        - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
+          name: bindownloaded
         - mountPath: /lib/modules
           name: modules
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
       volumes:
+      - name: gocache
+        hostPath:
+          path: /tmp/gocache
+          type: DirectoryOrCreate
+      - name: gopkgmod
+        hostPath:
+          path: /tmp/gopkgmod
+          type: DirectoryOrCreate
+      - name: bindownloaded
+        hostPath:
+          path: /tmp/bindownloaded
+          type: DirectoryOrCreate
       - name: modules
         hostPath:
           path: /lib/modules
@@ -1497,7 +1623,25 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
+        - mountPath: /root/.cache/go-build
+          name: gocache
+        - mountPath: /home/prow/go/pkg/mod
+          name: gopkgmod
+        - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
+          name: bindownloaded
       volumes:
+      - name: gocache
+        hostPath:
+          path: /tmp/gocache
+          type: DirectoryOrCreate
+      - name: gopkgmod
+        hostPath:
+          path: /tmp/gopkgmod
+          type: DirectoryOrCreate
+      - name: bindownloaded
+        hostPath:
+          path: /tmp/bindownloaded
+          type: DirectoryOrCreate
       - name: modules
         hostPath:
           path: /lib/modules
@@ -1606,12 +1750,30 @@ presubmits:
           capabilities:
             add: ["SYS_ADMIN"]
         volumeMounts:
+        - mountPath: /root/.cache/go-build
+          name: gocache
+        - mountPath: /home/prow/go/pkg/mod
+          name: gopkgmod
+        - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
+          name: bindownloaded
         - mountPath: /lib/modules
           name: modules
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
       volumes:
+      - name: gocache
+        hostPath:
+          path: /tmp/gocache
+          type: DirectoryOrCreate
+      - name: gopkgmod
+        hostPath:
+          path: /tmp/gopkgmod
+          type: DirectoryOrCreate
+      - name: bindownloaded
+        hostPath:
+          path: /tmp/bindownloaded
+          type: DirectoryOrCreate
       - name: modules
         hostPath:
           path: /lib/modules

--- a/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
@@ -965,6 +965,9 @@ presubmits:
         args:
         - runner
         - devel/ci-run-e2e.sh
+        env:
+        - name: K8S_VERSION
+          value: "1.24"
         resources:
           requests:
             cpu: 3500m

--- a/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
@@ -880,9 +880,6 @@ presubmits:
       preset-ginkgo-skip-default: "true"
     spec:
       containers:
-        # TODO: change to a custom image that embeds the system tools we
-        # need (jq, make, bash, Go, etc) but without Bazel. Tracked at
-        # https://github.com/cert-manager/cert-manager/issues/4939.
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
         args:
         - runner
@@ -958,9 +955,6 @@ presubmits:
       preset-ginkgo-skip-default: "true"
     spec:
       containers:
-        # TODO: change to a custom image that embeds the system tools we
-        # need (jq, make, bash, Go, etc) but without Bazel. Tracked at
-        # https://github.com/cert-manager/cert-manager/issues/4939.
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
         args:
         - runner

--- a/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
@@ -788,7 +788,272 @@ presubmits:
         - name: ndots
           value: "1"
 
+  - name: pull-cert-manager-e2e-v1-24
+    context: pull-cert-manager-make-e2e-v1-24
+    always_run: true
+    optional: false
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    branches:
+    - release-1.8
+    annotations:
+      testgrid-create-test-group: 'false'
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-cloudflare-credentials: "true"
+      preset-retry-flakey-tests: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+    spec:
+      containers:
+        # TODO: change to a custom image that embeds the system tools we
+        # need (jq, make, bash, Go, etc) but without Bazel. Tracked at
+        # https://github.com/cert-manager/cert-manager/issues/4939.
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+        args:
+        - runner
+        - make
+        - -j
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.24
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        - mountPath: /root/.cache/go-build
+          name: gocache
+        - mountPath: /home/prow/go/pkg/mod
+          name: gopkgmod
+        - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
+          name: bindownloaded
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      - name: gocache
+        hostPath:
+          path: /tmp/gocache
+          type: DirectoryOrCreate
+      - name: gopkgmod
+        hostPath:
+          path: /tmp/gopkgmod
+          type: DirectoryOrCreate
+      - name: bindownloaded
+        hostPath:
+          path: /tmp/bindownloaded
+          type: DirectoryOrCreate
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+
+# Run with Bazel for release-1.7 where make was not available yet
+  - name: pull-cert-manager-e2e-v1-24
+    context: pull-cert-manager-make-e2e-v1-24
+    always_run: true
+    optional: false
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    branches:
+    - release-1.7
+    annotations:
+      testgrid-create-test-group: 'false'
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-cloudflare-credentials: "true"
+      preset-retry-flakey-tests: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+    spec:
+      containers:
+        # TODO: change to a custom image that embeds the system tools we
+        # need (jq, make, bash, Go, etc) but without Bazel. Tracked at
+        # https://github.com/cert-manager/cert-manager/issues/4939.
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+        args:
+        - runner
+        - devel/ci-run-e2e.sh
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        - mountPath: /root/.cache/go-build
+          name: gocache
+        - mountPath: /home/prow/go/pkg/mod
+          name: gopkgmod
+        - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
+          name: bindownloaded
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      - name: gocache
+        hostPath:
+          path: /tmp/gocache
+          type: DirectoryOrCreate
+      - name: gopkgmod
+        hostPath:
+          path: /tmp/gopkgmod
+          type: DirectoryOrCreate
+      - name: bindownloaded
+        hostPath:
+          path: /tmp/bindownloaded
+          type: DirectoryOrCreate
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+
 ### E2E tests against all supported Kubernetes versions with all cert-manager alpha/beta feature gates disabled ###
+
+# Run with Bazel against release-1.7 where make was not available yet
+  - name: pull-cert-manager-e2e-feature-gates-disabled-24
+    always_run: false
+    optional: true
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    branches:
+    - release-1.7
+    annotations:
+      description: Runs the E2E tests with all feature gates disabled against Kubernetes 1.24
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-cloudflare-credentials: "true"
+      preset-retry-flakey-tests: "true"
+      preset-ginkgo-skip-default: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+        args:
+        - runner
+        - devel/ci-run-e2e.sh
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        env:
+        - name: K8S_VERSION
+          value: "1.24"
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+
+  - name: pull-cert-manager-e2e-feature-gates-disabled-24
+    always_run: false
+    optional: true
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    branches:
+    - release-1.8
+    annotations:
+      description: Runs the E2E tests with all feature gates disabled against Kubernetes 1.24
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-cloudflare-credentials: "true"
+      preset-retry-flakey-tests: "true"
+      preset-ginkgo-skip-default: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1 
+        args:
+        - runner
+        - make
+        - -j
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.24
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
 
 # Run with Bazel against release-1.7 where make was not available yet
   - name: pull-cert-manager-e2e-feature-gates-disabled-23


### PR DESCRIPTION
This PR adds periodics and presubmits to run e2e tests with and without all the alpha/beta feature gates against Kubernetes 1.24.
Normally the periodics run only against one previous release however in this case as we plan to use them to verify that 1.7 works with 1.24, I've added two extra ones that run against 1.7.

I've ran some tests locally to verify that the tests do pass on 1.7 and 1.8, but not all as my laptop collapsed trying to run the Bazel tests with 1.7.

The PRs to backport the actual changes against 1.7 and 1.8 are still in progress, but I would like to get this merged now as it will allow to run the tests in CI against those PRs.