### PR TITLE
Cleanup

### DIFF
--- a/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
@@ -168,11 +168,11 @@ periodics:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
       args:
       - runner
-      - bash
-      - -c
-      - |
-        apt-get install jq -y >/dev/null
-        make -j vendor-go e2e-ci K8S_VERSION=1.19
+      - make
+      - j
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.19
       resources:
         requests:
           cpu: 3500m
@@ -242,11 +242,11 @@ periodics:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
       args:
       - runner
-      - bash
-      - -c
-      - |
-        apt-get install jq -y >/dev/null
-        make -j vendor-go e2e-ci K8S_VERSION=1.20
+      - make
+      - j
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.20
       resources:
         requests:
           cpu: 3500m
@@ -319,11 +319,11 @@ periodics:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
       args:
       - runner
-      - bash
-      - -c
-      - |
-        apt-get install jq -y >/dev/null
-        make -j vendor-go e2e-ci K8S_VERSION=1.21
+      - make
+      - j
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.21
       resources:
         requests:
           cpu: 3500m
@@ -396,11 +396,11 @@ periodics:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
       args:
       - runner
-      - bash
-      - -c
-      - |
-        apt-get install jq -y >/dev/null
-        make -j vendor-go e2e-ci K8S_VERSION=1.22
+      - make
+      - j
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.22
       resources:
         requests:
           cpu: 3500m
@@ -476,11 +476,11 @@ periodics:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
       args:
       - runner
-      - bash
-      - -c
-      - |
-        apt-get install jq -y >/dev/null
-        make -j vendor-go e2e-ci K8S_VERSION=1.23
+      - make
+      - j
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.23
       resources:
         requests:
           cpu: 3500m

--- a/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
@@ -3,7 +3,6 @@ presubmits:
 
   - name: pull-cert-manager-bazel
     always_run: true
-    context: pull-cert-manager-bazel
     max_concurrency: 8
     agent: kubernetes
     decorate: true
@@ -38,7 +37,6 @@ presubmits:
 
   - name: pull-cert-manager-deps
     always_run: true
-    context: pull-cert-manager-deps
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -71,7 +69,6 @@ presubmits:
             value: "1"
 
   - name: pull-cert-manager-make-test
-    context: pull-cert-manager-make-test
     always_run: true
     optional: false
     max_concurrency: 8
@@ -125,7 +122,6 @@ presubmits:
 ### E2E tests against all supported Kubernetes versions with all cert-manager alpha/beta feature gates enabled ###
 
   - name: pull-cert-manager-e2e-v1-18
-    context: pull-cert-manager-e2e-v1-18
     always_run: false
     optional: true
     max_concurrency: 4
@@ -185,7 +181,6 @@ presubmits:
 
 # Run with Bazel for release-1.7 where make was not available
   - name: pull-cert-manager-e2e-v1-19
-    context: pull-cert-manager-e2e-v1-19
     always_run: false
     optional: true
     max_concurrency: 4
@@ -243,7 +238,6 @@ presubmits:
           value: "1"
 
   - name: pull-cert-manager-e2e-v1-19
-    context: pull-cert-manager-e2e-v1-19
     always_run: false
     optional: true
     max_concurrency: 4
@@ -321,7 +315,6 @@ presubmits:
 
 # Run with Bazel for release-1.7 where make was not available
   - name: pull-cert-manager-e2e-v1-20
-    context: pull-cert-manager-e2e-v1-20
     always_run: false
     optional: true
     max_concurrency: 4
@@ -379,7 +372,6 @@ presubmits:
           value: "1"
 
   - name: pull-cert-manager-e2e-v1-20
-    context: pull-cert-manager-e2e-v1-20
     always_run: false
     optional: true
     max_concurrency: 4
@@ -457,7 +449,6 @@ presubmits:
 
 # Run with Bazel for release-1.7 where make was not available yet
   - name: pull-cert-manager-e2e-v1-21
-    context: pull-cert-manager-e2e-v1-21
     always_run: false
     optional: true
     max_concurrency: 4
@@ -787,7 +778,7 @@ presubmits:
           value: "1"
 
   - name: pull-cert-manager-e2e-v1-23
-    context: pull-cert-manager-make-e2e-v1-23
+    context: pull-cert-manager-e2e-v1-23
     always_run: true
     optional: false
     max_concurrency: 4
@@ -861,7 +852,7 @@ presubmits:
           value: "1"
 
   - name: pull-cert-manager-e2e-v1-24
-    context: pull-cert-manager-make-e2e-v1-24
+    context: pull-cert-manager-e2e-v1-24
     always_run: true
     optional: false
     max_concurrency: 4

--- a/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
@@ -585,7 +585,7 @@ presubmits:
 # Run with Bazel for release-1.7 where make was not available yet
   - name: pull-cert-manager-e2e-v1-22
     context: pull-cert-manager-e2e-v1-22
-    always_run: true
+    always_run: false
     optional: true
     max_concurrency: 4
     agent: kubernetes

--- a/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
@@ -268,11 +268,11 @@ presubmits:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
         args:
         - runner
-        - bash
-        - -c
-        - |
-          apt-get install jq -y >/dev/null
-          make -j vendor-go e2e-ci K8S_VERSION=1.19
+        - make
+        - j
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.19
         resources:
           requests:
             cpu: 3500m
@@ -404,11 +404,11 @@ presubmits:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
         args:
         - runner
-        - bash
-        - -c
-        - |
-          apt-get install jq -y >/dev/null
-          make -j vendor-go e2e-ci K8S_VERSION=1.20
+        - make
+        - j
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.19
         resources:
           requests:
             cpu: 3500m
@@ -540,11 +540,11 @@ presubmits:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
         args:
         - runner
-        - bash
-        - -c
-        - |
-          apt-get install jq -y >/dev/null
-          make -j vendor-go e2e-ci K8S_VERSION=1.21
+        - make
+        - -j
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.21
         resources:
           requests:
             cpu: 3500m
@@ -676,11 +676,11 @@ presubmits:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
         args:
         - runner
-        - bash
-        - -c
-        - |
-          apt-get install jq -y >/dev/null
-          make -j vendor-go e2e-ci K8S_VERSION=1.22
+        - make
+        - -j
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.22
         resources:
           requests:
             cpu: 3500m
@@ -1205,11 +1205,11 @@ presubmits:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
         args:
         - runner
-        - bash
-        - -c
-        - |
-          apt-get install jq -y >/dev/null
-          make -j vendor-go e2e-ci K8S_VERSION=1.23
+        - make
+        - -j
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.23
         resources:
           requests:
             cpu: 3500m
@@ -1337,11 +1337,11 @@ presubmits:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
         args:
         - runner
-        - bash
-        - -c
-        - |
-          apt-get install jq -y >/dev/null
-          make -j vendor-go e2e-ci K8S_VERSION=1.22
+        - make
+        - -j
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.22
         resources:
           requests:
             cpu: 3500m
@@ -1469,11 +1469,11 @@ presubmits:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
         args:
         - runner
-        - bash
-        - -c
-        - |
-          apt-get install jq -y >/dev/null
-          make -j vendor-go e2e-ci K8S_VERSION=1.21
+        - make
+        - -j
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.21
         resources:
           requests:
             cpu: 3500m
@@ -1601,11 +1601,11 @@ presubmits:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
         args:
         - runner
-        - bash
-        - -c
-        - |
-          apt-get install jq -y >/dev/null
-          make -j vendor-go e2e-ci K8S_VERSION=1.20
+        - make
+        - -j
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.20
         resources:
           requests:
             cpu: 3500m
@@ -1733,11 +1733,11 @@ presubmits:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
         args:
         - runner
-        - bash
-        - -c
-        - |
-          apt-get install jq -y >/dev/null
-          make -j vendor-go e2e-ci K8S_VERSION=1.19
+        - make
+        - -j
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.19
         resources:
           requests:
             cpu: 3500m


### PR DESCRIPTION
A couple cleanup fixes for 'previous' jobs:

- Use the same form of make command everywhere
- Fix `always-run` value for a job that shouldn't always run
- Remove 'context' values (as I understand from [this Prow code comment](https://github.com/kubernetes/test-infra/blob/master/prow/config/jobs.go#L285-L287) this value determines the job name in GitHub and defaults to the same as the job name). We should be always fine with the default and having it explicitly specified has no value as it is not obvious what this field does from its name and is just one more value to forget to change when copy pasting these configs around (which I did in a previous PR)