### PR TITLE
[Cleanup] clean up TestGrid annotations, remove context value

### DIFF
--- a/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
@@ -662,6 +662,8 @@ presubmits:
     branches:
     - master
     annotations:
+      testgrid-create-test-group: 'true'
+      testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
       description: Runs cert-manager upgrade from latest published release
     labels:
       preset-service-account: "true"
@@ -723,6 +725,8 @@ presubmits:
     decorate: true
     branches: []
     annotations:
+      testgrid-create-test-group: 'true'
+      testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
       description: Runs the E2E tests with 'Venafi TPP' in name
     labels:
       preset-service-account: "true"
@@ -784,6 +788,8 @@ presubmits:
     decorate: true
     branches: []
     annotations:
+      testgrid-create-test-group: 'true'
+      testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
       description: Runs the E2E tests with 'Venafi Cloud' in name
     labels:
       preset-service-account: "true"
@@ -838,6 +844,8 @@ presubmits:
     decorate: true
     branches: []
     annotations:
+      testgrid-create-test-group: 'true'
+      testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
       description: Runs the E2E tests with all feature gates disabled
     labels:
       preset-service-account: "true"

--- a/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
@@ -9,7 +9,6 @@ presubmits:
 
   - name: pull-cert-manager-bazel
     always_run: true
-    context: pull-cert-manager-bazel
     max_concurrency: 8
     agent: kubernetes
     decorate: true
@@ -42,7 +41,6 @@ presubmits:
             value: "1"
 
   - name: pull-cert-manager-make-test
-    context: pull-cert-manager-make-test
     always_run: true
     optional: false
     max_concurrency: 8
@@ -99,7 +97,6 @@ presubmits:
     description: Run cert-manager unit tests with Bazel remote-caching disabled
     always_run: false
     optional: true
-    context: pull-cert-manager-bazel-nocache
     max_concurrency: 8
     agent: kubernetes
     decorate: true
@@ -133,7 +130,6 @@ presubmits:
     description: Run cert-manager unit tests with Bazel using a Go cache on the local node
     always_run: false
     optional: true
-    context: pull-cert-manager-bazel-gocache
     max_concurrency: 8
     agent: kubernetes
     decorate: true
@@ -168,7 +164,6 @@ presubmits:
   - name: pull-cert-manager-bazel-experimental
     always_run: false
     optional: true
-    context: pull-cert-manager-bazel-experimental
     max_concurrency: 8
     agent: kubernetes
     decorate: true
@@ -205,7 +200,6 @@ presubmits:
   # See https://github.com/helm/chart-testing/issues/53
   - name: pull-cert-manager-chart
     always_run: true
-    context: pull-cert-manager-chart
     max_concurrency: 8
     agent: kubernetes
     decorate: true
@@ -241,7 +235,6 @@ presubmits:
 
   - name: pull-cert-manager-deps
     always_run: true
-    context: pull-cert-manager-deps
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -272,7 +265,6 @@ presubmits:
             value: "1"
 
   - name: pull-cert-manager-e2e-v1-20
-    context: pull-cert-manager-e2e-v1-20
     always_run: false
     optional: true
     max_concurrency: 4
@@ -331,7 +323,6 @@ presubmits:
           value: "1"
 
   - name: pull-cert-manager-e2e-v1-21
-    context: pull-cert-manager-e2e-v1-21
     always_run: false
     optional: true
     max_concurrency: 4
@@ -390,7 +381,6 @@ presubmits:
           value: "1"
 
   - name: pull-cert-manager-e2e-v1-22
-    context: pull-cert-manager-e2e-v1-22
     always_run: false
     optional: true
     max_concurrency: 4
@@ -450,7 +440,6 @@ presubmits:
 
     # This is the default e2e test for all PRs.
   - name: pull-cert-manager-e2e-v1-23
-    context: pull-cert-manager-e2e-v1-23
     always_run: true
     optional: false
     max_concurrency: 4
@@ -509,7 +498,6 @@ presubmits:
           value: "1"
 
   - name: pull-cert-manager-make-e2e-v1-23
-    context: pull-cert-manager-make-e2e-v1-23
     always_run: true
     optional: false
     max_concurrency: 4
@@ -585,7 +573,6 @@ presubmits:
           value: "1"
 
   - name: pull-cert-manager-make-e2e-v1-24
-    context: pull-cert-manager-make-e2e-v1-24
     always_run: false
     optional: true
     max_concurrency: 4

--- a/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
@@ -98,7 +98,7 @@ periodics:
     base_ref: release-1.8
   annotations:
     testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-master
+    testgrid-dashboards: jetstack-cert-manager-previous
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     description: Runs cert-manager upgrade test
   labels:
@@ -678,7 +678,7 @@ periodics:
     base_ref: release-1.8
   annotations:
     testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-master
+    testgrid-dashboards: jetstack-cert-manager-previous
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     description: Runs the end-to-end test suite against a Kubernetes v1.19 cluster with all feature gates disabled
   labels:
@@ -753,7 +753,7 @@ periodics:
     base_ref: release-1.8
   annotations:
     testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-master
+    testgrid-dashboards: jetstack-cert-manager-previous
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     description: Runs the end-to-end test suite against a Kubernetes v1.20 cluster with all feature gates disabled
   labels:
@@ -828,7 +828,7 @@ periodics:
     base_ref: release-1.8
   annotations:
     testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-master
+    testgrid-dashboards: jetstack-cert-manager-previous
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     description: Runs the end-to-end test suite against a Kubernetes v1.21 cluster with all feature gates disabled
   labels:
@@ -903,7 +903,7 @@ periodics:
     base_ref: release-1.8
   annotations:
     testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-master
+    testgrid-dashboards: jetstack-cert-manager-previous
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     description: Runs the end-to-end test suite against a Kubernetes v1.22 cluster with all feature gates disabled
   labels:
@@ -978,7 +978,7 @@ periodics:
     base_ref: release-1.8
   annotations:
     testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-master
+    testgrid-dashboards: jetstack-cert-manager-previous
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     description: Runs the end-to-end test suite against a Kubernetes v1.23 cluster with all feature gates disabled
   labels:
@@ -1053,7 +1053,7 @@ periodics:
     base_ref: release-1.8
   annotations:
     testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-master
+    testgrid-dashboards: jetstack-cert-manager-previous
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     description: Runs the end-to-end test suite against a Kubernetes v1.24 cluster with all feature gates disabled
   labels:
@@ -1131,7 +1131,7 @@ periodics:
     base_ref: release-1.7
   annotations:
     testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-master
+    testgrid-dashboards: jetstack-cert-manager-previous
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     description: Runs the end-to-end test suite against a Kubernetes v1.24 cluster with all feature gates disabled
   labels:
@@ -1190,7 +1190,10 @@ periodics:
     repo: cert-manager
     base_ref: release-1.8
   annotations:
-    testgrid-create-test-group: 'false'
+    testgrid-create-test-group: 'true'
+    testgrid-dashboards: jetstack-cert-manager-previous
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    description: Runs e2e tests for Venafi issuer
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"

--- a/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
@@ -11,8 +11,6 @@ presubmits:
     # as of the release of 1.8, so we need to run bazel test for 1.8 too.
     - release-1.8
     - release-1.7
-    annotations:
-      testgrid-create-test-group: 'false'
     labels:
       preset-service-account: "true"
       preset-bazel-remote-cache-enabled: "true"
@@ -45,9 +43,6 @@ presubmits:
     # still, we might as well run it just in case
     - release-1.8
     - release-1.7
-    annotations:
-      testgrid-create-test-group: 'false'
-      description: Verifies dependency related files are up to date
     labels:
       preset-service-account: "true"
       preset-bazel-remote-cache-enabled: "true"
@@ -77,8 +72,6 @@ presubmits:
     branches:
     # make testing not supported on release-1.7
     - release-1.8
-    annotations:
-      testgrid-create-test-group: 'false'
     labels:
       preset-service-account: "true"
     spec:
@@ -130,9 +123,6 @@ presubmits:
     branches:
     # cert-manager 1.8 supports k8s 1.19+, so no need to run against release-1.8 here
     - release-1.7
-    annotations:
-      testgrid-create-test-group: 'false'
-      description: Runs the end-to-end test suite against a Kubernetes v1.18 cluster
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -188,9 +178,6 @@ presubmits:
     decorate: true
     branches:
     - release-1.7
-    annotations:
-      testgrid-create-test-group: 'false'
-      description: Runs the end-to-end test suite against a Kubernetes v1.19 cluster
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -245,9 +232,6 @@ presubmits:
     decorate: true
     branches:
     - release-1.8
-    annotations:
-      testgrid-create-test-group: 'false'
-      description: Runs the end-to-end test suite against a Kubernetes v1.19 cluster
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -322,9 +306,6 @@ presubmits:
     decorate: true
     branches:
     - release-1.7
-    annotations:
-      testgrid-create-test-group: 'false'
-      description: Runs the end-to-end test suite against a Kubernetes v1.20 cluster
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -379,9 +360,6 @@ presubmits:
     decorate: true
     branches:
     - release-1.8
-    annotations:
-      testgrid-create-test-group: 'false'
-      description: Runs the end-to-end test suite against a Kubernetes v1.20 cluster
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -456,9 +434,6 @@ presubmits:
     decorate: true
     branches:
     - release-1.7
-    annotations:
-      testgrid-create-test-group: 'false'
-      description: Runs the end-to-end test suite against a Kubernetes v1.21 cluster
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -513,9 +488,6 @@ presubmits:
     decorate: true
     branches:
     - release-1.8
-    annotations:
-      testgrid-create-test-group: 'false'
-      description: Runs the end-to-end test suite against a Kubernetes v1.21 cluster
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -590,9 +562,6 @@ presubmits:
     decorate: true
     branches:
     - release-1.7
-    annotations:
-      testgrid-create-test-group: 'false'
-      description: Runs the end-to-end test suite against a Kubernetes v1.22 cluster
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -647,9 +616,6 @@ presubmits:
     decorate: true
     branches:
     - release-1.8
-    annotations:
-      testgrid-create-test-group: 'false'
-      description: Runs the end-to-end test suite against a Kubernetes v1.22 cluster
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -724,9 +690,6 @@ presubmits:
     decorate: true
     branches:
     - release-1.7
-    annotations:
-      testgrid-create-test-group: 'false'
-      description: Runs the end-to-end test suite against a Kubernetes v1.23 cluster
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -781,8 +744,6 @@ presubmits:
     decorate: true
     branches:
     - release-1.8
-    annotations:
-      testgrid-create-test-group: 'false'
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -854,8 +815,6 @@ presubmits:
     decorate: true
     branches:
     - release-1.8
-    annotations:
-      testgrid-create-test-group: 'false'
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -928,8 +887,6 @@ presubmits:
     decorate: true
     branches:
     - release-1.7
-    annotations:
-      testgrid-create-test-group: 'false'
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -985,8 +942,6 @@ presubmits:
     decorate: true
     branches:
     - release-1.7
-    annotations:
-      description: Runs the E2E tests with all feature gates disabled against Kubernetes 1.24
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -1041,8 +996,6 @@ presubmits:
     decorate: true
     branches:
     - release-1.8
-    annotations:
-      description: Runs the E2E tests with all feature gates disabled against Kubernetes 1.24
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -1117,8 +1070,6 @@ presubmits:
     decorate: true
     branches:
     - release-1.7
-    annotations:
-      description: Runs the E2E tests with all feature gates disabled against Kubernetes 1.23
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -1173,8 +1124,6 @@ presubmits:
     decorate: true
     branches:
     - release-1.8
-    annotations:
-      description: Runs the E2E tests with all feature gates disabled against Kubernetes 1.23
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -1249,8 +1198,6 @@ presubmits:
     decorate: true
     branches:
     - release-1.7
-    annotations:
-      description: Runs the E2E tests with all feature gates disabled against Kubernetes 1.22
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -1305,8 +1252,6 @@ presubmits:
     decorate: true
     branches:
     - release-1.8
-    annotations:
-      description: Runs the E2E tests with all feature gates disabled against Kubernetes 1.22
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -1381,8 +1326,6 @@ presubmits:
     decorate: true
     branches:
     - release-1.7
-    annotations:
-      description: Runs the E2E tests with all feature gates disabled against Kubernetes 1.21
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -1437,8 +1380,6 @@ presubmits:
     decorate: true
     branches:
     - release-1.8
-    annotations:
-      description: Runs the E2E tests with all feature gates disabled against Kubernetes 1.21
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -1513,8 +1454,6 @@ presubmits:
     decorate: true
     branches:
     - release-1.7
-    annotations:
-      description: Runs the E2E tests with all feature gates disabled against Kubernetes 1.20
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -1569,8 +1508,6 @@ presubmits:
     decorate: true
     branches:
     - release-1.8
-    annotations:
-      description: Runs the E2E tests with all feature gates disabled against Kubernetes 1.20
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -1645,8 +1582,6 @@ presubmits:
     decorate: true
     branches:
     - release-1.7
-    annotations:
-      description: Runs the E2E tests with all feature gates disabled against Kubernetes 1.19
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -1701,8 +1636,6 @@ presubmits:
     decorate: true
     branches:
     - release-1.8
-    annotations:
-      description: Runs the E2E tests with all feature gates disabled against Kubernetes 1.19
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -1777,8 +1710,6 @@ presubmits:
     branches:
     # not needed for release-1.8 as cert-manager 1.8 no longer supports Kubernetes 1.8
     - release-1.7
-    annotations:
-      description: Runs the E2E tests with all feature gates disabled against Kubernetes 1.18
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -1843,8 +1774,6 @@ presubmits:
     branches:
     - release-1.8
     - release-1.7
-    annotations:
-      description: Runs the E2E tests with 'Venafi TPP' in name
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -1907,8 +1836,6 @@ presubmits:
     branches:
     - release-1.8
     - release-1.7
-    annotations:
-      description: Runs the E2E tests with 'Venafi Cloud' in name
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"

--- a/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
@@ -506,7 +506,6 @@ presubmits:
           value: "1"
 
   - name: pull-cert-manager-e2e-v1-21
-    context: pull-cert-manager-e2e-v1-21
     always_run: false
     optional: true
     max_concurrency: 4
@@ -584,7 +583,6 @@ presubmits:
 
 # Run with Bazel for release-1.7 where make was not available yet
   - name: pull-cert-manager-e2e-v1-22
-    context: pull-cert-manager-e2e-v1-22
     always_run: false
     optional: true
     max_concurrency: 4
@@ -642,7 +640,6 @@ presubmits:
           value: "1"
 
   - name: pull-cert-manager-e2e-v1-22
-    context: pull-cert-manager-e2e-v1-22
     always_run: false
     optional: true
     max_concurrency: 4
@@ -720,7 +717,6 @@ presubmits:
 
 # Run with Bazel for release-1.7 where make was not available yet
   - name: pull-cert-manager-e2e-v1-23
-    context: pull-cert-manager-e2e-v1-23
     always_run: true
     optional: false
     max_concurrency: 4
@@ -778,7 +774,6 @@ presubmits:
           value: "1"
 
   - name: pull-cert-manager-e2e-v1-23
-    context: pull-cert-manager-e2e-v1-23
     always_run: true
     optional: false
     max_concurrency: 4
@@ -852,7 +847,6 @@ presubmits:
           value: "1"
 
   - name: pull-cert-manager-e2e-v1-24
-    context: pull-cert-manager-e2e-v1-24
     always_run: true
     optional: false
     max_concurrency: 4
@@ -927,7 +921,6 @@ presubmits:
 
 # Run with Bazel for release-1.7 where make was not available yet
   - name: pull-cert-manager-e2e-v1-24
-    context: pull-cert-manager-make-e2e-v1-24
     always_run: true
     optional: false
     max_concurrency: 4


### PR DESCRIPTION
This PR does some cleanup mostly for 'previous presubmits':

- Ensures correct TestGrid annotations, remove unnecessary ones
-
- Removes all `context` fields from all cert-manager ProwJobs. We always want to default the job names in Github UI to the same as the ProwJob name so this field is useless and increases the chance of copy paste errors (This was already partially done in #685)







Signed-off-by: irbekrm <irbekrm@gmail.com>