### PR TITLE
Reinstate pull-cert-manager-chart presubmit for previous branches

### DIFF
--- a/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
@@ -9,7 +9,6 @@ presubmits:
 
   - name: pull-cert-manager-bazel
     always_run: true
-    context: pull-cert-manager-bazel
     max_concurrency: 8
     agent: kubernetes
     decorate: true
@@ -42,7 +41,6 @@ presubmits:
             value: "1"
 
   - name: pull-cert-manager-make-test
-    context: pull-cert-manager-make-test
     always_run: true
     optional: false
     max_concurrency: 8
@@ -99,7 +97,6 @@ presubmits:
     description: Run cert-manager unit tests with Bazel remote-caching disabled
     always_run: false
     optional: true
-    context: pull-cert-manager-bazel-nocache
     max_concurrency: 8
     agent: kubernetes
     decorate: true
@@ -133,7 +130,6 @@ presubmits:
     description: Run cert-manager unit tests with Bazel using a Go cache on the local node
     always_run: false
     optional: true
-    context: pull-cert-manager-bazel-gocache
     max_concurrency: 8
     agent: kubernetes
     decorate: true
@@ -168,7 +164,6 @@ presubmits:
   - name: pull-cert-manager-bazel-experimental
     always_run: false
     optional: true
-    context: pull-cert-manager-bazel-experimental
     max_concurrency: 8
     agent: kubernetes
     decorate: true
@@ -205,7 +200,6 @@ presubmits:
   # See https://github.com/helm/chart-testing/issues/53
   - name: pull-cert-manager-chart
     always_run: true
-    context: pull-cert-manager-chart
     max_concurrency: 8
     agent: kubernetes
     decorate: true
@@ -241,7 +235,6 @@ presubmits:
 
   - name: pull-cert-manager-deps
     always_run: true
-    context: pull-cert-manager-deps
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -272,7 +265,6 @@ presubmits:
             value: "1"
 
   - name: pull-cert-manager-e2e-v1-20
-    context: pull-cert-manager-e2e-v1-20
     always_run: false
     optional: true
     max_concurrency: 4
@@ -331,7 +323,6 @@ presubmits:
           value: "1"
 
   - name: pull-cert-manager-e2e-v1-21
-    context: pull-cert-manager-e2e-v1-21
     always_run: false
     optional: true
     max_concurrency: 4
@@ -390,7 +381,6 @@ presubmits:
           value: "1"
 
   - name: pull-cert-manager-e2e-v1-22
-    context: pull-cert-manager-e2e-v1-22
     always_run: false
     optional: true
     max_concurrency: 4
@@ -450,7 +440,6 @@ presubmits:
 
     # This is the default e2e test for all PRs.
   - name: pull-cert-manager-e2e-v1-23
-    context: pull-cert-manager-e2e-v1-23
     always_run: true
     optional: false
     max_concurrency: 4
@@ -509,7 +498,6 @@ presubmits:
           value: "1"
 
   - name: pull-cert-manager-make-e2e-v1-23
-    context: pull-cert-manager-make-e2e-v1-23
     always_run: true
     optional: false
     max_concurrency: 4
@@ -585,7 +573,6 @@ presubmits:
           value: "1"
 
   - name: pull-cert-manager-make-e2e-v1-24
-    context: pull-cert-manager-make-e2e-v1-24
     always_run: false
     optional: true
     max_concurrency: 4

--- a/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
@@ -506,7 +506,6 @@ presubmits:
           value: "1"
 
   - name: pull-cert-manager-e2e-v1-21
-    context: pull-cert-manager-e2e-v1-21
     always_run: false
     optional: true
     max_concurrency: 4
@@ -584,7 +583,6 @@ presubmits:
 
 # Run with Bazel for release-1.7 where make was not available yet
   - name: pull-cert-manager-e2e-v1-22
-    context: pull-cert-manager-e2e-v1-22
     always_run: false
     optional: true
     max_concurrency: 4
@@ -642,7 +640,6 @@ presubmits:
           value: "1"
 
   - name: pull-cert-manager-e2e-v1-22
-    context: pull-cert-manager-e2e-v1-22
     always_run: false
     optional: true
     max_concurrency: 4
@@ -720,7 +717,6 @@ presubmits:
 
 # Run with Bazel for release-1.7 where make was not available yet
   - name: pull-cert-manager-e2e-v1-23
-    context: pull-cert-manager-e2e-v1-23
     always_run: true
     optional: false
     max_concurrency: 4
@@ -778,7 +774,6 @@ presubmits:
           value: "1"
 
   - name: pull-cert-manager-e2e-v1-23
-    context: pull-cert-manager-e2e-v1-23
     always_run: true
     optional: false
     max_concurrency: 4
@@ -852,7 +847,6 @@ presubmits:
           value: "1"
 
   - name: pull-cert-manager-e2e-v1-24
-    context: pull-cert-manager-e2e-v1-24
     always_run: true
     optional: false
     max_concurrency: 4
@@ -927,7 +921,6 @@ presubmits:
 
 # Run with Bazel for release-1.7 where make was not available yet
   - name: pull-cert-manager-e2e-v1-24
-    context: pull-cert-manager-make-e2e-v1-24
     always_run: true
     optional: false
     max_concurrency: 4

--- a/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
@@ -68,6 +68,43 @@ presubmits:
           - name: ndots
             value: "1"
 
+  # Helm chart verification currently requires Docker.
+  # We maintain a standalone presubmit for running this.
+  # See https://github.com/helm/chart-testing/issues/53
+  - name: pull-cert-manager-chart
+    always_run: true
+    max_concurrency: 8
+    agent: kubernetes
+    decorate: true
+    branches:
+    - release-1.8
+    - release-1.7
+    annotations:
+      testgrid-create-test-group: 'false'
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+        args:
+        - runner
+        - make
+        - verify_chart
+        resources:
+          requests:
+            cpu: 1
+            memory: 1Gi
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+
   - name: pull-cert-manager-make-test
     always_run: true
     optional: false


### PR DESCRIPTION
In #660 we moved all 'previous' presubmit definitions to https://github.com/jetstack/testing/blob/master/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml (whereas previouosly some of those presubmits were available for the previous branches because they were included in the 'default' presubmits file i.e [here](https://github.com/irbekrm/testing/blob/1593e69ad4e7f64e867d01bf8e122bedb3a63632/config/jobs/cert-manager/cert-manager-presubmits.yaml#L85-L86)
`pull-cert-manager-chart` got lost in the change and as it is [required](https://github.com/jetstack/testing/blob/master/config/config.yaml#L41) is currently blocking backport PRs.