### PR TITLE
Split ProwJob volumes into presets

### DIFF
--- a/config/jobs/cert-manager/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager/cert-manager-periodics.yaml
@@ -46,6 +46,7 @@ periodics:
     base_ref: master
   labels:
     preset-service-account: "true"
+    preset-make-volumes: "true"
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-master
@@ -64,26 +65,6 @@ periodics:
           requests:
             cpu: 2
             memory: 4Gi
-        volumeMounts:
-          - mountPath: /root/.cache/go-build
-            name: gocache
-          - mountPath: /home/prow/go/pkg/mod
-            name: gopkgmod
-          - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-            name: bindownloaded
-    volumes:
-      - name: gocache
-        hostPath:
-          path: /tmp/gocache
-          type: DirectoryOrCreate
-      - name: gopkgmod
-        hostPath:
-          path: /tmp/gopkgmod
-          type: DirectoryOrCreate
-      - name: bindownloaded
-        hostPath:
-          path: /tmp/bindownloaded
-          type: DirectoryOrCreate
     dnsConfig:
       options:
         - name: ndots
@@ -108,6 +89,8 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-enable-all-feature-gates-disable-ssa: "true"
     preset-ginkgo-skip-default: "true"
+    preset-make-volumes: "true"
+    preset-default-e2e-volumes: "true"
   spec:
     containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -126,39 +109,6 @@ periodics:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-          - mountPath: /lib/modules
-            name: modules
-            readOnly: true
-          - mountPath: /sys/fs/cgroup
-            name: cgroup
-          - mountPath: /root/.cache/go-build
-            name: gocache
-          - mountPath: /home/prow/go/pkg/mod
-            name: gopkgmod
-          - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-            name: bindownloaded
-    volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-      - name: gocache
-        hostPath:
-          path: /tmp/gocache
-          type: DirectoryOrCreate
-      - name: gopkgmod
-        hostPath:
-          path: /tmp/gopkgmod
-          type: DirectoryOrCreate
-      - name: bindownloaded
-        hostPath:
-          path: /tmp/bindownloaded
-          type: DirectoryOrCreate
     dnsConfig:
       options:
         - name: ndots
@@ -183,6 +133,8 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-enable-all-feature-gates-disable-ssa: "true"
     preset-ginkgo-skip-default: "true"
+    preset-make-volumes: "true"
+    preset-default-e2e-volumes: "true"
   spec:
     containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -201,39 +153,6 @@ periodics:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-          - mountPath: /lib/modules
-            name: modules
-            readOnly: true
-          - mountPath: /sys/fs/cgroup
-            name: cgroup
-          - mountPath: /root/.cache/go-build
-            name: gocache
-          - mountPath: /home/prow/go/pkg/mod
-            name: gopkgmod
-          - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-            name: bindownloaded
-    volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-      - name: gocache
-        hostPath:
-          path: /tmp/gocache
-          type: DirectoryOrCreate
-      - name: gopkgmod
-        hostPath:
-          path: /tmp/gopkgmod
-          type: DirectoryOrCreate
-      - name: bindownloaded
-        hostPath:
-          path: /tmp/bindownloaded
-          type: DirectoryOrCreate
     dnsConfig:
       options:
         - name: ndots
@@ -258,6 +177,8 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
+    preset-make-volumes: "true"
+    preset-default-e2e-volumes: "true"
   spec:
     containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -276,39 +197,6 @@ periodics:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-          - mountPath: /lib/modules
-            name: modules
-            readOnly: true
-          - mountPath: /sys/fs/cgroup
-            name: cgroup
-          - mountPath: /root/.cache/go-build
-            name: gocache
-          - mountPath: /home/prow/go/pkg/mod
-            name: gopkgmod
-          - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-            name: bindownloaded
-    volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-      - name: gocache
-        hostPath:
-          path: /tmp/gocache
-          type: DirectoryOrCreate
-      - name: gopkgmod
-        hostPath:
-          path: /tmp/gopkgmod
-          type: DirectoryOrCreate
-      - name: bindownloaded
-        hostPath:
-          path: /tmp/bindownloaded
-          type: DirectoryOrCreate
     dnsConfig:
       options:
         - name: ndots
@@ -333,6 +221,8 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
+    preset-make-volumes: "true"
+    preset-default-e2e-volumes: "true"
   spec:
     containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -351,39 +241,6 @@ periodics:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-          - mountPath: /lib/modules
-            name: modules
-            readOnly: true
-          - mountPath: /sys/fs/cgroup
-            name: cgroup
-          - mountPath: /root/.cache/go-build
-            name: gocache
-          - mountPath: /home/prow/go/pkg/mod
-            name: gopkgmod
-          - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-            name: bindownloaded
-    volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-      - name: gocache
-        hostPath:
-          path: /tmp/gocache
-          type: DirectoryOrCreate
-      - name: gopkgmod
-        hostPath:
-          path: /tmp/gopkgmod
-          type: DirectoryOrCreate
-      - name: bindownloaded
-        hostPath:
-          path: /tmp/bindownloaded
-          type: DirectoryOrCreate
     dnsConfig:
       options:
         - name: ndots
@@ -408,6 +265,8 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
+    preset-make-volumes: "true"
+    preset-default-e2e-volumes: "true"
   spec:
     containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -426,39 +285,6 @@ periodics:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-          - mountPath: /lib/modules
-            name: modules
-            readOnly: true
-          - mountPath: /sys/fs/cgroup
-            name: cgroup
-          - mountPath: /root/.cache/go-build
-            name: gocache
-          - mountPath: /home/prow/go/pkg/mod
-            name: gopkgmod
-          - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-            name: bindownloaded
-    volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-      - name: gocache
-        hostPath:
-          path: /tmp/gocache
-          type: DirectoryOrCreate
-      - name: gopkgmod
-        hostPath:
-          path: /tmp/gopkgmod
-          type: DirectoryOrCreate
-      - name: bindownloaded
-        hostPath:
-          path: /tmp/bindownloaded
-          type: DirectoryOrCreate
     dnsConfig:
       options:
         - name: ndots
@@ -486,6 +312,8 @@ periodics:
     preset-venafi-cloud-credentials: "true"
     preset-venafi-tpp-credentials: "true"
     preset-ginkgo-focus-venafi: "true"
+    preset-make-volumes: "true"
+    preset-default-e2e-volumes: "true"
   spec:
     containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -504,39 +332,6 @@ periodics:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-          - mountPath: /lib/modules
-            name: modules
-            readOnly: true
-          - mountPath: /sys/fs/cgroup
-            name: cgroup
-          - mountPath: /root/.cache/go-build
-            name: gocache
-          - mountPath: /home/prow/go/pkg/mod
-            name: gopkgmod
-          - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-            name: bindownloaded
-    volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-      - name: gocache
-        hostPath:
-          path: /tmp/gocache
-          type: DirectoryOrCreate
-      - name: gopkgmod
-        hostPath:
-          path: /tmp/gopkgmod
-          type: DirectoryOrCreate
-      - name: bindownloaded
-        hostPath:
-          path: /tmp/bindownloaded
-          type: DirectoryOrCreate
     dnsConfig:
       options:
         - name: ndots
@@ -559,6 +354,8 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
+    preset-make-volumes: "true"
+    preset-default-e2e-volumes: "true"
   spec:
     containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -575,39 +372,6 @@ periodics:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-          - mountPath: /lib/modules
-            name: modules
-            readOnly: true
-          - mountPath: /sys/fs/cgroup
-            name: cgroup
-          - mountPath: /root/.cache/go-build
-            name: gocache
-          - mountPath: /home/prow/go/pkg/mod
-            name: gopkgmod
-          - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-            name: bindownloaded
-    volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-      - name: gocache
-        hostPath:
-          path: /tmp/gocache
-          type: DirectoryOrCreate
-      - name: gopkgmod
-        hostPath:
-          path: /tmp/gopkgmod
-          type: DirectoryOrCreate
-      - name: bindownloaded
-        hostPath:
-          path: /tmp/bindownloaded
-          type: DirectoryOrCreate
     dnsConfig:
       options:
         - name: ndots
@@ -683,6 +447,8 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-retry-flakey-tests: "true"
+    preset-default-e2e-volumes: "true"
+    preset-make-volumes: "true"
   spec:
     containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -701,39 +467,6 @@ periodics:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-          - mountPath: /lib/modules
-            name: modules
-            readOnly: true
-          - mountPath: /sys/fs/cgroup
-            name: cgroup
-          - mountPath: /root/.cache/go-build
-            name: gocache
-          - mountPath: /home/prow/go/pkg/mod
-            name: gopkgmod
-          - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-            name: bindownloaded
-    volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-      - name: gocache
-        hostPath:
-          path: /tmp/gocache
-          type: DirectoryOrCreate
-      - name: gopkgmod
-        hostPath:
-          path: /tmp/gopkgmod
-          type: DirectoryOrCreate
-      - name: bindownloaded
-        hostPath:
-          path: /tmp/bindownloaded
-          type: DirectoryOrCreate
     dnsConfig:
       options:
         - name: ndots
@@ -758,6 +491,8 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-retry-flakey-tests: "true"
+    preset-default-e2e-volumes: "true"
+    preset-make-volumes: "true"
   spec:
     containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -776,39 +511,6 @@ periodics:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-          - mountPath: /lib/modules
-            name: modules
-            readOnly: true
-          - mountPath: /sys/fs/cgroup
-            name: cgroup
-          - mountPath: /root/.cache/go-build
-            name: gocache
-          - mountPath: /home/prow/go/pkg/mod
-            name: gopkgmod
-          - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-            name: bindownloaded
-    volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-      - name: gocache
-        hostPath:
-          path: /tmp/gocache
-          type: DirectoryOrCreate
-      - name: gopkgmod
-        hostPath:
-          path: /tmp/gopkgmod
-          type: DirectoryOrCreate
-      - name: bindownloaded
-        hostPath:
-          path: /tmp/bindownloaded
-          type: DirectoryOrCreate
     dnsConfig:
       options:
         - name: ndots
@@ -833,6 +535,8 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-retry-flakey-tests: "true"
+    preset-default-e2e-volumes: "true"
+    preset-make-volumes: "true"
   spec:
     containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -851,39 +555,6 @@ periodics:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-          - mountPath: /lib/modules
-            name: modules
-            readOnly: true
-          - mountPath: /sys/fs/cgroup
-            name: cgroup
-          - mountPath: /root/.cache/go-build
-            name: gocache
-          - mountPath: /home/prow/go/pkg/mod
-            name: gopkgmod
-          - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-            name: bindownloaded
-    volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-      - name: gocache
-        hostPath:
-          path: /tmp/gocache
-          type: DirectoryOrCreate
-      - name: gopkgmod
-        hostPath:
-          path: /tmp/gopkgmod
-          type: DirectoryOrCreate
-      - name: bindownloaded
-        hostPath:
-          path: /tmp/bindownloaded
-          type: DirectoryOrCreate
     dnsConfig:
       options:
         - name: ndots
@@ -908,6 +579,8 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-retry-flakey-tests: "true"
+    preset-default-e2e-volumes: "true"
+    preset-make-volumes: "true"
   spec:
     containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -926,39 +599,6 @@ periodics:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-          - mountPath: /lib/modules
-            name: modules
-            readOnly: true
-          - mountPath: /sys/fs/cgroup
-            name: cgroup
-          - mountPath: /root/.cache/go-build
-            name: gocache
-          - mountPath: /home/prow/go/pkg/mod
-            name: gopkgmod
-          - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-            name: bindownloaded
-    volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-      - name: gocache
-        hostPath:
-          path: /tmp/gocache
-          type: DirectoryOrCreate
-      - name: gopkgmod
-        hostPath:
-          path: /tmp/gopkgmod
-          type: DirectoryOrCreate
-      - name: bindownloaded
-        hostPath:
-          path: /tmp/bindownloaded
-          type: DirectoryOrCreate
     dnsConfig:
       options:
         - name: ndots
@@ -983,6 +623,8 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-retry-flakey-tests: "true"
+    preset-default-e2e-volumes: "true"
+    preset-make-volumes: "true"
   spec:
     containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -1001,39 +643,6 @@ periodics:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-          - mountPath: /lib/modules
-            name: modules
-            readOnly: true
-          - mountPath: /sys/fs/cgroup
-            name: cgroup
-          - mountPath: /root/.cache/go-build
-            name: gocache
-          - mountPath: /home/prow/go/pkg/mod
-            name: gopkgmod
-          - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-            name: bindownloaded
-    volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-      - name: gocache
-        hostPath:
-          path: /tmp/gocache
-          type: DirectoryOrCreate
-      - name: gopkgmod
-        hostPath:
-          path: /tmp/gopkgmod
-          type: DirectoryOrCreate
-      - name: bindownloaded
-        hostPath:
-          path: /tmp/bindownloaded
-          type: DirectoryOrCreate
     dnsConfig:
       options:
         - name: ndots

--- a/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
@@ -54,6 +54,7 @@ presubmits:
     description: Runs unit and integration tests and verification scripts
     labels:
       preset-service-account: "true"
+      preset-make-volumes: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -68,26 +69,6 @@ presubmits:
           requests:
             cpu: 2
             memory: 4Gi
-        volumeMounts:
-        - mountPath: /root/.cache/go-build
-          name: gocache
-        - mountPath: /home/prow/go/pkg/mod
-          name: gopkgmod
-        - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-          name: bindownloaded
-      volumes:
-      - name: gocache
-        hostPath:
-          path: /tmp/gocache
-          type: DirectoryOrCreate
-      - name: gopkgmod
-        hostPath:
-          path: /tmp/gopkgmod
-          type: DirectoryOrCreate
-      - name: bindownloaded
-        hostPath:
-          path: /tmp/bindownloaded
-          type: DirectoryOrCreate
       dnsConfig:
         options:
           - name: ndots
@@ -285,6 +266,7 @@ presubmits:
       preset-retry-flakey-tests: "true"
       preset-enable-all-feature-gates-disable-ssa: "true"
       preset-ginkgo-skip-default: "true"
+      preset-default-e2e-volumes: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -302,21 +284,6 @@ presubmits:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
       dnsConfig:
         options:
         - name: ndots
@@ -343,6 +310,7 @@ presubmits:
       preset-retry-flakey-tests: "true"
       preset-enable-all-feature-gates-disable-ssa: "true"
       preset-ginkgo-skip-default: "true"
+      preset-default-e2e-volumes: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -360,21 +328,6 @@ presubmits:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
       dnsConfig:
         options:
         - name: ndots
@@ -401,6 +354,7 @@ presubmits:
       preset-retry-flakey-tests: "true"
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
+      preset-default-e2e-volumes: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -418,21 +372,6 @@ presubmits:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
       dnsConfig:
         options:
         - name: ndots
@@ -460,6 +399,7 @@ presubmits:
       preset-retry-flakey-tests: "true"
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
+      preset-default-e2e-volumes: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -477,21 +417,6 @@ presubmits:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
       dnsConfig:
         options:
         - name: ndots
@@ -516,6 +441,8 @@ presubmits:
       preset-retry-flakey-tests: "true"
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
+      preset-default-e2e-volumes: "true"
+      preset-make-volumes: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -534,39 +461,6 @@ presubmits:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-        - mountPath: /root/.cache/go-build
-          name: gocache
-        - mountPath: /home/prow/go/pkg/mod
-          name: gopkgmod
-        - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-          name: bindownloaded
-      volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-      - name: gocache
-        hostPath:
-          path: /tmp/gocache
-          type: DirectoryOrCreate
-      - name: gopkgmod
-        hostPath:
-          path: /tmp/gopkgmod
-          type: DirectoryOrCreate
-      - name: bindownloaded
-        hostPath:
-          path: /tmp/bindownloaded
-          type: DirectoryOrCreate
       dnsConfig:
         options:
         - name: ndots
@@ -591,6 +485,8 @@ presubmits:
       preset-retry-flakey-tests: "true"
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
+      preset-make-volumes: "true"
+      preset-default-e2e-volumes: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -609,39 +505,6 @@ presubmits:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-        - mountPath: /root/.cache/go-build
-          name: gocache
-        - mountPath: /home/prow/go/pkg/mod
-          name: gopkgmod
-        - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-          name: bindownloaded
-      volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-      - name: gocache
-        hostPath:
-          path: /tmp/gocache
-          type: DirectoryOrCreate
-      - name: gopkgmod
-        hostPath:
-          path: /tmp/gopkgmod
-          type: DirectoryOrCreate
-      - name: bindownloaded
-        hostPath:
-          path: /tmp/bindownloaded
-          type: DirectoryOrCreate
       dnsConfig:
         options:
         - name: ndots
@@ -670,6 +533,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-bazel-remote-cache-enabled: "true"
       preset-bazel-scratch-dir: "true"
+      preset-default-e2e-volumes: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -690,21 +554,6 @@ presubmits:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
       dnsConfig:
         options:
         - name: ndots
@@ -736,6 +585,7 @@ presubmits:
       preset-venafi-tpp-credentials: "true"
       preset-retry-flakey-tests: "true"
       preset-ginkgo-focus-venafi-tpp: "true"
+      preset-default-e2e-volumes: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -753,21 +603,6 @@ presubmits:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
       dnsConfig:
         options:
         - name: ndots
@@ -799,6 +634,7 @@ presubmits:
       preset-venafi-cloud-credentials: "true"
       preset-retry-flakey-tests: "true"
       preset-ginkgo-focus-venafi-cloud: "true"
+      preset-default-e2e-volumes: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -816,21 +652,6 @@ presubmits:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
       dnsConfig:
         options:
         - name: ndots
@@ -856,6 +677,7 @@ presubmits:
       preset-cloudflare-credentials: "true"
       preset-retry-flakey-tests: "true"
       preset-ginkgo-skip-default: "true"
+      preset-default-e2e-volumes: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -873,21 +695,6 @@ presubmits:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
       dnsConfig:
         options:
         - name: ndots

--- a/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
@@ -45,6 +45,7 @@ periodics:
     base_ref: release-1.8
   labels:
     preset-service-account: "true"
+    preset-make-volumes: "true"
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-previous
@@ -62,26 +63,6 @@ periodics:
           requests:
             cpu: 2
             memory: 4Gi
-        volumeMounts:
-          - mountPath: /root/.cache/go-build
-            name: gocache
-          - mountPath: /home/prow/go/pkg/mod
-            name: gopkgmod
-          - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-            name: bindownloaded
-    volumes:
-      - name: gocache
-        hostPath:
-          path: /tmp/gocache
-          type: DirectoryOrCreate
-      - name: gopkgmod
-        hostPath:
-          path: /tmp/gopkgmod
-          type: DirectoryOrCreate
-      - name: bindownloaded
-        hostPath:
-          path: /tmp/bindownloaded
-          type: DirectoryOrCreate
     dnsConfig:
       options:
         - name: ndots
@@ -104,6 +85,7 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
+    preset-default-e2e-volumes: "true"
   spec:
     containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -120,21 +102,6 @@ periodics:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-          - mountPath: /lib/modules
-            name: modules
-            readOnly: true
-          - mountPath: /sys/fs/cgroup
-            name: cgroup
-    volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
     dnsConfig:
       options:
         - name: ndots
@@ -163,6 +130,8 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
+    preset-default-e2e-volumes: "true"
+    preset-make-volumes: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -181,36 +150,6 @@ periodics:
         privileged: true
         capabilities:
           add: ["SYS_ADMIN"]
-      volumeMounts:
-      - mountPath: /root/.cache/go-build
-        name: gocache
-      - mountPath: /home/prow/go/pkg/mod
-        name: gopkgmod
-      - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-        name: bindownloaded
-      - mountPath: /lib/modules
-        name: modules
-        readOnly: true
-      - mountPath: /lib/modules
-        name: modules
-        readOnly: true
-      - mountPath: /sys/fs/cgroup
-        name: cgroup
-    volumes:
-    - mountPath: /root/.cache/go-build
-      name: gocache
-    - mountPath: /home/prow/go/pkg/mod
-      name: gopkgmod
-    - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-      name: bindownloaded
-    - name: modules
-      hostPath:
-        path: /lib/modules
-        type: Directory
-    - name: cgroup
-      hostPath:
-        path: /sys/fs/cgroup
-        type: Directory
     dnsConfig:
       options:
       - name: ndots
@@ -237,6 +176,8 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
+    preset-default-e2e-volumes: "true"
+    preset-make-volumes: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -255,39 +196,6 @@ periodics:
         privileged: true
         capabilities:
           add: ["SYS_ADMIN"]
-      volumeMounts:
-      - mountPath: /root/.cache/go-build
-        name: gocache
-      - mountPath: /home/prow/go/pkg/mod
-        name: gopkgmod
-      - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-        name: bindownloaded
-      - mountPath: /lib/modules
-        name: modules
-        readOnly: true
-      - mountPath: /sys/fs/cgroup
-        name: cgroup
-    volumes:
-    - name: gocache
-      hostPath:
-        path: /tmp/gocache
-        type: DirectoryOrCreate
-    - name: gopkgmod
-      hostPath:
-        path: /tmp/gopkgmod
-        type: DirectoryOrCreate
-    - name: bindownloaded
-      hostPath:
-        path: /tmp/bindownloaded
-        type: DirectoryOrCreate
-    - name: modules
-      hostPath:
-        path: /lib/modules
-        type: Directory
-    - name: cgroup
-      hostPath:
-        path: /sys/fs/cgroup
-        type: Directory
     dnsConfig:
       options:
       - name: ndots
@@ -314,6 +222,8 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
+    preset-default-e2e-volumes: "true"
+    preset-make-volumes: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -332,39 +242,6 @@ periodics:
         privileged: true
         capabilities:
           add: ["SYS_ADMIN"]
-      volumeMounts:
-      - mountPath: /root/.cache/go-build
-        name: gocache
-      - mountPath: /home/prow/go/pkg/mod
-        name: gopkgmod
-      - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-        name: bindownloaded
-      - mountPath: /lib/modules
-        name: modules
-        readOnly: true
-      - mountPath: /sys/fs/cgroup
-        name: cgroup
-    volumes:
-    - name: gocache
-      hostPath:
-        path: /tmp/gocache
-        type: DirectoryOrCreate
-    - name: gopkgmod
-      hostPath:
-        path: /tmp/gopkgmod
-        type: DirectoryOrCreate
-    - name: bindownloaded
-      hostPath:
-        path: /tmp/bindownloaded
-        type: DirectoryOrCreate
-    - name: modules
-      hostPath:
-        path: /lib/modules
-        type: Directory
-    - name: cgroup
-      hostPath:
-        path: /sys/fs/cgroup
-        type: Directory
     dnsConfig:
       options:
       - name: ndots
@@ -391,6 +268,8 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
+    preset-default-e2e-volumes: "true"
+    preset-make-volumes: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -409,42 +288,6 @@ periodics:
         privileged: true
         capabilities:
           add: ["SYS_ADMIN"]
-      volumeMounts:
-      - mountPath: /root/.cache/go-build
-        name: gocache
-      - mountPath: /home/prow/go/pkg/mod
-        name: gopkgmod
-      - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-        name: bindownloaded
-      - mountPath: /lib/modules
-        name: modules
-        readOnly: true
-      - mountPath: /lib/modules
-        name: modules
-        readOnly: true
-      - mountPath: /sys/fs/cgroup
-        name: cgroup
-    volumes:
-    - name: gocache
-      hostPath:
-        path: /tmp/gocache
-        type: DirectoryOrCreate
-    - name: gopkgmod
-      hostPath:
-        path: /tmp/gopkgmod
-        type: DirectoryOrCreate
-    - name: bindownloaded
-      hostPath:
-        path: /tmp/bindownloaded
-        type: DirectoryOrCreate
-    - name: modules
-      hostPath:
-        path: /lib/modules
-        type: Directory
-    - name: cgroup
-      hostPath:
-        path: /sys/fs/cgroup
-        type: Directory
     dnsConfig:
       options:
       - name: ndots
@@ -471,6 +314,8 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
+    preset-default-e2e-volumes: "true"
+    preset-make-volumes: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -489,39 +334,6 @@ periodics:
         privileged: true
         capabilities:
           add: ["SYS_ADMIN"]
-      volumeMounts:
-      - mountPath: /root/.cache/go-build
-        name: gocache
-      - mountPath: /home/prow/go/pkg/mod
-        name: gopkgmod
-      - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-        name: bindownloaded
-      - mountPath: /lib/modules
-        name: modules
-        readOnly: true
-      - mountPath: /sys/fs/cgroup
-        name: cgroup
-    volumes:
-    - name: gocache
-      hostPath:
-        path: /tmp/gocache
-        type: DirectoryOrCreate
-    - name: gopkgmod
-      hostPath:
-        path: /tmp/gopkgmod
-        type: DirectoryOrCreate
-    - name: bindownloaded
-      hostPath:
-        path: /tmp/bindownloaded
-        type: DirectoryOrCreate
-    - name: modules
-      hostPath:
-        path: /lib/modules
-        type: Directory
-    - name: cgroup
-      hostPath:
-        path: /sys/fs/cgroup
-        type: Directory
     dnsConfig:
       options:
       - name: ndots
@@ -548,6 +360,8 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
+    preset-default-e2e-volumes: "true"
+    preset-make-volumes: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -566,39 +380,6 @@ periodics:
         privileged: true
         capabilities:
           add: ["SYS_ADMIN"]
-      volumeMounts:
-      - mountPath: /root/.cache/go-build
-        name: gocache
-      - mountPath: /home/prow/go/pkg/mod
-        name: gopkgmod
-      - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-        name: bindownloaded
-      - mountPath: /lib/modules
-        name: modules
-        readOnly: true
-      - mountPath: /sys/fs/cgroup
-        name: cgroup
-    volumes:
-    - name: gocache
-      hostPath:
-        path: /tmp/gocache
-        type: DirectoryOrCreate
-    - name: gopkgmod
-      hostPath:
-        path: /tmp/gopkgmod
-        type: DirectoryOrCreate
-    - name: bindownloaded
-      hostPath:
-        path: /tmp/bindownloaded
-        type: DirectoryOrCreate
-    - name: modules
-      hostPath:
-        path: /lib/modules
-        type: Directory
-    - name: cgroup
-      hostPath:
-        path: /sys/fs/cgroup
-        type: Directory
     dnsConfig:
       options:
       - name: ndots
@@ -628,6 +409,7 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
+    preset-default-e2e-volumes: "true"
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -645,21 +427,6 @@ periodics:
         privileged: true
         capabilities:
           add: ["SYS_ADMIN"]
-      volumeMounts:
-      - mountPath: /lib/modules
-        name: modules
-        readOnly: true
-      - mountPath: /sys/fs/cgroup
-        name: cgroup
-    volumes:
-    - name: modules
-      hostPath:
-        path: /lib/modules
-        type: Directory
-    - name: cgroup
-      hostPath:
-        path: /sys/fs/cgroup
-        type: Directory
     dnsConfig:
       options:
       - name: ndots
@@ -687,6 +454,8 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-retry-flakey-tests: "true"
+    preset-make-volumes: "true"
+    preset-default-e2e-volumes: "true"
   spec:
     containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -705,39 +474,6 @@ periodics:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-          - mountPath: /lib/modules
-            name: modules
-            readOnly: true
-          - mountPath: /sys/fs/cgroup
-            name: cgroup
-          - mountPath: /root/.cache/go-build
-            name: gocache
-          - mountPath: /home/prow/go/pkg/mod
-            name: gopkgmod
-          - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-            name: bindownloaded
-    volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-      - name: gocache
-        hostPath:
-          path: /tmp/gocache
-          type: DirectoryOrCreate
-      - name: gopkgmod
-        hostPath:
-          path: /tmp/gopkgmod
-          type: DirectoryOrCreate
-      - name: bindownloaded
-        hostPath:
-          path: /tmp/bindownloaded
-          type: DirectoryOrCreate
     dnsConfig:
       options:
         - name: ndots
@@ -762,6 +498,8 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-retry-flakey-tests: "true"
+    preset-make-volumes: "true"
+    preset-default-e2e-volumes: "true"
   spec:
     containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -780,39 +518,6 @@ periodics:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-          - mountPath: /lib/modules
-            name: modules
-            readOnly: true
-          - mountPath: /sys/fs/cgroup
-            name: cgroup
-          - mountPath: /root/.cache/go-build
-            name: gocache
-          - mountPath: /home/prow/go/pkg/mod
-            name: gopkgmod
-          - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-            name: bindownloaded
-    volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-      - name: gocache
-        hostPath:
-          path: /tmp/gocache
-          type: DirectoryOrCreate
-      - name: gopkgmod
-        hostPath:
-          path: /tmp/gopkgmod
-          type: DirectoryOrCreate
-      - name: bindownloaded
-        hostPath:
-          path: /tmp/bindownloaded
-          type: DirectoryOrCreate
     dnsConfig:
       options:
         - name: ndots
@@ -837,6 +542,8 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-retry-flakey-tests: "true"
+    preset-make-volumes: "true"
+    preset-default-e2e-volumes: "true"
   spec:
     containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -855,39 +562,6 @@ periodics:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-          - mountPath: /lib/modules
-            name: modules
-            readOnly: true
-          - mountPath: /sys/fs/cgroup
-            name: cgroup
-          - mountPath: /root/.cache/go-build
-            name: gocache
-          - mountPath: /home/prow/go/pkg/mod
-            name: gopkgmod
-          - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-            name: bindownloaded
-    volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-      - name: gocache
-        hostPath:
-          path: /tmp/gocache
-          type: DirectoryOrCreate
-      - name: gopkgmod
-        hostPath:
-          path: /tmp/gopkgmod
-          type: DirectoryOrCreate
-      - name: bindownloaded
-        hostPath:
-          path: /tmp/bindownloaded
-          type: DirectoryOrCreate
     dnsConfig:
       options:
         - name: ndots
@@ -912,6 +586,8 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-retry-flakey-tests: "true"
+    preset-make-volumes: "true"
+    preset-default-e2e-volumes: "true"
   spec:
     containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -930,39 +606,6 @@ periodics:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-          - mountPath: /lib/modules
-            name: modules
-            readOnly: true
-          - mountPath: /sys/fs/cgroup
-            name: cgroup
-          - mountPath: /root/.cache/go-build
-            name: gocache
-          - mountPath: /home/prow/go/pkg/mod
-            name: gopkgmod
-          - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-            name: bindownloaded
-    volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-      - name: gocache
-        hostPath:
-          path: /tmp/gocache
-          type: DirectoryOrCreate
-      - name: gopkgmod
-        hostPath:
-          path: /tmp/gopkgmod
-          type: DirectoryOrCreate
-      - name: bindownloaded
-        hostPath:
-          path: /tmp/bindownloaded
-          type: DirectoryOrCreate
     dnsConfig:
       options:
         - name: ndots
@@ -987,6 +630,8 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-retry-flakey-tests: "true"
+    preset-make-volumes: "true"
+    preset-default-e2e-volumes: "true"
   spec:
     containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -1005,39 +650,6 @@ periodics:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-          - mountPath: /lib/modules
-            name: modules
-            readOnly: true
-          - mountPath: /sys/fs/cgroup
-            name: cgroup
-          - mountPath: /root/.cache/go-build
-            name: gocache
-          - mountPath: /home/prow/go/pkg/mod
-            name: gopkgmod
-          - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-            name: bindownloaded
-    volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-      - name: gocache
-        hostPath:
-          path: /tmp/gocache
-          type: DirectoryOrCreate
-      - name: gopkgmod
-        hostPath:
-          path: /tmp/gopkgmod
-          type: DirectoryOrCreate
-      - name: bindownloaded
-        hostPath:
-          path: /tmp/bindownloaded
-          type: DirectoryOrCreate
     dnsConfig:
       options:
         - name: ndots
@@ -1062,6 +674,8 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-retry-flakey-tests: "true"
+    preset-make-volumes: "true"
+    preset-default-e2e-volumes: "true"
   spec:
     containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -1080,39 +694,6 @@ periodics:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-          - mountPath: /lib/modules
-            name: modules
-            readOnly: true
-          - mountPath: /sys/fs/cgroup
-            name: cgroup
-          - mountPath: /root/.cache/go-build
-            name: gocache
-          - mountPath: /home/prow/go/pkg/mod
-            name: gopkgmod
-          - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-            name: bindownloaded
-    volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-      - name: gocache
-        hostPath:
-          path: /tmp/gocache
-          type: DirectoryOrCreate
-      - name: gopkgmod
-        hostPath:
-          path: /tmp/gopkgmod
-          type: DirectoryOrCreate
-      - name: bindownloaded
-        hostPath:
-          path: /tmp/bindownloaded
-          type: DirectoryOrCreate
     dnsConfig:
       options:
         - name: ndots
@@ -1140,6 +721,7 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-retry-flakey-tests: "true"
+    preset-default-e2e-volumes: "true"
   spec:
     containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -1157,21 +739,6 @@ periodics:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-          - mountPath: /lib/modules
-            name: modules
-            readOnly: true
-          - mountPath: /sys/fs/cgroup
-            name: cgroup
-    volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
     dnsConfig:
       options:
         - name: ndots
@@ -1200,6 +767,8 @@ periodics:
     preset-venafi-cloud-credentials: "true"
     preset-venafi-tpp-credentials: "true"
     preset-ginkgo-focus-venafi: "true"
+    preset-default-e2e-volumes: "true"
+    preset-make-volumes: "true"
   spec:
     containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -1218,39 +787,6 @@ periodics:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-          - mountPath: /lib/modules
-            name: modules
-            readOnly: true
-          - mountPath: /sys/fs/cgroup
-            name: cgroup
-          - mountPath: /root/.cache/go-build
-            name: gocache
-          - mountPath: /home/prow/go/pkg/mod
-            name: gopkgmod
-          - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-            name: bindownloaded
-    volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-      - name: gocache
-        hostPath:
-          path: /tmp/gocache
-          type: DirectoryOrCreate
-      - name: gopkgmod
-        hostPath:
-          path: /tmp/gopkgmod
-          type: DirectoryOrCreate
-      - name: bindownloaded
-        hostPath:
-          path: /tmp/bindownloaded
-          type: DirectoryOrCreate
     dnsConfig:
       options:
         - name: ndots

--- a/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
@@ -111,6 +111,7 @@ presubmits:
     - release-1.8
     labels:
       preset-service-account: "true"
+      preset-make-volumes: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -124,26 +125,6 @@ presubmits:
           requests:
             cpu: 2
             memory: 4Gi
-        volumeMounts:
-        - mountPath: /root/.cache/go-build
-          name: gocache
-        - mountPath: /home/prow/go/pkg/mod
-          name: gopkgmod
-        - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-          name: bindownloaded
-      volumes:
-      - name: gocache
-        hostPath:
-          path: /tmp/gocache
-          type: DirectoryOrCreate
-      - name: gopkgmod
-        hostPath:
-          path: /tmp/gopkgmod
-          type: DirectoryOrCreate
-      - name: bindownloaded
-        hostPath:
-          path: /tmp/bindownloaded
-          type: DirectoryOrCreate
       dnsConfig:
         options:
           - name: ndots
@@ -169,6 +150,7 @@ presubmits:
       preset-retry-flakey-tests: "true"
       preset-disable-all-alpha-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
+      preset-default-e2e-volumes: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -186,21 +168,6 @@ presubmits:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
       dnsConfig:
         options:
         - name: ndots
@@ -224,6 +191,7 @@ presubmits:
       preset-retry-flakey-tests: "true"
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
+      preset-default-e2e-volumes: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -241,21 +209,6 @@ presubmits:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
       dnsConfig:
         options:
         - name: ndots
@@ -278,6 +231,8 @@ presubmits:
       preset-retry-flakey-tests: "true"
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
+      preset-default-e2e-volumes: "true"
+      preset-make-volumes: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -296,39 +251,6 @@ presubmits:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /root/.cache/go-build
-          name: gocache
-        - mountPath: /home/prow/go/pkg/mod
-          name: gopkgmod
-        - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-          name: bindownloaded
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-      - name: gocache
-        hostPath:
-          path: /tmp/gocache
-          type: DirectoryOrCreate
-      - name: gopkgmod
-        hostPath:
-          path: /tmp/gopkgmod
-          type: DirectoryOrCreate
-      - name: bindownloaded
-        hostPath:
-          path: /tmp/bindownloaded
-          type: DirectoryOrCreate
       dnsConfig:
         options:
         - name: ndots
@@ -352,6 +274,7 @@ presubmits:
       preset-retry-flakey-tests: "true"
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
+      preset-default-e2e-volumes: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -369,21 +292,6 @@ presubmits:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
       dnsConfig:
         options:
         - name: ndots
@@ -406,6 +314,8 @@ presubmits:
       preset-retry-flakey-tests: "true"
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
+      preset-default-e2e-volumes: "true"
+      preset-make-volumes: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -424,39 +334,6 @@ presubmits:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /root/.cache/go-build
-          name: gocache
-        - mountPath: /home/prow/go/pkg/mod
-          name: gopkgmod
-        - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-          name: bindownloaded
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      volumes:
-      - name: gocache
-        hostPath:
-          path: /tmp/gocache
-          type: DirectoryOrCreate
-      - name: gopkgmod
-        hostPath:
-          path: /tmp/gopkgmod
-          type: DirectoryOrCreate
-      - name: bindownloaded
-        hostPath:
-          path: /tmp/bindownloaded
-          type: DirectoryOrCreate
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
       dnsConfig:
         options:
         - name: ndots
@@ -480,6 +357,7 @@ presubmits:
       preset-retry-flakey-tests: "true"
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
+      preset-default-e2e-volumes: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -497,21 +375,6 @@ presubmits:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
       dnsConfig:
         options:
         - name: ndots
@@ -534,6 +397,8 @@ presubmits:
       preset-retry-flakey-tests: "true"
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
+      preset-make-volumes: "true"
+      preset-default-e2e-volumes: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -552,39 +417,6 @@ presubmits:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /root/.cache/go-build
-          name: gocache
-        - mountPath: /home/prow/go/pkg/mod
-          name: gopkgmod
-        - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-          name: bindownloaded
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      volumes:
-      - name: gocache
-        hostPath:
-          path: /tmp/gocache
-          type: DirectoryOrCreate
-      - name: gopkgmod
-        hostPath:
-          path: /tmp/gopkgmod
-          type: DirectoryOrCreate
-      - name: bindownloaded
-        hostPath:
-          path: /tmp/bindownloaded
-          type: DirectoryOrCreate
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
       dnsConfig:
         options:
         - name: ndots
@@ -608,6 +440,7 @@ presubmits:
       preset-retry-flakey-tests: "true"
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
+      preset-default-e2e-volumes: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -625,21 +458,6 @@ presubmits:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
       dnsConfig:
         options:
         - name: ndots
@@ -662,6 +480,8 @@ presubmits:
       preset-retry-flakey-tests: "true"
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
+      preset-default-e2e-volumes: "true"
+      preset-make-volumes: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -680,39 +500,6 @@ presubmits:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /root/.cache/go-build
-          name: gocache
-        - mountPath: /home/prow/go/pkg/mod
-          name: gopkgmod
-        - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-          name: bindownloaded
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      volumes:
-      - name: gocache
-        hostPath:
-          path: /tmp/gocache
-          type: DirectoryOrCreate
-      - name: gopkgmod
-        hostPath:
-          path: /tmp/gopkgmod
-          type: DirectoryOrCreate
-      - name: bindownloaded
-        hostPath:
-          path: /tmp/bindownloaded
-          type: DirectoryOrCreate
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
       dnsConfig:
         options:
         - name: ndots
@@ -736,6 +523,7 @@ presubmits:
       preset-retry-flakey-tests: "true"
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
+      preset-default-e2e-volumes: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -753,21 +541,6 @@ presubmits:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
       dnsConfig:
         options:
         - name: ndots
@@ -788,6 +561,8 @@ presubmits:
       preset-retry-flakey-tests: "true"
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
+      preset-default-e2e-volumes: "true"
+      preset-make-volumes: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -806,39 +581,6 @@ presubmits:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-        - mountPath: /root/.cache/go-build
-          name: gocache
-        - mountPath: /home/prow/go/pkg/mod
-          name: gopkgmod
-        - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-          name: bindownloaded
-      volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-      - name: gocache
-        hostPath:
-          path: /tmp/gocache
-          type: DirectoryOrCreate
-      - name: gopkgmod
-        hostPath:
-          path: /tmp/gopkgmod
-          type: DirectoryOrCreate
-      - name: bindownloaded
-        hostPath:
-          path: /tmp/bindownloaded
-          type: DirectoryOrCreate
       dnsConfig:
         options:
         - name: ndots
@@ -859,6 +601,8 @@ presubmits:
       preset-retry-flakey-tests: "true"
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
+      preset-make-volumes: "true"
+      preset-default-e2e-volumes: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -877,39 +621,6 @@ presubmits:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-        - mountPath: /root/.cache/go-build
-          name: gocache
-        - mountPath: /home/prow/go/pkg/mod
-          name: gopkgmod
-        - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-          name: bindownloaded
-      volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-      - name: gocache
-        hostPath:
-          path: /tmp/gocache
-          type: DirectoryOrCreate
-      - name: gopkgmod
-        hostPath:
-          path: /tmp/gopkgmod
-          type: DirectoryOrCreate
-      - name: bindownloaded
-        hostPath:
-          path: /tmp/bindownloaded
-          type: DirectoryOrCreate
       dnsConfig:
         options:
         - name: ndots
@@ -931,6 +642,7 @@ presubmits:
       preset-retry-flakey-tests: "true"
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
+      preset-default-e2e-volumes: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -948,21 +660,6 @@ presubmits:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
       dnsConfig:
         options:
         - name: ndots
@@ -988,6 +685,7 @@ presubmits:
       preset-cloudflare-credentials: "true"
       preset-retry-flakey-tests: "true"
       preset-ginkgo-skip-default: "true"
+      preset-default-e2e-volumes: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -1005,21 +703,6 @@ presubmits:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
       dnsConfig:
         options:
         - name: ndots
@@ -1042,6 +725,8 @@ presubmits:
       preset-cloudflare-credentials: "true"
       preset-retry-flakey-tests: "true"
       preset-ginkgo-skip-default: "true"
+      preset-default-e2e-volumes: "true"
+      preset-make-volumes: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1 
@@ -1060,39 +745,6 @@ presubmits:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /root/.cache/go-build
-          name: gocache
-        - mountPath: /home/prow/go/pkg/mod
-          name: gopkgmod
-        - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-          name: bindownloaded
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      volumes:
-      - name: gocache
-        hostPath:
-          path: /tmp/gocache
-          type: DirectoryOrCreate
-      - name: gopkgmod
-        hostPath:
-          path: /tmp/gopkgmod
-          type: DirectoryOrCreate
-      - name: bindownloaded
-        hostPath:
-          path: /tmp/bindownloaded
-          type: DirectoryOrCreate
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
       dnsConfig:
         options:
         - name: ndots
@@ -1116,6 +768,7 @@ presubmits:
       preset-cloudflare-credentials: "true"
       preset-retry-flakey-tests: "true"
       preset-ginkgo-skip-default: "true"
+      preset-default-e2e-volumes: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -1133,21 +786,6 @@ presubmits:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
       dnsConfig:
         options:
         - name: ndots
@@ -1170,6 +808,8 @@ presubmits:
       preset-cloudflare-credentials: "true"
       preset-retry-flakey-tests: "true"
       preset-ginkgo-skip-default: "true"
+      preset-make-volumes: "true"
+      preset-default-e2e-volumes: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -1188,39 +828,6 @@ presubmits:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /root/.cache/go-build
-          name: gocache
-        - mountPath: /home/prow/go/pkg/mod
-          name: gopkgmod
-        - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-          name: bindownloaded
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      volumes:
-      - name: gocache
-        hostPath:
-          path: /tmp/gocache
-          type: DirectoryOrCreate
-      - name: gopkgmod
-        hostPath:
-          path: /tmp/gopkgmod
-          type: DirectoryOrCreate
-      - name: bindownloaded
-        hostPath:
-          path: /tmp/bindownloaded
-          type: DirectoryOrCreate
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
       dnsConfig:
         options:
         - name: ndots
@@ -1244,6 +851,7 @@ presubmits:
       preset-cloudflare-credentials: "true"
       preset-retry-flakey-tests: "true"
       preset-ginkgo-skip-default: "true"
+      preset-default-e2e-volumes: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -1261,21 +869,6 @@ presubmits:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
       dnsConfig:
         options:
         - name: ndots
@@ -1298,6 +891,8 @@ presubmits:
       preset-cloudflare-credentials: "true"
       preset-retry-flakey-tests: "true"
       preset-ginkgo-skip-default: "true"
+      preset-default-e2e-volumes: "true"
+      preset-make-volumes: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -1316,39 +911,6 @@ presubmits:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /root/.cache/go-build
-          name: gocache
-        - mountPath: /home/prow/go/pkg/mod
-          name: gopkgmod
-        - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-          name: bindownloaded
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      volumes:
-      - name: gocache
-        hostPath:
-          path: /tmp/gocache
-          type: DirectoryOrCreate
-      - name: gopkgmod
-        hostPath:
-          path: /tmp/gopkgmod
-          type: DirectoryOrCreate
-      - name: bindownloaded
-        hostPath:
-          path: /tmp/bindownloaded
-          type: DirectoryOrCreate
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
       dnsConfig:
         options:
         - name: ndots
@@ -1372,6 +934,7 @@ presubmits:
       preset-cloudflare-credentials: "true"
       preset-retry-flakey-tests: "true"
       preset-ginkgo-skip-default: "true"
+      preset-default-e2e-volumes: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -1389,21 +952,6 @@ presubmits:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
       dnsConfig:
         options:
         - name: ndots
@@ -1426,6 +974,8 @@ presubmits:
       preset-cloudflare-credentials: "true"
       preset-retry-flakey-tests: "true"
       preset-ginkgo-skip-default: "true"
+      preset-default-e2e-volumes: "true"
+      preset-make-volumes: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -1444,39 +994,6 @@ presubmits:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /root/.cache/go-build
-          name: gocache
-        - mountPath: /home/prow/go/pkg/mod
-          name: gopkgmod
-        - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-          name: bindownloaded
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      volumes:
-      - name: gocache
-        hostPath:
-          path: /tmp/gocache
-          type: DirectoryOrCreate
-      - name: gopkgmod
-        hostPath:
-          path: /tmp/gopkgmod
-          type: DirectoryOrCreate
-      - name: bindownloaded
-        hostPath:
-          path: /tmp/bindownloaded
-          type: DirectoryOrCreate
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
       dnsConfig:
         options:
         - name: ndots
@@ -1500,6 +1017,7 @@ presubmits:
       preset-cloudflare-credentials: "true"
       preset-retry-flakey-tests: "true"
       preset-ginkgo-skip-default: "true"
+      preset-default-e2e-volumes: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -1517,21 +1035,6 @@ presubmits:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
       dnsConfig:
         options:
         - name: ndots
@@ -1554,6 +1057,8 @@ presubmits:
       preset-cloudflare-credentials: "true"
       preset-retry-flakey-tests: "true"
       preset-ginkgo-skip-default: "true"
+      preset-default-e2e-volumes: "true"
+      preset-make-volumes: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -1572,39 +1077,6 @@ presubmits:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-        - mountPath: /root/.cache/go-build
-          name: gocache
-        - mountPath: /home/prow/go/pkg/mod
-          name: gopkgmod
-        - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-          name: bindownloaded
-      volumes:
-      - name: gocache
-        hostPath:
-          path: /tmp/gocache
-          type: DirectoryOrCreate
-      - name: gopkgmod
-        hostPath:
-          path: /tmp/gopkgmod
-          type: DirectoryOrCreate
-      - name: bindownloaded
-        hostPath:
-          path: /tmp/bindownloaded
-          type: DirectoryOrCreate
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
       dnsConfig:
         options:
         - name: ndots
@@ -1628,6 +1100,7 @@ presubmits:
       preset-cloudflare-credentials: "true"
       preset-retry-flakey-tests: "true"
       preset-ginkgo-skip-default: "true"
+      preset-default-e2e-volumes: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -1645,21 +1118,6 @@ presubmits:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
       dnsConfig:
         options:
         - name: ndots
@@ -1682,6 +1140,8 @@ presubmits:
       preset-cloudflare-credentials: "true"
       preset-retry-flakey-tests: "true"
       preset-ginkgo-skip-default: "true"
+      preset-default-e2e-volumes: "true"
+      preset-make-volumes: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -1700,39 +1160,6 @@ presubmits:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /root/.cache/go-build
-          name: gocache
-        - mountPath: /home/prow/go/pkg/mod
-          name: gopkgmod
-        - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
-          name: bindownloaded
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      volumes:
-      - name: gocache
-        hostPath:
-          path: /tmp/gocache
-          type: DirectoryOrCreate
-      - name: gopkgmod
-        hostPath:
-          path: /tmp/gopkgmod
-          type: DirectoryOrCreate
-      - name: bindownloaded
-        hostPath:
-          path: /tmp/bindownloaded
-          type: DirectoryOrCreate
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
       dnsConfig:
         options:
         - name: ndots
@@ -1756,6 +1183,7 @@ presubmits:
       preset-cloudflare-credentials: "true"
       preset-retry-flakey-tests: "true"
       preset-ginkgo-skip-default: "true"
+      preset-default-e2e-volumes: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -1773,21 +1201,6 @@ presubmits:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
       dnsConfig:
         options:
         - name: ndots
@@ -1819,6 +1232,7 @@ presubmits:
       preset-venafi-tpp-credentials: "true"
       preset-retry-flakey-tests: "true"
       preset-ginkgo-focus-venafi-tpp: "true"
+      preset-default-e2e-volumes: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -1836,21 +1250,6 @@ presubmits:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
       dnsConfig:
         options:
         - name: ndots
@@ -1881,6 +1280,7 @@ presubmits:
       preset-venafi-cloud-credentials: "true"
       preset-retry-flakey-tests: "true"
       preset-ginkgo-focus-venafi-cloud: "true"
+      preset-default-e2e-volumes: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -1898,21 +1298,6 @@ presubmits:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
       dnsConfig:
         options:
         - name: ndots

--- a/config/jobs/cert-manager/config.yaml
+++ b/config/jobs/cert-manager/config.yaml
@@ -147,3 +147,48 @@ presets:
   env:
   - name: GINKGO_FOCUS
     value: 'Venafi Cloud'
+
+# This preset should be added to all tests that are run with make. It ensures
+# that gocache, go module cache and make cache are mounted to the Job's pod
+- labels:
+    preset-make-volumes: "true"
+  volumeMounts:
+  - mountPath: /root/.cache/go-build
+    name: gocache
+  - mountPath: /home/prow/go/pkg/mod
+    name: gopkgmod
+  - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
+    name: bindownloaded
+  volumes:
+  - name: gocache
+    hostPath:
+      path: /tmp/gocache
+      type: DirectoryOrCreate
+  - name: gopkgmod
+    hostPath:
+      path: /tmp/gopkgmod
+      type: DirectoryOrCreate
+  - name: bindownloaded
+    hostPath:
+      path: /tmp/bindownloaded
+      type: DirectoryOrCreate
+
+# This preset should be added to all e2e tests to ensure Docker (used to spin up
+# Kind clusters) can be set up.
+- labels:
+    preset-default-e2e-volumes: "true"
+  volumes:
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+  volumeMounts:
+    - mountPath: /lib/modules
+      name: modules
+      readOnly: true
+    - mountPath: /sys/fs/cgroup
+      name: cgroup


### PR DESCRIPTION
This PR:

- splits volumes for ProwJob configs into presets so there is less of a chance of human error when copy-pasting jobs around
- fixes two such errors where a volume was duplicated [here](https://github.com/jetstack/testing/blob/master/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml#L191-L196) and [here](https://github.com/jetstack/testing/blob/master/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml#L419-L424)

I have checked that the presets get merged as expected by checking some of the job configs with [mkpj](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/mkpj):
- clone https://github.com/kubernetes/test-infra
- from within that repo run `go run ./prow/cmd/mkpj/main.go --config-path=<path to jetstack/testing/config/config.yaml> --job-config-path=<path to jetstack/testing/config/jobs/cert-manager> --job <job-name>`
- observe that the output ProwJob yaml contains the expected volumes and volume mounts

Signed-off-by: irbekrm <irbekrm@gmail.com>