### PR TITLE
WIP Makes 1.24 the default kube version for master e2e tests

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -39,7 +39,7 @@ branch-protection:
             - pull-cert-manager-bazel
             - pull-cert-manager-deps
             - pull-cert-manager-chart
-            - pull-cert-manager-e2e-v1-23
+            - pull-cert-manager-e2e-v1-24
             # - pull-cert-manager-make-test
         website:
           required_status_checks:

--- a/config/jobs/cert-manager/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager/cert-manager-periodics.yaml
@@ -305,7 +305,7 @@ periodics:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-master
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs Venafi (VaaS and TPP) e2e tests against Kubernetes v1.23 cluster
+    description: Runs Venafi (VaaS and TPP) e2e tests against Kubernetes v1.24 cluster
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
@@ -323,7 +323,7 @@ periodics:
         - -j
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.23
+        - K8S_VERSION=1.24
         resources:
           requests:
             cpu: 3500m

--- a/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
@@ -275,10 +275,9 @@ presubmits:
         - name: ndots
           value: "1"
 
-    # This is the default e2e test for all PRs.
   - name: pull-cert-manager-e2e-v1-23
-    always_run: true
-    optional: false
+    always_run: false
+    optional: true
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -320,9 +319,10 @@ presubmits:
         - name: ndots
           value: "1"
 
+  # This is the default e2e test for all PRs against cert-manager master branch
   - name: pull-cert-manager-e2e-v1-24
-    always_run: false
-    optional: true
+    always_run: true
+    optional: false
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -403,7 +403,7 @@ presubmits:
         env:
         # Used by https://github.com/cert-manager/cert-manager/blob/master/devel/cluster/create-kind.sh
         - name: K8S_VERSION
-          value: "1.23"
+          value: "1.24"
         securityContext:
           privileged: true
           capabilities:
@@ -448,7 +448,7 @@ presubmits:
         - -j
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.23
+        - K8S_VERSION=1.24
         resources:
           requests:
             cpu: 3500m


### PR DESCRIPTION
This PR makes 1.24 the default Kubernetes version for e2e tests against current master.

(Before merging this we should merge https://github.com/cert-manager/cert-manager/pull/5190 which uses upstream kind image for 1.24 clusters)

Signed-off-by: irbekrm <irbekrm@gmail.com>