### PR TITLE
Run 1.8 presubmits with Bazel, ensure SSA disabled for kube below 1.22

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -39,7 +39,7 @@ branch-protection:
             - pull-cert-manager-bazel
             - pull-cert-manager-deps
             - pull-cert-manager-chart
-            - pull-cert-manager-e2e-v1-23
+            - pull-cert-manager-e2e-v1-24
             # - pull-cert-manager-make-test
         website:
           required_status_checks:

--- a/config/jobs/cert-manager/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager/cert-manager-periodics.yaml
@@ -305,7 +305,7 @@ periodics:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-master
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs Venafi (VaaS and TPP) e2e tests against Kubernetes v1.23 cluster
+    description: Runs Venafi (VaaS and TPP) e2e tests against Kubernetes v1.24 cluster
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
@@ -323,7 +323,7 @@ periodics:
         - -j
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.23
+        - K8S_VERSION=1.24
         resources:
           requests:
             cpu: 3500m

--- a/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
@@ -275,10 +275,9 @@ presubmits:
         - name: ndots
           value: "1"
 
-    # This is the default e2e test for all PRs.
   - name: pull-cert-manager-e2e-v1-23
-    always_run: true
-    optional: false
+    always_run: false
+    optional: true
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -320,9 +319,10 @@ presubmits:
         - name: ndots
           value: "1"
 
+  # This is the default e2e test for all PRs against cert-manager master branch
   - name: pull-cert-manager-e2e-v1-24
-    always_run: false
-    optional: true
+    always_run: true
+    optional: false
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -403,7 +403,7 @@ presubmits:
         env:
         # Used by https://github.com/cert-manager/cert-manager/blob/master/devel/cluster/create-kind.sh
         - name: K8S_VERSION
-          value: "1.23"
+          value: "1.24"
         securityContext:
           privileged: true
           capabilities:
@@ -448,7 +448,7 @@ presubmits:
         - -j
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.23
+        - K8S_VERSION=1.24
         resources:
           requests:
             cpu: 3500m

--- a/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
@@ -148,7 +148,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
       preset-retry-flakey-tests: "true"
-      preset-disable-all-alpha-feature-gates: "true"
+      preset-disable-alpha-enable-output-formats-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
       preset-default-e2e-volumes: "true"
     spec:
@@ -173,7 +173,6 @@ presubmits:
         - name: ndots
           value: "1"
 
-# Run with Bazel for release-1.7 where make was not available
   - name: pull-cert-manager-e2e-v1-19
     always_run: false
     optional: true
@@ -182,6 +181,7 @@ presubmits:
     decorate: true
     branches:
     - release-1.7
+    - release-1.8
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -189,7 +189,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
       preset-retry-flakey-tests: "true"
-      preset-enable-all-feature-gates: "true"
+      preset-enable-all-feature-gates-disable-ssa: "true"
       preset-ginkgo-skip-default: "true"
       preset-default-e2e-volumes: "true"
     spec:
@@ -214,49 +214,6 @@ presubmits:
         - name: ndots
           value: "1"
 
-  - name: pull-cert-manager-e2e-v1-19
-    always_run: false
-    optional: true
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    branches:
-    - release-1.8
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-cloudflare-credentials: "true"
-      preset-retry-flakey-tests: "true"
-      preset-enable-all-feature-gates: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-default-e2e-volumes: "true"
-      preset-make-volumes: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.19
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-
-# Run with Bazel for release-1.7 where make was not available
   - name: pull-cert-manager-e2e-v1-20
     always_run: false
     optional: true
@@ -265,6 +222,7 @@ presubmits:
     decorate: true
     branches:
     - release-1.7
+    - release-1.8
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -272,7 +230,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
       preset-retry-flakey-tests: "true"
-      preset-enable-all-feature-gates: "true"
+      preset-enable-all-feature-gates-disable-ssa: "true"
       preset-ginkgo-skip-default: "true"
       preset-default-e2e-volumes: "true"
     spec:
@@ -297,49 +255,6 @@ presubmits:
         - name: ndots
           value: "1"
 
-  - name: pull-cert-manager-e2e-v1-20
-    always_run: false
-    optional: true
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    branches:
-    - release-1.8
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-cloudflare-credentials: "true"
-      preset-retry-flakey-tests: "true"
-      preset-enable-all-feature-gates: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-default-e2e-volumes: "true"
-      preset-make-volumes: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.19
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-
-# Run with Bazel for release-1.7 where make was not available yet
   - name: pull-cert-manager-e2e-v1-21
     always_run: false
     optional: true
@@ -348,6 +263,7 @@ presubmits:
     decorate: true
     branches:
     - release-1.7
+    - release-1.8
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -355,7 +271,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
       preset-cloudflare-credentials: "true"
       preset-retry-flakey-tests: "true"
-      preset-enable-all-feature-gates: "true"
+      preset-enable-all-feature-gates-disable-ssa: "true"
       preset-ginkgo-skip-default: "true"
       preset-default-e2e-volumes: "true"
     spec:
@@ -380,49 +296,6 @@ presubmits:
         - name: ndots
           value: "1"
 
-  - name: pull-cert-manager-e2e-v1-21
-    always_run: false
-    optional: true
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    branches:
-    - release-1.8
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-cloudflare-credentials: "true"
-      preset-retry-flakey-tests: "true"
-      preset-enable-all-feature-gates: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-make-volumes: "true"
-      preset-default-e2e-volumes: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.21
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-
-# Run with Bazel for release-1.7 where make was not available yet
   - name: pull-cert-manager-e2e-v1-22
     always_run: false
     optional: true
@@ -431,6 +304,7 @@ presubmits:
     decorate: true
     branches:
     - release-1.7
+    - release-1.8
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -463,49 +337,6 @@ presubmits:
         - name: ndots
           value: "1"
 
-  - name: pull-cert-manager-e2e-v1-22
-    always_run: false
-    optional: true
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    branches:
-    - release-1.8
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-cloudflare-credentials: "true"
-      preset-retry-flakey-tests: "true"
-      preset-enable-all-feature-gates: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-default-e2e-volumes: "true"
-      preset-make-volumes: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.22
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-
-# Run with Bazel for release-1.7 where make was not available yet
   - name: pull-cert-manager-e2e-v1-23
     always_run: true
     optional: false
@@ -514,6 +345,7 @@ presubmits:
     decorate: true
     branches:
     - release-1.7
+    - release-1.8
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -537,46 +369,6 @@ presubmits:
         env:
         - name: K8S_VERSION
           value: "1.23"
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-
-  - name: pull-cert-manager-e2e-v1-23
-    always_run: true
-    optional: false
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    branches:
-    - release-1.8
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-cloudflare-credentials: "true"
-      preset-retry-flakey-tests: "true"
-      preset-enable-all-feature-gates: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-default-e2e-volumes: "true"
-      preset-make-volumes: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.23
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
         securityContext:
           privileged: true
           capabilities:
@@ -667,7 +459,6 @@ presubmits:
 
 ### E2E tests against all supported Kubernetes versions with all cert-manager alpha/beta feature gates disabled ###
 
-# Run with Bazel against release-1.7 where make was not available yet
   - name: pull-cert-manager-e2e-feature-gates-disabled-24
     always_run: false
     optional: true
@@ -750,7 +541,6 @@ presubmits:
         - name: ndots
           value: "1"
 
-# Run with Bazel against release-1.7 where make was not available yet
   - name: pull-cert-manager-e2e-feature-gates-disabled-23
     always_run: false
     optional: true
@@ -759,6 +549,7 @@ presubmits:
     decorate: true
     branches:
     - release-1.7
+    - release-1.8
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -791,49 +582,6 @@ presubmits:
         - name: ndots
           value: "1"
 
-  - name: pull-cert-manager-e2e-feature-gates-disabled-23
-    always_run: false
-    optional: true
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    branches:
-    - release-1.8
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-disable-all-alpha-beta-feature-gates: "true"
-      preset-cloudflare-credentials: "true"
-      preset-retry-flakey-tests: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-make-volumes: "true"
-      preset-default-e2e-volumes: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.23
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-
-# Run with Bazel for release-1.7 where make was not available yet
   - name: pull-cert-manager-e2e-feature-gates-disabled-22
     always_run: false
     optional: true
@@ -842,6 +590,7 @@ presubmits:
     decorate: true
     branches:
     - release-1.7
+    - release-1.8
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -874,49 +623,6 @@ presubmits:
         - name: ndots
           value: "1"
 
-  - name: pull-cert-manager-e2e-feature-gates-disabled-22
-    always_run: false
-    optional: true
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    branches:
-    - release-1.8
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-disable-all-alpha-beta-feature-gates: "true"
-      preset-cloudflare-credentials: "true"
-      preset-retry-flakey-tests: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-default-e2e-volumes: "true"
-      preset-make-volumes: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.22
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-
-# Run with Bazel against release-1.7 where make was not available yet
   - name: pull-cert-manager-e2e-feature-gates-disabled-21
     always_run: false
     optional: true
@@ -925,6 +631,7 @@ presubmits:
     decorate: true
     branches:
     - release-1.7
+    - release-1.8
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -957,49 +664,6 @@ presubmits:
         - name: ndots
           value: "1"
 
-  - name: pull-cert-manager-e2e-feature-gates-disabled-21
-    always_run: false
-    optional: true
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    branches:
-    - release-1.8
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-disable-all-alpha-beta-feature-gates: "true"
-      preset-cloudflare-credentials: "true"
-      preset-retry-flakey-tests: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-default-e2e-volumes: "true"
-      preset-make-volumes: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.21
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-
-# Run with Bazel on release-1.7 where make was not available yet
   - name: pull-cert-manager-e2e-feature-gates-disabled-20
     always_run: false
     optional: true
@@ -1008,6 +672,7 @@ presubmits:
     decorate: true
     branches:
     - release-1.7
+    - release-1.8
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -1040,49 +705,6 @@ presubmits:
         - name: ndots
           value: "1"
 
-  - name: pull-cert-manager-e2e-feature-gates-disabled-20
-    always_run: false
-    optional: true
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    branches:
-    - release-1.8
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-disable-all-alpha-beta-feature-gates: "true"
-      preset-cloudflare-credentials: "true"
-      preset-retry-flakey-tests: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-default-e2e-volumes: "true"
-      preset-make-volumes: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.20
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-
-# Run with Bazel for release-1.7 where make was not yet available
   - name: pull-cert-manager-e2e-feature-gates-disabled-19
     always_run: false
     optional: true
@@ -1091,6 +713,7 @@ presubmits:
     decorate: true
     branches:
     - release-1.7
+    - release-1.8
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -1114,48 +737,6 @@ presubmits:
         env:
         - name: K8S_VERSION
           value: "1.19"
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-
-  - name: pull-cert-manager-e2e-feature-gates-disabled-19
-    always_run: false
-    optional: true
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    branches:
-    - release-1.8
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-disable-all-alpha-beta-feature-gates: "true"
-      preset-cloudflare-credentials: "true"
-      preset-retry-flakey-tests: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-default-e2e-volumes: "true"
-      preset-make-volumes: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.19
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
         securityContext:
           privileged: true
           capabilities:


### PR DESCRIPTION
This PR : 

- Fixes 'previous' presubmits for Kubernetes 1.19 - 1.21 by ensuring that the SSA feature gate that only works with Kubernetes 1.22+ is not enabled
- Makes 'previous' presubmits run with Bazel again to match the 'previous' periodics, see the discussion here https://github.com/jetstack/testing/pull/694