### PR TITLE
Don't run unit/integration tests with bazel where we use make

### DIFF
--- a/config/jobs/cert-manager/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager/cert-manager-periodics.yaml
@@ -1,7 +1,6 @@
 periodics:
 
-# We can't remove this job in favor of "make" because "bazel test" runs the
-# scripts in ./hack/verify-crds.sh that have not been ported to "make" yet.
+# The bazel test has only a couple of older tests which haven't been ported to make yet
 - name: ci-cert-manager-bazel
   interval: 2h
   agent: kubernetes
@@ -17,7 +16,7 @@ periodics:
   annotations:
     testgrid-create-test-group: 'true'
     testgrid-dashboards: jetstack-cert-manager-master
-    description: Runs 'bazel test --jobs=1 //...'
+    description: Runs some older bazel-only tests
   spec:
     containers:
     - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -26,11 +25,11 @@ periodics:
       - bazel
       - test
       - --jobs=1
-      - //...
+      - //hack/...
       resources:
         requests:
-          cpu: 2
-          memory: 4Gi
+          cpu: 1
+          memory: 2Gi
     dnsConfig:
       options:
         - name: ndots

--- a/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
@@ -25,11 +25,11 @@ periodics:
       - bazel
       - test
       - --jobs=1
-      - //...
+      - //hack/...
       resources:
         requests:
-          cpu: 2
-          memory: 4Gi
+          cpu: 1
+          memory: 2Gi
     dnsConfig:
       options:
         - name: ndots

--- a/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
@@ -1,15 +1,13 @@
 presubmits:
   cert-manager/cert-manager:
 
-  - name: pull-cert-manager-bazel
+  - name: pull-cert-manager-bazel-1.7
     always_run: true
     max_concurrency: 8
     agent: kubernetes
     decorate: true
     branches:
-    # release-1.8 is tested via make, but there were still some leftover tests which were bazel-only
-    # as of the release of 1.8, so we need to run bazel test for 1.8 too.
-    - release-1.8
+    # release-1.7 was released + built with bazel so we need to run all tests using bazel
     - release-1.7
     labels:
       preset-service-account: "true"
@@ -28,6 +26,39 @@ presubmits:
           requests:
             cpu: 2
             memory: 4Gi
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+
+  - name: pull-cert-manager-bazel-1.8
+    always_run: true
+    max_concurrency: 8
+    agent: kubernetes
+    decorate: true
+    branches:
+    # release-1.8 is tested via make, but there were still some leftover tests which were bazel-only
+    # as of the release of 1.8, so we need to run bazel test for 1.8 too.
+    # Still, the unit and integration tests _are_ running in make so we only need to run a subset of tests
+    # here
+    - release-1.8
+    labels:
+      preset-service-account: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+        args:
+        - runner
+        - bazel
+        - test
+        - --jobs=1
+        - //hack/...
+        resources:
+          requests:
+            cpu: 1
+            memory: 2Gi
       dnsConfig:
         options:
           - name: ndots
@@ -520,7 +551,7 @@ presubmits:
       preset-make-volumes: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1 
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
         args:
         - runner
         - make


### PR DESCRIPTION
I think we could've made this change a while ago and saved some build time :sweat_smile: 

We run unit and integration tests with make for release-1.8 and master. We don't need to also run them with bazel.

We'll be able to remove the bazel tests entirely when all of our tests are available in make, which shouldn't take long. Still, we can take this win now!