### PR TITLE
Remove bazel + verify_deps presubmits

### DIFF
--- a/config/jobs/cert-manager/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager/cert-manager-periodics.yaml
@@ -1,40 +1,5 @@
 periodics:
 
-# The bazel test has only a couple of older tests which haven't been ported to make yet
-- name: ci-cert-manager-bazel
-  interval: 2h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: master
-  labels:
-    preset-service-account: "true"
-    preset-bazel-remote-cache-enabled: "true"
-    preset-bazel-scratch-dir: "true"
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-master
-    description: Runs some older bazel-only tests
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-      args:
-      - runner
-      - bazel
-      - test
-      - --jobs=1
-      - //hack/...
-      resources:
-        requests:
-          cpu: 1
-          memory: 2Gi
-    dnsConfig:
-      options:
-        - name: ndots
-          value: "1"
-
 - name: ci-cert-manager-make-test
   interval: 2h
   agent: kubernetes

--- a/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
@@ -112,37 +112,6 @@ presubmits:
           - name: ndots
             value: "1"
 
-  - name: pull-cert-manager-deps
-    always_run: true
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    branches:
-    - master
-    annotations:
-      testgrid-create-test-group: 'true'
-      testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
-      description: Verifies dependency related files are up to date
-    labels:
-      preset-service-account: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - verify_deps
-        resources:
-          requests:
-            cpu: 2
-            memory: 4Gi
-      dnsConfig:
-        options:
-          - name: ndots
-            value: "1"
-
   - name: pull-cert-manager-e2e-v1-20
     always_run: false
     optional: true


### PR DESCRIPTION
All of this functionality is now implemented in make or else is redundant in a world where we no longer use bazel for any tests which aren't directly related to bazel