### PR TITLE
Bump base

### DIFF
--- a/images/bazelbuild/Dockerfile
+++ b/images/bazelbuild/Dockerfile
@@ -15,7 +15,7 @@
 # Includes bazel, docker-in-docker and gcloud
 ARG DEBIAN_VERSION
 FROM debian:"${DEBIAN_VERSION}"
-LABEL maintainer="james@jetstack.io"
+LABEL maintainer="cert-manager-maintainers@googlegroups.com"
 
 #
 # BEGIN: DOCKER IN DOCKER SETUP

--- a/images/bazelbuild/Dockerfile
+++ b/images/bazelbuild/Dockerfile
@@ -81,7 +81,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     zlib1g-dev \
     unzip \
     python \
-    python-pip \
+    python3-pip \
     wget \
     ca-certificates \
     git \
@@ -93,7 +93,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     moreutils \
     jq \
     && apt-get clean \
-    && python -m pip install --upgrade pip setuptools wheel
+    && python3 -m pip install --upgrade pip setuptools wheel
 
 ARG BAZEL_VERSION
 ARG BAZEL_CHANNEL=release

--- a/images/bazelbuild/Dockerfile
+++ b/images/bazelbuild/Dockerfile
@@ -33,11 +33,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     lsb-release
 
 # Add the Docker apt-repository
-RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg \
-    | apt-key add - && \
-    add-apt-repository \
-    "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") \
-    $(lsb_release -cs) stable"
+RUN mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
+    echo \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
+    $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
 
 # Install Docker
 # TODO(bentheelder): the `sed` is a bit of a hack, look into alternatives.

--- a/images/bazelbuild/Dockerfile
+++ b/images/bazelbuild/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Includes bazel, docker-in-docker and gcloud
-ARG DEBIAN_VERSION=buster
+ARG DEBIAN_VERSION
 FROM debian:"${DEBIAN_VERSION}"
 LABEL maintainer="james@jetstack.io"
 
@@ -45,9 +45,7 @@ RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID"
 # We're already inside docker though so we can be sure these are already mounted.
 # Trying to remount these makes for a very noisy error block in the beginning of
 # the pod logs, so we just comment out the call to it... :shrug:
-# TODO(benthelder): update docker version. This is pinned because of
-# https://github.com/kubernetes/test-infra/issues/6187
-ARG DOCKER_VERSION="17.09.1~ce-0~debian"
+ARG DOCKER_VERSION
 RUN apt-get update && \
     apt-get install -y --no-install-recommends docker-ce="${DOCKER_VERSION}" && \
     sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker \

--- a/images/bazelbuild/build.yaml
+++ b/images/bazelbuild/build.yaml
@@ -13,7 +13,7 @@ variants:
     arguments:
       BAZEL_VERSION: "4.2.1"
       DEBIAN_VERSION: bullseye
-      DOCKER_VERSION: 5:19.03.3~3-0~debian-buster
+      DOCKER_VERSION: 5:20.10.17~3-0~debian-bullseye
 
   "3.5.0":
     # Specify build arguments for this variant

--- a/images/bazelbuild/build.yaml
+++ b/images/bazelbuild/build.yaml
@@ -12,7 +12,7 @@ variants:
   "4.2.1":
     arguments:
       BAZEL_VERSION: "4.2.1"
-      DEBIAN_VERSION: buster
+      DEBIAN_VERSION: bullseye
       DOCKER_VERSION: 5:19.03.3~3-0~debian-buster
 
   "3.5.0":


### PR DESCRIPTION
This PR bumps a couple versions in the Bazel base image:

- bumps Debian `buster` -> `bullseye`
- bumps Docker `5:19.03.3~3-0~debian-buster` -> `5:20.10.17\~3-0\~debian-bullseye`
- bumps Python 2 -> 3 (needed because bullseye seemed to not have package for Python2)

To test this:
1. `docker build  --load -t foo:v0.0.1 --build-arg BAZEL_VERSION="4.2.1" --build-arg DEBIAN_VERSION=bullseye --build-arg DOCKER_VERSION=5:20.10.17~3-0~debian-bullseye ./images/bazelbuild`
2. `docker run -it foo:v0.0.1 bash`
3. check that all the versions are as expected etc

In future I think we will remove Bazel from this image alltogether so perhaps this newer image version will actually never be used in our tests- but I am bumping now as we have some other projects that use this image and need newer versions of `git` etc