### PR TITLE
Bump golang dind

### DIFF
--- a/images/golang-dind/Dockerfile
+++ b/images/golang-dind/Dockerfile
@@ -15,7 +15,8 @@
 # Includes golang, docker-in-docker and gcloud
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
-LABEL maintainer="joshua.vanleeuwen@jetstack.io"
+LABEL maintainer="cert-manager-maintainers@googlegroups.com"
+
 
 # install golang
 ARG GO_VERSION

--- a/images/golang-dind/build.yaml
+++ b/images/golang-dind/build.yaml
@@ -3,28 +3,16 @@ name: golang-dind # Name of the image to be built
 variants:
   "1.18":
     arguments:
-      BASE_IMAGE: "eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1"
-      GO_VERSION: "1.18.1"
+      BASE_IMAGE: "eu.gcr.io/jetstack-build-infra-images/bazelbuild@sha256:4757d0b78814ccc138561b9e2b57c3b84d2b339d2d3c5c796e5520f3cd298aa4"
+      GO_VERSION: "1.18.3"
   "1.17":
     arguments:
-      BASE_IMAGE: "eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1"
-      GO_VERSION: "1.17.7"
-  "1.16.6":
+      BASE_IMAGE: "eu.gcr.io/jetstack-build-infra-images/bazelbuild@sha256:4757d0b78814ccc138561b9e2b57c3b84d2b339d2d3c5c796e5520f3cd298aa4"
+      GO_VERSION: "1.17.11"
+  "1.16":
     arguments:
-      BASE_IMAGE: "eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210331-363c37a-3.5.0"
-      GO_VERSION: "1.16.6"
-  "1.15.7":
-    arguments:
-      BASE_IMAGE: "eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210331-363c37a-3.5.0"
-      GO_VERSION: "1.15.7"
-  "1.14.2":
-    arguments:
-      BASE_IMAGE: "eu.gcr.io/jetstack-build-infra-images/bazelbuild:20200428-6b034c1-2.2.0"
-      GO_VERSION: "1.14.2"
-  "1.13.4":
-    arguments:
-      BASE_IMAGE: "eu.gcr.io/jetstack-build-infra-images/bazelbuild:20191016-eff358a-1.0.0"
-      GO_VERSION: "1.13.4"
+      BASE_IMAGE: "eu.gcr.io/jetstack-build-infra-images/bazelbuild@sha256:4757d0b78814ccc138561b9e2b57c3b84d2b339d2d3c5c796e5520f3cd298aa4"
+      GO_VERSION: "1.16.15"
 
 # Image names to be tagged and pushed
 images:


### PR DESCRIPTION
This PR:
- bumps Go versions for the various tags of `golang-dind` image we build
- bumps base image to one with a newer version of Debian and Docker
- removes some older Go versions as we shouldn't need those anymore

We should eventually automate this process so that when a newer base or other dependencies become available, there are automated PRs to update all the various images that use those dependencies. But perhaps we should first remove Bazel from the base image and see what the flow looks like then