### PR TITLE
Bumps a bunch of versions for bazel-tools image

### DIFF
--- a/images/bazel-tools/Dockerfile
+++ b/images/bazel-tools/Dockerfile
@@ -27,12 +27,11 @@ RUN go install github.com/cert-manager/goversion@v1.3.0 && \
     go install github.com/google/go-containerregistry/cmd/gcrane@v0.9.0 && \
     apt-get update && \
     apt-get install -y \
-    jq=1.5+dfsg-2+b1 \
     nodejs=${NODE_VERSION} && \
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
     apt update && \
-    apt install gh=2.12.1
+    apt install gh=2.13.0
 
 # Add GOPATH/bin to PATH
 ENV PATH=/root/go/bin:$PATH

--- a/images/bazel-tools/build.yaml
+++ b/images/bazel-tools/build.yaml
@@ -3,16 +3,16 @@ name: bazel-tools # Name of the image to be built
 variants:
   "10.24":
     arguments:
-      BASE_IMAGE: "eu.gcr.io/jetstack-build-infra-images/bazelbuild@sha256:4757d0b78814ccc138561b9e2b57c3b84d2b339d2d3c5c796e5520f3cd298aa4"
+      BASE_IMAGE: "eu.gcr.io/jetstack-build-infra-images/golang-dind@sha256:5f966580a1f9700b03fa2072f65c91ee0711d314163bef13f06f75fd196e92cb"
       # Version of Bazel that is bundled in the BASE_IMAGE
       BAZEL_VERSION: "4.2.1"
       # Version of Go that is bundled in the BASE_IMAGE
-      GO_VERSION: "1.17"
-      NODE_VERSION: "10.24.0~dfsg-1~deb10u1"
+      GO_VERSION: "1.18"
+      NODE_VERSION: "12.22.12~dfsg-1~deb11u1"
       # This NODE_DOCKER_TAG is the Docker tag that corresponds to the Node version
       # we use. We don't use the Node version directly because it is not a valid
       # Docker tag.
-      NODE_DOCKER_TAG: "10.24.0"
+      NODE_DOCKER_TAG: "12.22.0"
 
 # Image names to be tagged and pushed
 images:


### PR DESCRIPTION
This PR:
- ensures that bazel-tools image is built from a base that has Go
- removes installation of jq that is already in base
- bumps a bunch of versions

To test it run `docker build --load -t foo:v0.0.2 --build-arg NODE_VERSION=12.22.12~dfsg-1~deb11u1 --build-arg BASE_IMAGE=eu.gcr.io/jetstack-build-infra-images/golang-dind@sha256:5f966580a1f9700b03fa2072f65c91ee0711d314163bef13f06f75fd196e92cb images/bazel-tools/` and test that `foo:v0.0.2` image has the right versions of tools


Signed-off-by: irbekrm <irbekrm@gmail.com>