### PR TITLE
Removes pull-cert-manager-deps test from required tests

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -36,7 +36,6 @@ branch-protection:
         cert-manager:
           required_status_checks:
             contexts:
-            - pull-cert-manager-deps
             - pull-cert-manager-chart
             - pull-cert-manager-e2e-v1-24
             - pull-cert-manager-make-test


### PR DESCRIPTION
As this test is now removed from presubmits

Signed-off-by: irbekrm <irbekrm@gmail.com>