### PR TITLE
Sort keys in all test specs

### DIFF
--- a/config/jobs/cert-manager/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager/cert-manager-periodics.yaml
@@ -1,614 +1,611 @@
 periodics:
-
-- name: ci-cert-manager-make-test
-  interval: 2h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: master
-  labels:
-    preset-service-account: "true"
-    preset-make-volumes: "true"
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-master
-    description: Runs unit and integration tests and verification scripts
-  spec:
-    containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-          - runner
-          - make
-          - -j
-          - vendor-go
-          - ci-presubmit
-          - test-ci
-        resources:
-          requests:
-            cpu: 2
-            memory: 4Gi
-    dnsConfig:
-      options:
-        - name: ndots
-          value: "1"
-
-- name: ci-cert-manager-e2e-v1-20
-  interval: 2h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: master
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-master
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs the end-to-end test suite against a Kubernetes v1.20 cluster
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-cloudflare-credentials: "true"
-    preset-enable-all-feature-gates-disable-ssa: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-make-volumes: "true"
-    preset-default-e2e-volumes: "true"
-  spec:
-    containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.20
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-    dnsConfig:
-      options:
-        - name: ndots
-          value: "1"
-
-- name: ci-cert-manager-e2e-v1-21
-  interval: 2h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: master
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-master
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs the end-to-end test suite against a Kubernetes v1.21 cluster
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-cloudflare-credentials: "true"
-    preset-enable-all-feature-gates-disable-ssa: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-make-volumes: "true"
-    preset-default-e2e-volumes: "true"
-  spec:
-    containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.21
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-    dnsConfig:
-      options:
-        - name: ndots
-          value: "1"
-
-- name: ci-cert-manager-e2e-v1-22
-  interval: 2h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: master
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-master
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs the end-to-end test suite against a Kubernetes v1.22 cluster
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-cloudflare-credentials: "true"
-    preset-enable-all-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-make-volumes: "true"
-    preset-default-e2e-volumes: "true"
-  spec:
-    containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.22
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-    dnsConfig:
-      options:
-        - name: ndots
-          value: "1"
-
-- name: ci-cert-manager-e2e-v1-23
-  interval: 2h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: master
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-master
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs the end-to-end test suite against a Kubernetes v1.23 cluster
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-cloudflare-credentials: "true"
-    preset-enable-all-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-make-volumes: "true"
-    preset-default-e2e-volumes: "true"
-  spec:
-    containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.23
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-    dnsConfig:
-      options:
-        - name: ndots
-          value: "1"
-
-- name: ci-cert-manager-e2e-v1-24
-  interval: 2h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: master
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-master
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs the end-to-end test suite against a Kubernetes v1.24 cluster
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-cloudflare-credentials: "true"
-    preset-enable-all-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-make-volumes: "true"
-    preset-default-e2e-volumes: "true"
-  spec:
-    containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.24
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-    dnsConfig:
-      options:
-        - name: ndots
-          value: "1"
-
-
-# This test runs Venafi (VaaS and TPP) tests once every 12hrs.
-# This is the only CI test job that runs those.
-- name: ci-cert-manager-venafi
-  interval: 12h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: master
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-master
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs Venafi (VaaS and TPP) e2e tests against Kubernetes v1.24 cluster
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-venafi-cloud-credentials: "true"
-    preset-venafi-tpp-credentials: "true"
-    preset-ginkgo-focus-venafi: "true"
-    preset-make-volumes: "true"
-    preset-default-e2e-volumes: "true"
-  spec:
-    containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.24
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-    dnsConfig:
-      options:
-        - name: ndots
-          value: "1"
-
-- name: ci-cert-manager-upgrade
-  interval: 8h
-  agent: kubernetes
-  decorate: true
-  # extra refs specify what repo should be cloned
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: master
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-master
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs cert-manager upgrade test every 8 hours
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-default-e2e-volumes: "true"
-    preset-make-volumes: "true"
-  spec:
-    containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-          - runner
-          - make
-          - K8S_VERSION=1.24
-          - vendor-go
-          - test-upgrade
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-    dnsConfig:
-      options:
-        - name: ndots
-          value: "1"
-
-# TODO: find a permanent home for the AWS periodics and reinstate this job
-# - name: aws-tests
-#   interval: 48h
-#   agent: kubernetes
-#   decorate: true
-#   extra_refs:            # Periodic job doesn't clone any repo by default, needs to be added explicitly
-#     - org: cert-manager
-#       repo: test-infra
-#       base_ref: main
-#     - org: cert-manager
-#       repo: cert-manager
-#       base_ref: master
-#   annotations:
-#     testgrid-create-test-group: 'true'
-#     testgrid-dashboards: jetstack-cert-manager-master
-#     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-#     description: Runs the end-to-end test suite against a EKS cluster
-#   labels:
-#     preset-service-account: "true"
-#     preset-dind-enabled: "true"
-#     preset-bazel-remote-cache-enabled: "true"
-#     preset-bazel-scratch-dir: "true"
-#     preset-aws-credentials: "true"
-#     preset-ginkgo-focus-http01-ingress: "true"
-#   spec:
-#     containers:
-#     - image: eu.gcr.io/jetstack-build-infra-images/golang-aws@sha256:1f330e4c9552ca383d157067b73fb0e090b64b0777939fd59e58b60e06020d66
-#       args:
-#       - bash
-#       - -c
-#       - |
-#         set -euo && \
-#         ls && \
-#         pwd && \
-#         cd /home/prow/go/src/github.com/cert-manager/test-infra/aws && \
-#         terraform init && \
-#         trap 'terraform destroy -auto-approve' ERR && \
-#         terraform apply -auto-approve && \
-#         ls && \
-#         pwd && \
-#         cd /home && \
-#         ls && \
-#         cd /home/prow/go/src/github.com/cert-manager/cert-manager && \
-#         ./devel/run-e2e.sh --acme-server-url=https://acme-staging-v02.api.letsencrypt.org/directory --ingress-controller-domain=aws.e2e-tests.cert-manager.io --testing-acme-email=cert-manager-dev-alerts@googlegroups.com --kubernetes-config=/home/prow/go/src/github.com/cert-manager/test-infra/aws/kubeconfig_cert-manager-cluster || true && \
-#         cd /home/prow/go/src/github.com/cert-manager/test-infra/aws && \
-#         terraform destroy -auto-approve;
-#       resources:
-#         requests:
-#           cpu: 3500m
-#           memory: 12Gi
-
-- name: ci-cert-manager-e2e-feature-gates-disabled-v1-20
-  interval: 24h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: master
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-master
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs the end-to-end test suite against a Kubernetes v1.20 cluster with all feature gates disabled
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-cloudflare-credentials: "true"
-    preset-disable-all-alpha-beta-feature-gates: "true"
-    preset-retry-flakey-tests: "true"
-    preset-default-e2e-volumes: "true"
-    preset-make-volumes: "true"
-  spec:
-    containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.20
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-    dnsConfig:
-      options:
-        - name: ndots
-          value: "1"
-
-- name: ci-cert-manager-e2e-feature-gates-disabled-v1-21
-  interval: 24h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: master
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-master
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs the end-to-end test suite against a Kubernetes v1.21 cluster with all feature gates disabled
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-cloudflare-credentials: "true"
-    preset-disable-all-alpha-beta-feature-gates: "true"
-    preset-retry-flakey-tests: "true"
-    preset-default-e2e-volumes: "true"
-    preset-make-volumes: "true"
-  spec:
-    containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.21
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-    dnsConfig:
-      options:
-        - name: ndots
-          value: "1"
-
-- name: ci-cert-manager-e2e-feature-gates-disabled-v1-22
-  interval: 24h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: master
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-master
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs the end-to-end test suite against a Kubernetes v1.22 cluster with all feature gates disabled
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-cloudflare-credentials: "true"
-    preset-disable-all-alpha-beta-feature-gates: "true"
-    preset-retry-flakey-tests: "true"
-    preset-default-e2e-volumes: "true"
-    preset-make-volumes: "true"
-  spec:
-    containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.22
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-    dnsConfig:
-      options:
-        - name: ndots
-          value: "1"
-
-- name: ci-cert-manager-e2e-feature-gates-disabled-v1-23
-  interval: 24h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: master
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-master
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs the end-to-end test suite against a Kubernetes v1.23 cluster with all feature gates disabled
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-cloudflare-credentials: "true"
-    preset-disable-all-alpha-beta-feature-gates: "true"
-    preset-retry-flakey-tests: "true"
-    preset-default-e2e-volumes: "true"
-    preset-make-volumes: "true"
-  spec:
-    containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.23
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-    dnsConfig:
-      options:
-        - name: ndots
-          value: "1"
-
-- name: ci-cert-manager-e2e-feature-gates-disabled-v1-24
-  interval: 24h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: master
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-master
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs the end-to-end test suite against a Kubernetes v1.24 cluster with all feature gates disabled
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-cloudflare-credentials: "true"
-    preset-disable-all-alpha-beta-feature-gates: "true"
-    preset-retry-flakey-tests: "true"
-    preset-default-e2e-volumes: "true"
-    preset-make-volumes: "true"
-  spec:
-    containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.24
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-    dnsConfig:
-      options:
-        - name: ndots
-          value: "1"
+  - agent: kubernetes
+    annotations:
+      description: Runs unit and integration tests and verification scripts
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-master
+    decorate: true
+    extra_refs:
+      - base_ref: master
+        org: cert-manager
+        repo: cert-manager
+    interval: 2h
+    labels:
+      preset-make-volumes: "true"
+      preset-service-account: "true"
+    name: ci-cert-manager-make-test
+    spec:
+      containers:
+        - args:
+            - runner
+            - make
+            - -j
+            - vendor-go
+            - ci-presubmit
+            - test-ci
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+          resources:
+            requests:
+              cpu: 2
+              memory: 4Gi
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+  - agent: kubernetes
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.20 cluster
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-master
+    decorate: true
+    extra_refs:
+      - base_ref: master
+        org: cert-manager
+        repo: cert-manager
+    interval: 2h
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-default-e2e-volumes: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates-disable-ssa: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-make-volumes: "true"
+      preset-service-account: "true"
+    name: ci-cert-manager-e2e-v1-20
+    spec:
+      containers:
+        - args:
+            - runner
+            - make
+            - -j
+            - vendor-go
+            - e2e-ci
+            - K8S_VERSION=1.20
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+  - agent: kubernetes
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.21 cluster
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-master
+    decorate: true
+    extra_refs:
+      - base_ref: master
+        org: cert-manager
+        repo: cert-manager
+    interval: 2h
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-default-e2e-volumes: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates-disable-ssa: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-make-volumes: "true"
+      preset-service-account: "true"
+    name: ci-cert-manager-e2e-v1-21
+    spec:
+      containers:
+        - args:
+            - runner
+            - make
+            - -j
+            - vendor-go
+            - e2e-ci
+            - K8S_VERSION=1.21
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+  - agent: kubernetes
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.22 cluster
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-master
+    decorate: true
+    extra_refs:
+      - base_ref: master
+        org: cert-manager
+        repo: cert-manager
+    interval: 2h
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-default-e2e-volumes: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-make-volumes: "true"
+      preset-service-account: "true"
+    name: ci-cert-manager-e2e-v1-22
+    spec:
+      containers:
+        - args:
+            - runner
+            - make
+            - -j
+            - vendor-go
+            - e2e-ci
+            - K8S_VERSION=1.22
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+  - agent: kubernetes
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.23 cluster
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-master
+    decorate: true
+    extra_refs:
+      - base_ref: master
+        org: cert-manager
+        repo: cert-manager
+    interval: 2h
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-default-e2e-volumes: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-make-volumes: "true"
+      preset-service-account: "true"
+    name: ci-cert-manager-e2e-v1-23
+    spec:
+      containers:
+        - args:
+            - runner
+            - make
+            - -j
+            - vendor-go
+            - e2e-ci
+            - K8S_VERSION=1.23
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+  - agent: kubernetes
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.24 cluster
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-master
+    decorate: true
+    extra_refs:
+      - base_ref: master
+        org: cert-manager
+        repo: cert-manager
+    interval: 2h
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-default-e2e-volumes: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-make-volumes: "true"
+      preset-service-account: "true"
+    name: ci-cert-manager-e2e-v1-24
+    spec:
+      containers:
+        - args:
+            - runner
+            - make
+            - -j
+            - vendor-go
+            - e2e-ci
+            - K8S_VERSION=1.24
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+  # This test runs Venafi (VaaS and TPP) tests once every 12hrs.
+  # This is the only CI test job that runs those.
+  - agent: kubernetes
+    annotations:
+      description: Runs Venafi (VaaS and TPP) e2e tests against Kubernetes v1.24 cluster
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-master
+    decorate: true
+    extra_refs:
+      - base_ref: master
+        org: cert-manager
+        repo: cert-manager
+    interval: 12h
+    labels:
+      preset-default-e2e-volumes: "true"
+      preset-dind-enabled: "true"
+      preset-ginkgo-focus-venafi: "true"
+      preset-make-volumes: "true"
+      preset-service-account: "true"
+      preset-venafi-cloud-credentials: "true"
+      preset-venafi-tpp-credentials: "true"
+    name: ci-cert-manager-venafi
+    spec:
+      containers:
+        - args:
+            - runner
+            - make
+            - -j
+            - vendor-go
+            - e2e-ci
+            - K8S_VERSION=1.24
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+  - agent: kubernetes
+    annotations:
+      description: Runs cert-manager upgrade test every 8 hours
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-master
+    decorate: true
+    # extra refs specify what repo should be cloned
+    extra_refs:
+      - base_ref: master
+        org: cert-manager
+        repo: cert-manager
+    interval: 8h
+    labels:
+      preset-default-e2e-volumes: "true"
+      preset-dind-enabled: "true"
+      preset-make-volumes: "true"
+      preset-service-account: "true"
+    name: ci-cert-manager-upgrade
+    spec:
+      containers:
+        - args:
+            - runner
+            - make
+            - K8S_VERSION=1.24
+            - vendor-go
+            - test-upgrade
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+  # TODO: find a permanent home for the AWS periodics and reinstate this job
+  # - name: aws-tests
+  #   interval: 48h
+  #   agent: kubernetes
+  #   decorate: true
+  #   extra_refs:            # Periodic job doesn't clone any repo by default, needs to be added explicitly
+  #     - org: cert-manager
+  #       repo: test-infra
+  #       base_ref: main
+  #     - org: cert-manager
+  #       repo: cert-manager
+  #       base_ref: master
+  #   annotations:
+  #     testgrid-create-test-group: 'true'
+  #     testgrid-dashboards: jetstack-cert-manager-master
+  #     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+  #     description: Runs the end-to-end test suite against a EKS cluster
+  #   labels:
+  #     preset-service-account: "true"
+  #     preset-dind-enabled: "true"
+  #     preset-bazel-remote-cache-enabled: "true"
+  #     preset-bazel-scratch-dir: "true"
+  #     preset-aws-credentials: "true"
+  #     preset-ginkgo-focus-http01-ingress: "true"
+  #   spec:
+  #     containers:
+  #     - image: eu.gcr.io/jetstack-build-infra-images/golang-aws@sha256:1f330e4c9552ca383d157067b73fb0e090b64b0777939fd59e58b60e06020d66
+  #       args:
+  #       - bash
+  #       - -c
+  #       - |
+  #         set -euo && \
+  #         ls && \
+  #         pwd && \
+  #         cd /home/prow/go/src/github.com/cert-manager/test-infra/aws && \
+  #         terraform init && \
+  #         trap 'terraform destroy -auto-approve' ERR && \
+  #         terraform apply -auto-approve && \
+  #         ls && \
+  #         pwd && \
+  #         cd /home && \
+  #         ls && \
+  #         cd /home/prow/go/src/github.com/cert-manager/cert-manager && \
+  #         ./devel/run-e2e.sh --acme-server-url=https://acme-staging-v02.api.letsencrypt.org/directory --ingress-controller-domain=aws.e2e-tests.cert-manager.io --testing-acme-email=cert-manager-dev-alerts@googlegroups.com --kubernetes-config=/home/prow/go/src/github.com/cert-manager/test-infra/aws/kubeconfig_cert-manager-cluster || true && \
+  #         cd /home/prow/go/src/github.com/cert-manager/test-infra/aws && \
+  #         terraform destroy -auto-approve;
+  #       resources:
+  #         requests:
+  #           cpu: 3500m
+  #           memory: 12Gi
+  - agent: kubernetes
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.20 cluster with all feature gates disabled
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-master
+    decorate: true
+    extra_refs:
+      - base_ref: master
+        org: cert-manager
+        repo: cert-manager
+    interval: 24h
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-default-e2e-volumes: "true"
+      preset-dind-enabled: "true"
+      preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-make-volumes: "true"
+      preset-retry-flakey-tests: "true"
+      preset-service-account: "true"
+    name: ci-cert-manager-e2e-feature-gates-disabled-v1-20
+    spec:
+      containers:
+        - args:
+            - runner
+            - make
+            - -j
+            - vendor-go
+            - e2e-ci
+            - K8S_VERSION=1.20
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+  - agent: kubernetes
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.21 cluster with all feature gates disabled
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-master
+    decorate: true
+    extra_refs:
+      - base_ref: master
+        org: cert-manager
+        repo: cert-manager
+    interval: 24h
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-default-e2e-volumes: "true"
+      preset-dind-enabled: "true"
+      preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-make-volumes: "true"
+      preset-retry-flakey-tests: "true"
+      preset-service-account: "true"
+    name: ci-cert-manager-e2e-feature-gates-disabled-v1-21
+    spec:
+      containers:
+        - args:
+            - runner
+            - make
+            - -j
+            - vendor-go
+            - e2e-ci
+            - K8S_VERSION=1.21
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+  - agent: kubernetes
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.22 cluster with all feature gates disabled
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-master
+    decorate: true
+    extra_refs:
+      - base_ref: master
+        org: cert-manager
+        repo: cert-manager
+    interval: 24h
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-default-e2e-volumes: "true"
+      preset-dind-enabled: "true"
+      preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-make-volumes: "true"
+      preset-retry-flakey-tests: "true"
+      preset-service-account: "true"
+    name: ci-cert-manager-e2e-feature-gates-disabled-v1-22
+    spec:
+      containers:
+        - args:
+            - runner
+            - make
+            - -j
+            - vendor-go
+            - e2e-ci
+            - K8S_VERSION=1.22
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+  - agent: kubernetes
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.23 cluster with all feature gates disabled
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-master
+    decorate: true
+    extra_refs:
+      - base_ref: master
+        org: cert-manager
+        repo: cert-manager
+    interval: 24h
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-default-e2e-volumes: "true"
+      preset-dind-enabled: "true"
+      preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-make-volumes: "true"
+      preset-retry-flakey-tests: "true"
+      preset-service-account: "true"
+    name: ci-cert-manager-e2e-feature-gates-disabled-v1-23
+    spec:
+      containers:
+        - args:
+            - runner
+            - make
+            - -j
+            - vendor-go
+            - e2e-ci
+            - K8S_VERSION=1.23
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+  - agent: kubernetes
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.24 cluster with all feature gates disabled
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-master
+    decorate: true
+    extra_refs:
+      - base_ref: master
+        org: cert-manager
+        repo: cert-manager
+    interval: 24h
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-default-e2e-volumes: "true"
+      preset-dind-enabled: "true"
+      preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-make-volumes: "true"
+      preset-retry-flakey-tests: "true"
+      preset-service-account: "true"
+    name: ci-cert-manager-e2e-feature-gates-disabled-v1-24
+    spec:
+      containers:
+        - args:
+            - runner
+            - make
+            - -j
+            - vendor-go
+            - e2e-ci
+            - K8S_VERSION=1.24
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"

--- a/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/cert-manager-presubmits.yaml
@@ -1,488 +1,485 @@
 presubmits:
   cert-manager/cert-manager:
-
-  # Why do we have only have presubmits on "master" but not on the
-  # to-be-released branch, e.g. "release-1.9"? Because we don't need to be
-  # testing e.g. release-1.9 before we have made the first alpha release, e.g.,
-  # "1.9.0-alpha.0". See Step 13.3 in
-  # https://cert-manager.io/docs/contributing/release-process/
-
-  - name: pull-cert-manager-make-test
-    always_run: true
-    optional: false
-    max_concurrency: 8
-    agent: kubernetes
-    decorate: true
-    branches:
-    - master
-    annotations:
-      testgrid-create-test-group: 'true'
-      testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
-    description: Runs unit and integration tests and verification scripts
-    labels:
-      preset-service-account: "true"
-      preset-make-volumes: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j
-        - vendor-go
-        - ci-presubmit
-        - test-ci
-        resources:
-          requests:
-            cpu: 2
-            memory: 4Gi
-      dnsConfig:
-        options:
-          - name: ndots
-            value: "1"
-
-  # Helm chart verification currently requires Docker.
-  # We maintain a standalone presubmit for running this.
-  # See https://github.com/helm/chart-testing/issues/53
-  # Explicitly calls vendor-go because of this gotcha: https://github.com/cert-manager/cert-manager/blob/066fcbbbfa0e9840632a5dc3a5c36f6261c53405/make/tools.mk#L423-L426
-  - name: pull-cert-manager-chart
-    always_run: true
-    max_concurrency: 8
-    agent: kubernetes
-    decorate: true
-    branches:
-    - master
-    annotations:
-      testgrid-create-test-group: 'true'
-      testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
-      description: Verifies the Helm chart passes linting checks
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-make-volumes: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - vendor-go
-        - verify-chart
-        resources:
-          requests:
-            cpu: 1
-            memory: 1Gi
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-      dnsConfig:
-        options:
-          - name: ndots
-            value: "1"
-
-  - name: pull-cert-manager-e2e-v1-20
-    always_run: false
-    optional: true
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    branches:
-    - master
-    annotations:
-      testgrid-create-test-group: 'true'
-      testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
-      description: Runs the end-to-end test suite against a Kubernetes v1.20 cluster
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-cloudflare-credentials: "true"
-      preset-retry-flakey-tests: "true"
-      preset-enable-all-feature-gates-disable-ssa: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-default-e2e-volumes: "true"
-      preset-make-volumes: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.20
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-
-  - name: pull-cert-manager-e2e-v1-21
-    always_run: false
-    optional: true
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    branches:
-    - master
-    annotations:
-      testgrid-create-test-group: 'true'
-      testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
-      description: Runs the end-to-end test suite against a Kubernetes v1.21 cluster
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-cloudflare-credentials: "true"
-      preset-retry-flakey-tests: "true"
-      preset-enable-all-feature-gates-disable-ssa: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-default-e2e-volumes: "true"
-      preset-make-volumes: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.21
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-
-  - name: pull-cert-manager-e2e-v1-22
-    always_run: false
-    optional: true
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    branches:
-    - master
-    annotations:
-      testgrid-create-test-group: 'true'
-      testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
-      description: Runs the end-to-end test suite against a Kubernetes v1.22 cluster
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-cloudflare-credentials: "true"
-      preset-retry-flakey-tests: "true"
-      preset-enable-all-feature-gates: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-default-e2e-volumes: "true"
-      preset-make-volumes: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.22
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-
-  - name: pull-cert-manager-e2e-v1-23
-    always_run: false
-    optional: true
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    branches:
-    - master
-    annotations:
-      testgrid-create-test-group: 'true'
-      testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
-      description: Runs the end-to-end test suite against a Kubernetes v1.23 cluster
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-cloudflare-credentials: "true"
-      preset-retry-flakey-tests: "true"
-      preset-enable-all-feature-gates: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-default-e2e-volumes: "true"
-      preset-make-volumes: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.23
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-
-  # This is the default e2e test for all PRs against cert-manager master branch
-  - name: pull-cert-manager-e2e-v1-24
-    always_run: true
-    optional: false
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    branches:
-    - master
-    annotations:
-      testgrid-create-test-group: 'true'
-      testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
-      description: Runs 'make e2e-ci K8S_VERSION=1.24'
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-cloudflare-credentials: "true"
-      preset-retry-flakey-tests: "true"
-      preset-enable-all-feature-gates: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-make-volumes: "true"
-      preset-default-e2e-volumes: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.24
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-
-  # Verifies upgrade from the latest published release with both Helm chart and static manifests.
-  # Explicitly calls vendor-go because of this gotcha: https://github.com/cert-manager/cert-manager/blob/066fcbbbfa0e9840632a5dc3a5c36f6261c53405/make/tools.mk#L423-L426
-  - name: pull-cert-manager-upgrade
-    # Run always
-    always_run: true
-    optional: false
-    # No more than 4 instances of this job at the same time.
-    max_concurrency: 4
-    # This job will run on Kubernetes cluster.
-    agent: kubernetes
-    # Pod utilities will be set up.
-    decorate: true
-    branches:
-    - master
-    annotations:
-      testgrid-create-test-group: 'true'
-      testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
-      description: Runs cert-manager upgrade from latest published release
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-default-e2e-volumes: "true"
-      preset-make-volumes: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - K8S_VERSION=1.24
-        - vendor-go
-        - test-upgrade
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-
-  # An E2E test job to allow us to manually trigger the Venafi  TPP E2E tests
-  # with the following GitHub comment:
-  #
-  #  /test pull-cert-manager-issuers-venafi-tpp
-  #
-  # See https://github.com/cert-manager/cert-manager/issues/3555
-  #
-  - name: pull-cert-manager-issuers-venafi-tpp
-    always_run: false
-    optional: true
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    branches: []
-    annotations:
-      testgrid-create-test-group: 'true'
-      testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
-      description: Runs the E2E tests with 'Venafi TPP' in name
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-venafi-tpp-credentials: "true"
-      preset-retry-flakey-tests: "true"
-      preset-ginkgo-focus-venafi-tpp: "true"
-      preset-default-e2e-volumes: "true"
-      preset-make-volumes: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.24
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-
-  # An E2E test job to allow us to manually trigger the Venafi Cloud E2E tests
-  # with the following GitHub comment:
-  #
-  #  /test pull-cert-manager-issuers-venafi-cloud
-  #
-  # The regular presubmit jobs do not run Venafi e2e tests.
-  #
-  - name: pull-cert-manager-e2e-issuers-venafi-cloud
-    always_run: false
-    optional: true
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    branches: []
-    annotations:
-      testgrid-create-test-group: 'true'
-      testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
-      description: Runs the E2E tests with 'Venafi Cloud' in name
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-venafi-cloud-credentials: "true"
-      preset-retry-flakey-tests: "true"
-      preset-ginkgo-focus-venafi-cloud: "true"
-      preset-default-e2e-volumes: "true"
-      preset-make-volumes: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.23
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-
-  - name: pull-cert-manager-e2e-feature-gates-disabled
-    always_run: false
-    optional: true
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    branches: []
-    annotations:
-      testgrid-create-test-group: 'true'
-      testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
-      description: Runs the E2E tests with all feature gates disabled
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-disable-all-alpha-beta-feature-gates: "true"
-      preset-cloudflare-credentials: "true"
-      preset-retry-flakey-tests: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-default-e2e-volumes: "true"
-      preset-make-volumes: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.23
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
+    # Why do we have only have presubmits on "master" but not on the
+    # to-be-released branch, e.g. "release-1.9"? Because we don't need to be
+    # testing e.g. release-1.9 before we have made the first alpha release, e.g.,
+    # "1.9.0-alpha.0". See Step 13.3 in
+    # https://cert-manager.io/docs/contributing/release-process/
+    - agent: kubernetes
+      always_run: true
+      annotations:
+        testgrid-create-test-group: "true"
+        testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
+      branches:
+        - master
+      decorate: true
+      description: Runs unit and integration tests and verification scripts
+      labels:
+        preset-make-volumes: "true"
+        preset-service-account: "true"
+      max_concurrency: 8
+      name: pull-cert-manager-make-test
+      optional: false
+      spec:
+        containers:
+          - args:
+              - runner
+              - make
+              - -j
+              - vendor-go
+              - ci-presubmit
+              - test-ci
+            image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+            resources:
+              requests:
+                cpu: 2
+                memory: 4Gi
+        dnsConfig:
+          options:
+            - name: ndots
+              value: "1"
+    # Helm chart verification currently requires Docker.
+    # We maintain a standalone presubmit for running this.
+    # See https://github.com/helm/chart-testing/issues/53
+    # Explicitly calls vendor-go because of this gotcha: https://github.com/cert-manager/cert-manager/blob/066fcbbbfa0e9840632a5dc3a5c36f6261c53405/make/tools.mk#L423-L426
+    - agent: kubernetes
+      always_run: true
+      annotations:
+        description: Verifies the Helm chart passes linting checks
+        testgrid-create-test-group: "true"
+        testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
+      branches:
+        - master
+      decorate: true
+      labels:
+        preset-dind-enabled: "true"
+        preset-make-volumes: "true"
+        preset-service-account: "true"
+      max_concurrency: 8
+      name: pull-cert-manager-chart
+      spec:
+        containers:
+          - args:
+              - runner
+              - make
+              - vendor-go
+              - verify-chart
+            image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+            resources:
+              requests:
+                cpu: 1
+                memory: 1Gi
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+        dnsConfig:
+          options:
+            - name: ndots
+              value: "1"
+    - agent: kubernetes
+      always_run: false
+      annotations:
+        description: Runs the end-to-end test suite against a Kubernetes v1.20 cluster
+        testgrid-create-test-group: "true"
+        testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
+      branches:
+        - master
+      decorate: true
+      labels:
+        preset-cloudflare-credentials: "true"
+        preset-default-e2e-volumes: "true"
+        preset-dind-enabled: "true"
+        preset-enable-all-feature-gates-disable-ssa: "true"
+        preset-ginkgo-skip-default: "true"
+        preset-make-volumes: "true"
+        preset-retry-flakey-tests: "true"
+        preset-service-account: "true"
+      max_concurrency: 4
+      name: pull-cert-manager-e2e-v1-20
+      optional: true
+      spec:
+        containers:
+          - args:
+              - runner
+              - make
+              - -j
+              - vendor-go
+              - e2e-ci
+              - K8S_VERSION=1.20
+            image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+            resources:
+              requests:
+                cpu: 3500m
+                memory: 12Gi
+            securityContext:
+              capabilities:
+                add:
+                  - SYS_ADMIN
+              privileged: true
+        dnsConfig:
+          options:
+            - name: ndots
+              value: "1"
+    - agent: kubernetes
+      always_run: false
+      annotations:
+        description: Runs the end-to-end test suite against a Kubernetes v1.21 cluster
+        testgrid-create-test-group: "true"
+        testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
+      branches:
+        - master
+      decorate: true
+      labels:
+        preset-cloudflare-credentials: "true"
+        preset-default-e2e-volumes: "true"
+        preset-dind-enabled: "true"
+        preset-enable-all-feature-gates-disable-ssa: "true"
+        preset-ginkgo-skip-default: "true"
+        preset-make-volumes: "true"
+        preset-retry-flakey-tests: "true"
+        preset-service-account: "true"
+      max_concurrency: 4
+      name: pull-cert-manager-e2e-v1-21
+      optional: true
+      spec:
+        containers:
+          - args:
+              - runner
+              - make
+              - -j
+              - vendor-go
+              - e2e-ci
+              - K8S_VERSION=1.21
+            image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+            resources:
+              requests:
+                cpu: 3500m
+                memory: 12Gi
+            securityContext:
+              capabilities:
+                add:
+                  - SYS_ADMIN
+              privileged: true
+        dnsConfig:
+          options:
+            - name: ndots
+              value: "1"
+    - agent: kubernetes
+      always_run: false
+      annotations:
+        description: Runs the end-to-end test suite against a Kubernetes v1.22 cluster
+        testgrid-create-test-group: "true"
+        testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
+      branches:
+        - master
+      decorate: true
+      labels:
+        preset-cloudflare-credentials: "true"
+        preset-default-e2e-volumes: "true"
+        preset-dind-enabled: "true"
+        preset-enable-all-feature-gates: "true"
+        preset-ginkgo-skip-default: "true"
+        preset-make-volumes: "true"
+        preset-retry-flakey-tests: "true"
+        preset-service-account: "true"
+      max_concurrency: 4
+      name: pull-cert-manager-e2e-v1-22
+      optional: true
+      spec:
+        containers:
+          - args:
+              - runner
+              - make
+              - -j
+              - vendor-go
+              - e2e-ci
+              - K8S_VERSION=1.22
+            image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+            resources:
+              requests:
+                cpu: 3500m
+                memory: 12Gi
+            securityContext:
+              capabilities:
+                add:
+                  - SYS_ADMIN
+              privileged: true
+        dnsConfig:
+          options:
+            - name: ndots
+              value: "1"
+    - agent: kubernetes
+      always_run: false
+      annotations:
+        description: Runs the end-to-end test suite against a Kubernetes v1.23 cluster
+        testgrid-create-test-group: "true"
+        testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
+      branches:
+        - master
+      decorate: true
+      labels:
+        preset-cloudflare-credentials: "true"
+        preset-default-e2e-volumes: "true"
+        preset-dind-enabled: "true"
+        preset-enable-all-feature-gates: "true"
+        preset-ginkgo-skip-default: "true"
+        preset-make-volumes: "true"
+        preset-retry-flakey-tests: "true"
+        preset-service-account: "true"
+      max_concurrency: 4
+      name: pull-cert-manager-e2e-v1-23
+      optional: true
+      spec:
+        containers:
+          - args:
+              - runner
+              - make
+              - -j
+              - vendor-go
+              - e2e-ci
+              - K8S_VERSION=1.23
+            image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+            resources:
+              requests:
+                cpu: 3500m
+                memory: 12Gi
+            securityContext:
+              capabilities:
+                add:
+                  - SYS_ADMIN
+              privileged: true
+        dnsConfig:
+          options:
+            - name: ndots
+              value: "1"
+    # This is the default e2e test for all PRs against cert-manager master branch
+    - agent: kubernetes
+      always_run: true
+      annotations:
+        description: Runs 'make e2e-ci K8S_VERSION=1.24'
+        testgrid-create-test-group: "true"
+        testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
+      branches:
+        - master
+      decorate: true
+      labels:
+        preset-cloudflare-credentials: "true"
+        preset-default-e2e-volumes: "true"
+        preset-dind-enabled: "true"
+        preset-enable-all-feature-gates: "true"
+        preset-ginkgo-skip-default: "true"
+        preset-make-volumes: "true"
+        preset-retry-flakey-tests: "true"
+        preset-service-account: "true"
+      max_concurrency: 4
+      name: pull-cert-manager-e2e-v1-24
+      optional: false
+      spec:
+        containers:
+          - args:
+              - runner
+              - make
+              - -j
+              - vendor-go
+              - e2e-ci
+              - K8S_VERSION=1.24
+            image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+            resources:
+              requests:
+                cpu: 3500m
+                memory: 12Gi
+            securityContext:
+              capabilities:
+                add:
+                  - SYS_ADMIN
+              privileged: true
+        dnsConfig:
+          options:
+            - name: ndots
+              value: "1"
+    # Verifies upgrade from the latest published release with both Helm chart and static manifests.
+    # Explicitly calls vendor-go because of this gotcha: https://github.com/cert-manager/cert-manager/blob/066fcbbbfa0e9840632a5dc3a5c36f6261c53405/make/tools.mk#L423-L426
+    - # This job will run on Kubernetes cluster.
+      agent: kubernetes
+      # Run always
+      always_run: true
+      annotations:
+        description: Runs cert-manager upgrade from latest published release
+        testgrid-create-test-group: "true"
+        testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
+      branches:
+        - master
+      # Pod utilities will be set up.
+      decorate: true
+      labels:
+        preset-default-e2e-volumes: "true"
+        preset-dind-enabled: "true"
+        preset-make-volumes: "true"
+        preset-service-account: "true"
+      # No more than 4 instances of this job at the same time.
+      max_concurrency: 4
+      name: pull-cert-manager-upgrade
+      optional: false
+      spec:
+        containers:
+          - args:
+              - runner
+              - make
+              - K8S_VERSION=1.24
+              - vendor-go
+              - test-upgrade
+            image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+            resources:
+              requests:
+                cpu: 3500m
+                memory: 12Gi
+            securityContext:
+              capabilities:
+                add:
+                  - SYS_ADMIN
+              privileged: true
+        dnsConfig:
+          options:
+            - name: ndots
+              value: "1"
+    # An E2E test job to allow us to manually trigger the Venafi  TPP E2E tests
+    # with the following GitHub comment:
+    #
+    #  /test pull-cert-manager-issuers-venafi-tpp
+    #
+    # See https://github.com/cert-manager/cert-manager/issues/3555
+    #
+    - agent: kubernetes
+      always_run: false
+      annotations:
+        description: Runs the E2E tests with 'Venafi TPP' in name
+        testgrid-create-test-group: "true"
+        testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
+      branches: []
+      decorate: true
+      labels:
+        preset-default-e2e-volumes: "true"
+        preset-dind-enabled: "true"
+        preset-ginkgo-focus-venafi-tpp: "true"
+        preset-make-volumes: "true"
+        preset-retry-flakey-tests: "true"
+        preset-service-account: "true"
+        preset-venafi-tpp-credentials: "true"
+      max_concurrency: 4
+      name: pull-cert-manager-issuers-venafi-tpp
+      optional: true
+      spec:
+        containers:
+          - args:
+              - runner
+              - make
+              - -j
+              - vendor-go
+              - e2e-ci
+              - K8S_VERSION=1.24
+            image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+            resources:
+              requests:
+                cpu: 3500m
+                memory: 12Gi
+            securityContext:
+              capabilities:
+                add:
+                  - SYS_ADMIN
+              privileged: true
+        dnsConfig:
+          options:
+            - name: ndots
+              value: "1"
+    # An E2E test job to allow us to manually trigger the Venafi Cloud E2E tests
+    # with the following GitHub comment:
+    #
+    #  /test pull-cert-manager-issuers-venafi-cloud
+    #
+    # The regular presubmit jobs do not run Venafi e2e tests.
+    #
+    - agent: kubernetes
+      always_run: false
+      annotations:
+        description: Runs the E2E tests with 'Venafi Cloud' in name
+        testgrid-create-test-group: "true"
+        testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
+      branches: []
+      decorate: true
+      labels:
+        preset-default-e2e-volumes: "true"
+        preset-dind-enabled: "true"
+        preset-ginkgo-focus-venafi-cloud: "true"
+        preset-make-volumes: "true"
+        preset-retry-flakey-tests: "true"
+        preset-service-account: "true"
+        preset-venafi-cloud-credentials: "true"
+      max_concurrency: 4
+      name: pull-cert-manager-e2e-issuers-venafi-cloud
+      optional: true
+      spec:
+        containers:
+          - args:
+              - runner
+              - make
+              - -j
+              - vendor-go
+              - e2e-ci
+              - K8S_VERSION=1.23
+            image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+            resources:
+              requests:
+                cpu: 3500m
+                memory: 12Gi
+            securityContext:
+              capabilities:
+                add:
+                  - SYS_ADMIN
+              privileged: true
+        dnsConfig:
+          options:
+            - name: ndots
+              value: "1"
+    - agent: kubernetes
+      always_run: false
+      annotations:
+        description: Runs the E2E tests with all feature gates disabled
+        testgrid-create-test-group: "true"
+        testgrid-dashboards: jetstack-cert-manager-presubmits-blocking
+      branches: []
+      decorate: true
+      labels:
+        preset-cloudflare-credentials: "true"
+        preset-default-e2e-volumes: "true"
+        preset-dind-enabled: "true"
+        preset-disable-all-alpha-beta-feature-gates: "true"
+        preset-ginkgo-skip-default: "true"
+        preset-make-volumes: "true"
+        preset-retry-flakey-tests: "true"
+        preset-service-account: "true"
+      max_concurrency: 4
+      name: pull-cert-manager-e2e-feature-gates-disabled
+      optional: true
+      spec:
+        containers:
+          - args:
+              - runner
+              - make
+              - -j
+              - vendor-go
+              - e2e-ci
+              - K8S_VERSION=1.23
+            image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+            resources:
+              requests:
+                cpu: 3500m
+                memory: 12Gi
+            securityContext:
+              capabilities:
+                add:
+                  - SYS_ADMIN
+              privileged: true
+        dnsConfig:
+          options:
+            - name: ndots
+              value: "1"

--- a/config/jobs/cert-manager/cert-manager/release-next/cert-manager-release-next-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-next/cert-manager-release-next-periodics.yaml
@@ -6,339 +6,338 @@
 # https://cert-manager.io/docs/contributing/release-process/
 
 # Since we're in an alpha phase now, we'll enable these tests
-
 periodics:
-- name: ci-cert-manager-next-make-test
-  interval: 2h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: release-1.9
-  labels:
-    preset-service-account: "true"
-    preset-make-volumes: "true"
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-next
-    description: Runs unit and integration tests and verification scripts
-  spec:
-    containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-          - runner
-          - make
-          - -j
-          - vendor-go
-          - ci-presubmit
-          - test-ci
-        resources:
-          requests:
-            cpu: 2
-            memory: 4Gi
-    dnsConfig:
-      options:
-        - name: ndots
-          value: "1"
-
-- name: ci-cert-manager-next-e2e-v1-20
-  interval: 2h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: release-1.9
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-next
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs the end-to-end test suite against a Kubernetes v1.20 cluster
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-cloudflare-credentials: "true"
-    preset-enable-all-feature-gates-disable-ssa: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-make-volumes: "true"
-    preset-default-e2e-volumes: "true"
-  spec:
-    containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.20
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-    dnsConfig:
-      options:
-        - name: ndots
-          value: "1"
-
-- name: ci-cert-manager-next-e2e-v1-21
-  interval: 2h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: release-1.9
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-next
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs the end-to-end test suite against a Kubernetes v1.21 cluster
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-cloudflare-credentials: "true"
-    preset-enable-all-feature-gates-disable-ssa: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-make-volumes: "true"
-    preset-default-e2e-volumes: "true"
-  spec:
-    containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.21
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-    dnsConfig:
-      options:
-        - name: ndots
-          value: "1"
-
-- name: ci-cert-manager-next-e2e-v1-22
-  interval: 2h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: release-1.9
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-next
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs the end-to-end test suite against a Kubernetes v1.22 cluster
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-cloudflare-credentials: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-make-volumes: "true"
-    preset-default-e2e-volumes: "true"
-  spec:
-    containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.22
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-    dnsConfig:
-      options:
-        - name: ndots
-          value: "1"
-
-- name: ci-cert-manager-next-e2e-v1-23
-  interval: 2h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: release-1.9
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-next
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs the end-to-end test suite against a Kubernetes v1.23 cluster
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-cloudflare-credentials: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-make-volumes: "true"
-    preset-default-e2e-volumes: "true"
-  spec:
-    containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.23
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-    dnsConfig:
-      options:
-        - name: ndots
-          value: "1"
-
-- name: ci-cert-manager-next-e2e-v1-24
-  interval: 2h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: release-1.9
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-next
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs the end-to-end test suite against a Kubernetes v1.24 cluster
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-cloudflare-credentials: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-make-volumes: "true"
-    preset-default-e2e-volumes: "true"
-  spec:
-    containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.24
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-    dnsConfig:
-      options:
-        - name: ndots
-          value: "1"
-
-- name: ci-cert-manager-next-venafi
-  interval: 12h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: master
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-next
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs Venafi (VaaS and TPP) e2e tests against Kubernetes v1.24 cluster
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-venafi-cloud-credentials: "true"
-    preset-venafi-tpp-credentials: "true"
-    preset-ginkgo-focus-venafi: "true"
-    preset-make-volumes: "true"
-    preset-default-e2e-volumes: "true"
-  spec:
-    containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.24
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-    dnsConfig:
-      options:
-        - name: ndots
-          value: "1"
-
-- name: ci-cert-manager-next-upgrade
-  interval: 8h
-  agent: kubernetes
-  decorate: true
-  # extra refs specify what repo should be cloned
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: release-1.9
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-master
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs cert-manager upgrade test every 8 hours
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-make-volumes: "true"
-    preset-default-e2e-volumes: "true"
-  spec:
-    containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-          - runner
-          - make
-          - cluster
-          - verify_upgrade
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-    dnsConfig:
-      options:
-        - name: ndots
-          value: "1"
+  - agent: kubernetes
+    annotations:
+      description: Runs unit and integration tests and verification scripts
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-next
+    decorate: true
+    extra_refs:
+      - base_ref: release-1.9
+        org: cert-manager
+        repo: cert-manager
+    interval: 2h
+    labels:
+      preset-make-volumes: "true"
+      preset-service-account: "true"
+    name: ci-cert-manager-next-make-test
+    spec:
+      containers:
+        - args:
+            - runner
+            - make
+            - -j
+            - vendor-go
+            - ci-presubmit
+            - test-ci
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+          resources:
+            requests:
+              cpu: 2
+              memory: 4Gi
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+  - agent: kubernetes
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.20 cluster
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-next
+    decorate: true
+    extra_refs:
+      - base_ref: release-1.9
+        org: cert-manager
+        repo: cert-manager
+    interval: 2h
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-default-e2e-volumes: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates-disable-ssa: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-make-volumes: "true"
+      preset-service-account: "true"
+    name: ci-cert-manager-next-e2e-v1-20
+    spec:
+      containers:
+        - args:
+            - runner
+            - make
+            - -j
+            - vendor-go
+            - e2e-ci
+            - K8S_VERSION=1.20
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+  - agent: kubernetes
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.21 cluster
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-next
+    decorate: true
+    extra_refs:
+      - base_ref: release-1.9
+        org: cert-manager
+        repo: cert-manager
+    interval: 2h
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-default-e2e-volumes: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates-disable-ssa: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-make-volumes: "true"
+      preset-service-account: "true"
+    name: ci-cert-manager-next-e2e-v1-21
+    spec:
+      containers:
+        - args:
+            - runner
+            - make
+            - -j
+            - vendor-go
+            - e2e-ci
+            - K8S_VERSION=1.21
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+  - agent: kubernetes
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.22 cluster
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-next
+    decorate: true
+    extra_refs:
+      - base_ref: release-1.9
+        org: cert-manager
+        repo: cert-manager
+    interval: 2h
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-default-e2e-volumes: "true"
+      preset-dind-enabled: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-make-volumes: "true"
+      preset-service-account: "true"
+    name: ci-cert-manager-next-e2e-v1-22
+    spec:
+      containers:
+        - args:
+            - runner
+            - make
+            - -j
+            - vendor-go
+            - e2e-ci
+            - K8S_VERSION=1.22
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+  - agent: kubernetes
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.23 cluster
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-next
+    decorate: true
+    extra_refs:
+      - base_ref: release-1.9
+        org: cert-manager
+        repo: cert-manager
+    interval: 2h
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-default-e2e-volumes: "true"
+      preset-dind-enabled: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-make-volumes: "true"
+      preset-service-account: "true"
+    name: ci-cert-manager-next-e2e-v1-23
+    spec:
+      containers:
+        - args:
+            - runner
+            - make
+            - -j
+            - vendor-go
+            - e2e-ci
+            - K8S_VERSION=1.23
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+  - agent: kubernetes
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.24 cluster
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-next
+    decorate: true
+    extra_refs:
+      - base_ref: release-1.9
+        org: cert-manager
+        repo: cert-manager
+    interval: 2h
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-default-e2e-volumes: "true"
+      preset-dind-enabled: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-make-volumes: "true"
+      preset-service-account: "true"
+    name: ci-cert-manager-next-e2e-v1-24
+    spec:
+      containers:
+        - args:
+            - runner
+            - make
+            - -j
+            - vendor-go
+            - e2e-ci
+            - K8S_VERSION=1.24
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+  - agent: kubernetes
+    annotations:
+      description: Runs Venafi (VaaS and TPP) e2e tests against Kubernetes v1.24 cluster
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-next
+    decorate: true
+    extra_refs:
+      - base_ref: master
+        org: cert-manager
+        repo: cert-manager
+    interval: 12h
+    labels:
+      preset-default-e2e-volumes: "true"
+      preset-dind-enabled: "true"
+      preset-ginkgo-focus-venafi: "true"
+      preset-make-volumes: "true"
+      preset-service-account: "true"
+      preset-venafi-cloud-credentials: "true"
+      preset-venafi-tpp-credentials: "true"
+    name: ci-cert-manager-next-venafi
+    spec:
+      containers:
+        - args:
+            - runner
+            - make
+            - -j
+            - vendor-go
+            - e2e-ci
+            - K8S_VERSION=1.24
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+  - agent: kubernetes
+    annotations:
+      description: Runs cert-manager upgrade test every 8 hours
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-master
+    decorate: true
+    # extra refs specify what repo should be cloned
+    extra_refs:
+      - base_ref: release-1.9
+        org: cert-manager
+        repo: cert-manager
+    interval: 8h
+    labels:
+      preset-default-e2e-volumes: "true"
+      preset-dind-enabled: "true"
+      preset-make-volumes: "true"
+      preset-service-account: "true"
+    name: ci-cert-manager-next-upgrade
+    spec:
+      containers:
+        - args:
+            - runner
+            - make
+            - cluster
+            - verify_upgrade
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"

--- a/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
@@ -1,948 +1,945 @@
 periodics:
-
-- name: ci-cert-manager-previous-bazel
-  interval: 2h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: release-1.8 # still required on 1.8 because some tests were only present in bazel
-  labels:
-    preset-service-account: "true"
-    preset-bazel-remote-cache-enabled: "true"
-    preset-bazel-scratch-dir: "true"
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs 'bazel test --jobs=1 //...'
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-      args:
-      - runner
-      - bazel
-      - test
-      - --jobs=1
-      - //hack/...
-      resources:
-        requests:
-          cpu: 1
-          memory: 2Gi
-    dnsConfig:
-      options:
-        - name: ndots
-          value: "1"
-
-# Re-add bazel-experimental periodics once Bazel v5.0.0 is released and we have
-# a bazelbuild image with that https://github.com/bazelbuild/bazel/releases
-
-- name: ci-cert-manager-previous-e2e-v1-18
-  interval: 2h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: release-1.8
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs the end-to-end test suite against a Kubernetes v1.18 cluster
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-bazel-remote-cache-enabled: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-cloudflare-credentials: "true"
-    preset-disable-alpha-enable-output-formats-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-      args:
-      - runner
-      - devel/ci-run-e2e.sh
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 12Gi
-      env:
-      - name: K8S_VERSION
-        value: "1.18"
-      securityContext:
-        privileged: true
-        capabilities:
-          add: ["SYS_ADMIN"]
-      volumeMounts:
-      - mountPath: /lib/modules
-        name: modules
-        readOnly: true
-      - mountPath: /sys/fs/cgroup
-        name: cgroup
-    volumes:
-    - name: modules
-      hostPath:
-        path: /lib/modules
-        type: Directory
-    - name: cgroup
-      hostPath:
-        path: /sys/fs/cgroup
-        type: Directory
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
-
-- name: ci-cert-manager-previous-e2e-v1-19
-  interval: 2h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: release-1.8
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs the end-to-end test suite against a Kubernetes v1.19 cluster
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-bazel-remote-cache-enabled: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-cloudflare-credentials: "true"
-    preset-enable-all-feature-gates-disable-ssa: "true"
-    preset-ginkgo-skip-default: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-      args:
-      - runner
-      - devel/ci-run-e2e.sh
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 12Gi
-      env:
-      - name: K8S_VERSION
-        value: "1.19"
-      securityContext:
-        privileged: true
-        capabilities:
-          add: ["SYS_ADMIN"]
-      volumeMounts:
-      - mountPath: /lib/modules
-        name: modules
-        readOnly: true
-      - mountPath: /sys/fs/cgroup
-        name: cgroup
-    volumes:
-    - name: modules
-      hostPath:
-        path: /lib/modules
-        type: Directory
-    - name: cgroup
-      hostPath:
-        path: /sys/fs/cgroup
-        type: Directory
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
-
-- name: ci-cert-manager-previous-e2e-v1-20
-  interval: 2h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: release-1.8
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs the end-to-end test suite against a Kubernetes v1.20 cluster
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-bazel-remote-cache-enabled: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-cloudflare-credentials: "true"
-    preset-enable-all-feature-gates-disable-ssa: "true"
-    preset-ginkgo-skip-default: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-      args:
-      - runner
-      - devel/ci-run-e2e.sh
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 12Gi
-      env:
-      - name: K8S_VERSION
-        value: "1.20"
-      securityContext:
-        privileged: true
-        capabilities:
-          add: ["SYS_ADMIN"]
-      volumeMounts:
-      - mountPath: /lib/modules
-        name: modules
-        readOnly: true
-      - mountPath: /sys/fs/cgroup
-        name: cgroup
-    volumes:
-    - name: modules
-      hostPath:
-        path: /lib/modules
-        type: Directory
-    - name: cgroup
-      hostPath:
-        path: /sys/fs/cgroup
-        type: Directory
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
-
-- name: ci-cert-manager-previous-e2e-v1-21
-  interval: 2h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: release-1.8
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs the end-to-end test suite against a Kubernetes v1.21 cluster
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-bazel-remote-cache-enabled: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-cloudflare-credentials: "true"
-    preset-enable-all-feature-gates-disable-ssa: "true"
-    preset-ginkgo-skip-default: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-      args:
-      - runner
-      - devel/ci-run-e2e.sh
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 12Gi
-      env:
-      - name: K8S_VERSION
-        value: "1.21"
-      securityContext:
-        privileged: true
-        capabilities:
-          add: ["SYS_ADMIN"]
-      volumeMounts:
-      - mountPath: /lib/modules
-        name: modules
-        readOnly: true
-      - mountPath: /sys/fs/cgroup
-        name: cgroup
-    volumes:
-    - name: modules
-      hostPath:
-        path: /lib/modules
-        type: Directory
-    - name: cgroup
-      hostPath:
-        path: /sys/fs/cgroup
-        type: Directory
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
-
-- name: ci-cert-manager-previous-e2e-v1-22
-  interval: 2h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: release-1.8
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs the end-to-end test suite against a Kubernetes v1.22 cluster
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-bazel-remote-cache-enabled: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-cloudflare-credentials: "true"
-    preset-enable-all-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-      args:
-      - runner
-      - devel/ci-run-e2e.sh
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 12Gi
-      env:
-      - name: K8S_VERSION
-        value: "1.22"
-      securityContext:
-        privileged: true
-        capabilities:
-          add: ["SYS_ADMIN"]
-      volumeMounts:
-      - mountPath: /lib/modules
-        name: modules
-        readOnly: true
-      - mountPath: /sys/fs/cgroup
-        name: cgroup
-    volumes:
-    - name: modules
-      hostPath:
-        path: /lib/modules
-        type: Directory
-    - name: cgroup
-      hostPath:
-        path: /sys/fs/cgroup
-        type: Directory
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
-
-- name: ci-cert-manager-previous-e2e-v1-23
-  interval: 2h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: release-1.8
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs the end-to-end test suite against a Kubernetes v1.23 cluster
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-bazel-remote-cache-enabled: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-cloudflare-credentials: "true"
-    preset-enable-all-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-      args:
-      - runner
-      - devel/ci-run-e2e.sh
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 12Gi
-      env:
-      - name: K8S_VERSION
-        value: "1.23"
-      securityContext:
-        privileged: true
-        capabilities:
-          add: ["SYS_ADMIN"]
-      volumeMounts:
-      - mountPath: /lib/modules
-        name: modules
-        readOnly: true
-      - mountPath: /sys/fs/cgroup
-        name: cgroup
-    volumes:
-    - name: modules
-      hostPath:
-        path: /lib/modules
-        type: Directory
-    - name: cgroup
-      hostPath:
-        path: /sys/fs/cgroup
-        type: Directory
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
-
-# This job uses make to invoke end-to-end tests as support for running jobs against 1.24
-# was only backported into the make based e2e infra in the release-1.8 branch.
-- name: ci-cert-manager-previous-e2e-v1-24
-  interval: 2h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-    - org: cert-manager
-      repo: cert-manager
-      base_ref: release-1.8
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs the end-to-end test suite against a Kubernetes v1.24 cluster
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-bazel-remote-cache-enabled: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-cloudflare-credentials: "true"
-    preset-enable-all-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-default-e2e-volumes: "true"
-    preset-make-volumes: "true"
-  spec:
-    containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-          - runner
-          - make
-          - -j
-          - vendor-go
-          - e2e-ci
-          - K8S_VERSION=1.24
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-    dnsConfig:
-      options:
-        - name: ndots
-          value: "1"
-
-# This test runs Venafi (VaaS and TPP) tests once every 12hrs.
-# This is the only CI test job that runs those.
-- name: ci-cert-manager-previous-venafi
-  interval: 12h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: release-1.8
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs Venafi (VaaS and TPP) e2e tests against Kubernetes v1.22 cluster
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-bazel-remote-cache-enabled: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-venafi-cloud-credentials: "true"
-    preset-venafi-tpp-credentials: "true"
-    preset-ginkgo-focus-venafi: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-      args:
-      - runner
-      - devel/ci-run-e2e.sh
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 12Gi
-      env:
-      - name: K8S_VERSION
-        value: "1.23"
-      securityContext:
-        privileged: true
-        capabilities:
-          add: ["SYS_ADMIN"]
-      volumeMounts:
-      - mountPath: /lib/modules
-        name: modules
-        readOnly: true
-      - mountPath: /sys/fs/cgroup
-        name: cgroup
-    volumes:
-    - name: modules
-      hostPath:
-        path: /lib/modules
-        type: Directory
-    - name: cgroup
-      hostPath:
-        path: /sys/fs/cgroup
-        type: Directory
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
-
-
-- name: ci-cert-manager-previous-upgrade
-  interval: 8h
-  agent: kubernetes
-  decorate: true
-  # extra refs specify what repo should be cloned
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: release-1.8
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs cert-manager upgrade test every 8 hours
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-bazel-remote-cache-enabled: "true"
-    preset-bazel-scratch-dir: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-      args:
-      - runner
-      - make
-      - cluster
-      - verify_upgrade
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 12Gi
-      env:
-      - name: K8S_VERSION
-        value: "1.23"
-      securityContext:
-        privileged: true
-        capabilities:
-          add: ["SYS_ADMIN"]
-      volumeMounts:
-      - mountPath: /lib/modules
-        name: modules
-        readOnly: true
-      - mountPath: /sys/fs/cgroup
-        name: cgroup
-    volumes:
-    - name: modules
-      hostPath:
-        path: /lib/modules
-        type: Directory
-    - name: cgroup
-      hostPath:
-        path: /sys/fs/cgroup
-        type: Directory
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
-
-- name: ci-cert-manager-previous-e2e-feature-gates-disabled-v1-18
-  interval: 24h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: release-1.8
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs the end-to-end test suite against a Kubernetes v1.18 cluster with all feature gates disabled
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-bazel-remote-cache-enabled: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-cloudflare-credentials: "true"
-    preset-disable-all-alpha-beta-feature-gates: "true"
-    preset-retry-flakey-tests: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-      args:
-      - runner
-      - devel/ci-run-e2e.sh
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 12Gi
-      env:
-      - name: K8S_VERSION
-        value: "1.18"
-      securityContext:
-        privileged: true
-        capabilities:
-          add: ["SYS_ADMIN"]
-      volumeMounts:
-      - mountPath: /lib/modules
-        name: modules
-        readOnly: true
-      - mountPath: /sys/fs/cgroup
-        name: cgroup
-    volumes:
-    - name: modules
-      hostPath:
-        path: /lib/modules
-        type: Directory
-    - name: cgroup
-      hostPath:
-        path: /sys/fs/cgroup
-        type: Directory
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
-
-- name: ci-cert-manager-previous-e2e-feature-gates-disabled-v1-19
-  interval: 24h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: release-1.8
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs the end-to-end test suite against a Kubernetes v1.19 cluster with all feature gates disabled
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-bazel-remote-cache-enabled: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-cloudflare-credentials: "true"
-    preset-disable-all-alpha-beta-feature-gates: "true"
-    preset-retry-flakey-tests: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-      args:
-      - runner
-      - devel/ci-run-e2e.sh
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 12Gi
-      env:
-      - name: K8S_VERSION
-        value: "1.19"
-      securityContext:
-        privileged: true
-        capabilities:
-          add: ["SYS_ADMIN"]
-      volumeMounts:
-      - mountPath: /lib/modules
-        name: modules
-        readOnly: true
-      - mountPath: /sys/fs/cgroup
-        name: cgroup
-    volumes:
-    - name: modules
-      hostPath:
-        path: /lib/modules
-        type: Directory
-    - name: cgroup
-      hostPath:
-        path: /sys/fs/cgroup
-        type: Directory
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
-
-- name: ci-cert-manager-previous-e2e-feature-gates-disabled-v1-20
-  interval: 24h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: release-1.8
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs the end-to-end test suite against a Kubernetes v1.20 cluster with all feature gates disabled
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-bazel-remote-cache-enabled: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-cloudflare-credentials: "true"
-    preset-disable-all-alpha-beta-feature-gates: "true"
-    preset-retry-flakey-tests: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-      args:
-      - runner
-      - devel/ci-run-e2e.sh
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 12Gi
-      env:
-      - name: K8S_VERSION
-        value: "1.20"
-      securityContext:
-        privileged: true
-        capabilities:
-          add: ["SYS_ADMIN"]
-      volumeMounts:
-      - mountPath: /lib/modules
-        name: modules
-        readOnly: true
-      - mountPath: /sys/fs/cgroup
-        name: cgroup
-    volumes:
-    - name: modules
-      hostPath:
-        path: /lib/modules
-        type: Directory
-    - name: cgroup
-      hostPath:
-        path: /sys/fs/cgroup
-        type: Directory
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
-
-- name: ci-cert-manager-previous-e2e-feature-gates-disabled-v1-21
-  interval: 24h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: release-1.8
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs the end-to-end test suite against a Kubernetes v1.21 cluster with all feature gates disabled
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-bazel-remote-cache-enabled: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-cloudflare-credentials: "true"
-    preset-disable-all-alpha-beta-feature-gates: "true"
-    preset-retry-flakey-tests: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-      args:
-      - runner
-      - devel/ci-run-e2e.sh
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 12Gi
-      env:
-      - name: K8S_VERSION
-        value: "1.21"
-      securityContext:
-        privileged: true
-        capabilities:
-          add: ["SYS_ADMIN"]
-      volumeMounts:
-      - mountPath: /lib/modules
-        name: modules
-        readOnly: true
-      - mountPath: /sys/fs/cgroup
-        name: cgroup
-    volumes:
-    - name: modules
-      hostPath:
-        path: /lib/modules
-        type: Directory
-    - name: cgroup
-      hostPath:
-        path: /sys/fs/cgroup
-        type: Directory
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
-
-- name: ci-cert-manager-previous-e2e-feature-gates-disabled-v1-22
-  interval: 24h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: release-1.8
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs the end-to-end test suite against a Kubernetes v1.22 cluster with all feature gates disabled
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-bazel-remote-cache-enabled: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-cloudflare-credentials: "true"
-    preset-disable-all-alpha-beta-feature-gates: "true"
-    preset-retry-flakey-tests: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-      args:
-      - runner
-      - devel/ci-run-e2e.sh
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 12Gi
-      env:
-      - name: K8S_VERSION
-        value: "1.22"
-      securityContext:
-        privileged: true
-        capabilities:
-          add: ["SYS_ADMIN"]
-      volumeMounts:
-      - mountPath: /lib/modules
-        name: modules
-        readOnly: true
-      - mountPath: /sys/fs/cgroup
-        name: cgroup
-    volumes:
-    - name: modules
-      hostPath:
-        path: /lib/modules
-        type: Directory
-    - name: cgroup
-      hostPath:
-        path: /sys/fs/cgroup
-        type: Directory
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
-
-- name: ci-cert-manager-previous-e2e-feature-gates-disabled-v1-23
-  interval: 24h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: release-1.8
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs the end-to-end test suite against a Kubernetes v1.23 cluster with all feature gates disabled
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-bazel-remote-cache-enabled: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-cloudflare-credentials: "true"
-    preset-disable-all-alpha-beta-feature-gates: "true"
-    preset-retry-flakey-tests: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
-      args:
-      - runner
-      - devel/ci-run-e2e.sh
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 12Gi
-      env:
-      - name: K8S_VERSION
-        value: "1.23"
-      securityContext:
-        privileged: true
-        capabilities:
-          add: ["SYS_ADMIN"]
-      volumeMounts:
-      - mountPath: /lib/modules
-        name: modules
-        readOnly: true
-      - mountPath: /sys/fs/cgroup
-        name: cgroup
-    volumes:
-    - name: modules
-      hostPath:
-        path: /lib/modules
-        type: Directory
-    - name: cgroup
-      hostPath:
-        path: /sys/fs/cgroup
-        type: Directory
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
-
-# This job uses make to invoke end-to-end tests as support for running jobs against 1.24
-# was only backported into the make based e2e infra in the release-1.8 branch.
-- name: ci-cert-manager-previous-e2e-feature-gates-disabled-v1-24
-  interval: 24h
-  agent: kubernetes
-  decorate: true
-  extra_refs:
-    - org: cert-manager
-      repo: cert-manager
-      base_ref: release-1.8
-  annotations:
-    testgrid-create-test-group: 'true'
-    testgrid-dashboards: jetstack-cert-manager-previous
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs the end-to-end test suite against a Kubernetes v1.24 cluster with all feature gates disabled
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-cloudflare-credentials: "true"
-    preset-disable-all-alpha-beta-feature-gates: "true"
-    preset-retry-flakey-tests: "true"
-    preset-make-volumes: "true"
-    preset-default-e2e-volumes: "true"
-  spec:
-    containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-          - runner
-          - make
-          - -j
-          - vendor-go
-          - e2e-ci
-          - K8S_VERSION=1.24
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-    dnsConfig:
-      options:
-        - name: ndots
-          value: "1"
+  - agent: kubernetes
+    annotations:
+      description: Runs 'bazel test --jobs=1 //...'
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-previous
+    decorate: true
+    extra_refs:
+      - base_ref: release-1.8 # still required on 1.8 because some tests were only present in bazel
+        org: cert-manager
+        repo: cert-manager
+    interval: 2h
+    labels:
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-service-account: "true"
+    name: ci-cert-manager-previous-bazel
+    spec:
+      containers:
+        - args:
+            - runner
+            - bazel
+            - test
+            - --jobs=1
+            - //hack/...
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+          resources:
+            requests:
+              cpu: 1
+              memory: 2Gi
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+  # Re-add bazel-experimental periodics once Bazel v5.0.0 is released and we have
+  # a bazelbuild image with that https://github.com/bazelbuild/bazel/releases
+  - agent: kubernetes
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.18 cluster
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-previous
+    decorate: true
+    extra_refs:
+      - base_ref: release-1.8
+        org: cert-manager
+        repo: cert-manager
+    interval: 2h
+    labels:
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-cloudflare-credentials: "true"
+      preset-dind-enabled: "true"
+      preset-disable-alpha-enable-output-formats-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-service-account: "true"
+    name: ci-cert-manager-previous-e2e-v1-18
+    spec:
+      containers:
+        - args:
+            - runner
+            - devel/ci-run-e2e.sh
+          env:
+            - name: K8S_VERSION
+              value: "1.18"
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: modules
+              readOnly: true
+            - mountPath: /sys/fs/cgroup
+              name: cgroup
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+      volumes:
+        - hostPath:
+            path: /lib/modules
+            type: Directory
+          name: modules
+        - hostPath:
+            path: /sys/fs/cgroup
+            type: Directory
+          name: cgroup
+  - agent: kubernetes
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.19 cluster
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-previous
+    decorate: true
+    extra_refs:
+      - base_ref: release-1.8
+        org: cert-manager
+        repo: cert-manager
+    interval: 2h
+    labels:
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-cloudflare-credentials: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates-disable-ssa: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-service-account: "true"
+    name: ci-cert-manager-previous-e2e-v1-19
+    spec:
+      containers:
+        - args:
+            - runner
+            - devel/ci-run-e2e.sh
+          env:
+            - name: K8S_VERSION
+              value: "1.19"
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: modules
+              readOnly: true
+            - mountPath: /sys/fs/cgroup
+              name: cgroup
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+      volumes:
+        - hostPath:
+            path: /lib/modules
+            type: Directory
+          name: modules
+        - hostPath:
+            path: /sys/fs/cgroup
+            type: Directory
+          name: cgroup
+  - agent: kubernetes
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.20 cluster
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-previous
+    decorate: true
+    extra_refs:
+      - base_ref: release-1.8
+        org: cert-manager
+        repo: cert-manager
+    interval: 2h
+    labels:
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-cloudflare-credentials: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates-disable-ssa: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-service-account: "true"
+    name: ci-cert-manager-previous-e2e-v1-20
+    spec:
+      containers:
+        - args:
+            - runner
+            - devel/ci-run-e2e.sh
+          env:
+            - name: K8S_VERSION
+              value: "1.20"
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: modules
+              readOnly: true
+            - mountPath: /sys/fs/cgroup
+              name: cgroup
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+      volumes:
+        - hostPath:
+            path: /lib/modules
+            type: Directory
+          name: modules
+        - hostPath:
+            path: /sys/fs/cgroup
+            type: Directory
+          name: cgroup
+  - agent: kubernetes
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.21 cluster
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-previous
+    decorate: true
+    extra_refs:
+      - base_ref: release-1.8
+        org: cert-manager
+        repo: cert-manager
+    interval: 2h
+    labels:
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-cloudflare-credentials: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates-disable-ssa: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-service-account: "true"
+    name: ci-cert-manager-previous-e2e-v1-21
+    spec:
+      containers:
+        - args:
+            - runner
+            - devel/ci-run-e2e.sh
+          env:
+            - name: K8S_VERSION
+              value: "1.21"
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: modules
+              readOnly: true
+            - mountPath: /sys/fs/cgroup
+              name: cgroup
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+      volumes:
+        - hostPath:
+            path: /lib/modules
+            type: Directory
+          name: modules
+        - hostPath:
+            path: /sys/fs/cgroup
+            type: Directory
+          name: cgroup
+  - agent: kubernetes
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.22 cluster
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-previous
+    decorate: true
+    extra_refs:
+      - base_ref: release-1.8
+        org: cert-manager
+        repo: cert-manager
+    interval: 2h
+    labels:
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-cloudflare-credentials: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-service-account: "true"
+    name: ci-cert-manager-previous-e2e-v1-22
+    spec:
+      containers:
+        - args:
+            - runner
+            - devel/ci-run-e2e.sh
+          env:
+            - name: K8S_VERSION
+              value: "1.22"
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: modules
+              readOnly: true
+            - mountPath: /sys/fs/cgroup
+              name: cgroup
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+      volumes:
+        - hostPath:
+            path: /lib/modules
+            type: Directory
+          name: modules
+        - hostPath:
+            path: /sys/fs/cgroup
+            type: Directory
+          name: cgroup
+  - agent: kubernetes
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.23 cluster
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-previous
+    decorate: true
+    extra_refs:
+      - base_ref: release-1.8
+        org: cert-manager
+        repo: cert-manager
+    interval: 2h
+    labels:
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-cloudflare-credentials: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-service-account: "true"
+    name: ci-cert-manager-previous-e2e-v1-23
+    spec:
+      containers:
+        - args:
+            - runner
+            - devel/ci-run-e2e.sh
+          env:
+            - name: K8S_VERSION
+              value: "1.23"
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: modules
+              readOnly: true
+            - mountPath: /sys/fs/cgroup
+              name: cgroup
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+      volumes:
+        - hostPath:
+            path: /lib/modules
+            type: Directory
+          name: modules
+        - hostPath:
+            path: /sys/fs/cgroup
+            type: Directory
+          name: cgroup
+  # This job uses make to invoke end-to-end tests as support for running jobs against 1.24
+  # was only backported into the make based e2e infra in the release-1.8 branch.
+  - agent: kubernetes
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.24 cluster
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-previous
+    decorate: true
+    extra_refs:
+      - base_ref: release-1.8
+        org: cert-manager
+        repo: cert-manager
+    interval: 2h
+    labels:
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-cloudflare-credentials: "true"
+      preset-default-e2e-volumes: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-make-volumes: "true"
+      preset-service-account: "true"
+    name: ci-cert-manager-previous-e2e-v1-24
+    spec:
+      containers:
+        - args:
+            - runner
+            - make
+            - -j
+            - vendor-go
+            - e2e-ci
+            - K8S_VERSION=1.24
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+  # This test runs Venafi (VaaS and TPP) tests once every 12hrs.
+  # This is the only CI test job that runs those.
+  - agent: kubernetes
+    annotations:
+      description: Runs Venafi (VaaS and TPP) e2e tests against Kubernetes v1.22 cluster
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-previous
+    decorate: true
+    extra_refs:
+      - base_ref: release-1.8
+        org: cert-manager
+        repo: cert-manager
+    interval: 12h
+    labels:
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-dind-enabled: "true"
+      preset-ginkgo-focus-venafi: "true"
+      preset-service-account: "true"
+      preset-venafi-cloud-credentials: "true"
+      preset-venafi-tpp-credentials: "true"
+    name: ci-cert-manager-previous-venafi
+    spec:
+      containers:
+        - args:
+            - runner
+            - devel/ci-run-e2e.sh
+          env:
+            - name: K8S_VERSION
+              value: "1.23"
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: modules
+              readOnly: true
+            - mountPath: /sys/fs/cgroup
+              name: cgroup
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+      volumes:
+        - hostPath:
+            path: /lib/modules
+            type: Directory
+          name: modules
+        - hostPath:
+            path: /sys/fs/cgroup
+            type: Directory
+          name: cgroup
+  - agent: kubernetes
+    annotations:
+      description: Runs cert-manager upgrade test every 8 hours
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-previous
+    decorate: true
+    # extra refs specify what repo should be cloned
+    extra_refs:
+      - base_ref: release-1.8
+        org: cert-manager
+        repo: cert-manager
+    interval: 8h
+    labels:
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-dind-enabled: "true"
+      preset-service-account: "true"
+    name: ci-cert-manager-previous-upgrade
+    spec:
+      containers:
+        - args:
+            - runner
+            - make
+            - cluster
+            - verify_upgrade
+          env:
+            - name: K8S_VERSION
+              value: "1.23"
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: modules
+              readOnly: true
+            - mountPath: /sys/fs/cgroup
+              name: cgroup
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+      volumes:
+        - hostPath:
+            path: /lib/modules
+            type: Directory
+          name: modules
+        - hostPath:
+            path: /sys/fs/cgroup
+            type: Directory
+          name: cgroup
+  - agent: kubernetes
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.18 cluster with all feature gates disabled
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-previous
+    decorate: true
+    extra_refs:
+      - base_ref: release-1.8
+        org: cert-manager
+        repo: cert-manager
+    interval: 24h
+    labels:
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-cloudflare-credentials: "true"
+      preset-dind-enabled: "true"
+      preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-retry-flakey-tests: "true"
+      preset-service-account: "true"
+    name: ci-cert-manager-previous-e2e-feature-gates-disabled-v1-18
+    spec:
+      containers:
+        - args:
+            - runner
+            - devel/ci-run-e2e.sh
+          env:
+            - name: K8S_VERSION
+              value: "1.18"
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: modules
+              readOnly: true
+            - mountPath: /sys/fs/cgroup
+              name: cgroup
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+      volumes:
+        - hostPath:
+            path: /lib/modules
+            type: Directory
+          name: modules
+        - hostPath:
+            path: /sys/fs/cgroup
+            type: Directory
+          name: cgroup
+  - agent: kubernetes
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.19 cluster with all feature gates disabled
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-previous
+    decorate: true
+    extra_refs:
+      - base_ref: release-1.8
+        org: cert-manager
+        repo: cert-manager
+    interval: 24h
+    labels:
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-cloudflare-credentials: "true"
+      preset-dind-enabled: "true"
+      preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-retry-flakey-tests: "true"
+      preset-service-account: "true"
+    name: ci-cert-manager-previous-e2e-feature-gates-disabled-v1-19
+    spec:
+      containers:
+        - args:
+            - runner
+            - devel/ci-run-e2e.sh
+          env:
+            - name: K8S_VERSION
+              value: "1.19"
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: modules
+              readOnly: true
+            - mountPath: /sys/fs/cgroup
+              name: cgroup
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+      volumes:
+        - hostPath:
+            path: /lib/modules
+            type: Directory
+          name: modules
+        - hostPath:
+            path: /sys/fs/cgroup
+            type: Directory
+          name: cgroup
+  - agent: kubernetes
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.20 cluster with all feature gates disabled
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-previous
+    decorate: true
+    extra_refs:
+      - base_ref: release-1.8
+        org: cert-manager
+        repo: cert-manager
+    interval: 24h
+    labels:
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-cloudflare-credentials: "true"
+      preset-dind-enabled: "true"
+      preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-retry-flakey-tests: "true"
+      preset-service-account: "true"
+    name: ci-cert-manager-previous-e2e-feature-gates-disabled-v1-20
+    spec:
+      containers:
+        - args:
+            - runner
+            - devel/ci-run-e2e.sh
+          env:
+            - name: K8S_VERSION
+              value: "1.20"
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: modules
+              readOnly: true
+            - mountPath: /sys/fs/cgroup
+              name: cgroup
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+      volumes:
+        - hostPath:
+            path: /lib/modules
+            type: Directory
+          name: modules
+        - hostPath:
+            path: /sys/fs/cgroup
+            type: Directory
+          name: cgroup
+  - agent: kubernetes
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.21 cluster with all feature gates disabled
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-previous
+    decorate: true
+    extra_refs:
+      - base_ref: release-1.8
+        org: cert-manager
+        repo: cert-manager
+    interval: 24h
+    labels:
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-cloudflare-credentials: "true"
+      preset-dind-enabled: "true"
+      preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-retry-flakey-tests: "true"
+      preset-service-account: "true"
+    name: ci-cert-manager-previous-e2e-feature-gates-disabled-v1-21
+    spec:
+      containers:
+        - args:
+            - runner
+            - devel/ci-run-e2e.sh
+          env:
+            - name: K8S_VERSION
+              value: "1.21"
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: modules
+              readOnly: true
+            - mountPath: /sys/fs/cgroup
+              name: cgroup
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+      volumes:
+        - hostPath:
+            path: /lib/modules
+            type: Directory
+          name: modules
+        - hostPath:
+            path: /sys/fs/cgroup
+            type: Directory
+          name: cgroup
+  - agent: kubernetes
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.22 cluster with all feature gates disabled
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-previous
+    decorate: true
+    extra_refs:
+      - base_ref: release-1.8
+        org: cert-manager
+        repo: cert-manager
+    interval: 24h
+    labels:
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-cloudflare-credentials: "true"
+      preset-dind-enabled: "true"
+      preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-retry-flakey-tests: "true"
+      preset-service-account: "true"
+    name: ci-cert-manager-previous-e2e-feature-gates-disabled-v1-22
+    spec:
+      containers:
+        - args:
+            - runner
+            - devel/ci-run-e2e.sh
+          env:
+            - name: K8S_VERSION
+              value: "1.22"
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: modules
+              readOnly: true
+            - mountPath: /sys/fs/cgroup
+              name: cgroup
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+      volumes:
+        - hostPath:
+            path: /lib/modules
+            type: Directory
+          name: modules
+        - hostPath:
+            path: /sys/fs/cgroup
+            type: Directory
+          name: cgroup
+  - agent: kubernetes
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.23 cluster with all feature gates disabled
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-previous
+    decorate: true
+    extra_refs:
+      - base_ref: release-1.8
+        org: cert-manager
+        repo: cert-manager
+    interval: 24h
+    labels:
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-cloudflare-credentials: "true"
+      preset-dind-enabled: "true"
+      preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-retry-flakey-tests: "true"
+      preset-service-account: "true"
+    name: ci-cert-manager-previous-e2e-feature-gates-disabled-v1-23
+    spec:
+      containers:
+        - args:
+            - runner
+            - devel/ci-run-e2e.sh
+          env:
+            - name: K8S_VERSION
+              value: "1.23"
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: modules
+              readOnly: true
+            - mountPath: /sys/fs/cgroup
+              name: cgroup
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+      volumes:
+        - hostPath:
+            path: /lib/modules
+            type: Directory
+          name: modules
+        - hostPath:
+            path: /sys/fs/cgroup
+            type: Directory
+          name: cgroup
+  # This job uses make to invoke end-to-end tests as support for running jobs against 1.24
+  # was only backported into the make based e2e infra in the release-1.8 branch.
+  - agent: kubernetes
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.24 cluster with all feature gates disabled
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: jetstack-cert-manager-previous
+    decorate: true
+    extra_refs:
+      - base_ref: release-1.8
+        org: cert-manager
+        repo: cert-manager
+    interval: 24h
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-default-e2e-volumes: "true"
+      preset-dind-enabled: "true"
+      preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-make-volumes: "true"
+      preset-retry-flakey-tests: "true"
+      preset-service-account: "true"
+    name: ci-cert-manager-previous-e2e-feature-gates-disabled-v1-24
+    spec:
+      containers:
+        - args:
+            - runner
+            - make
+            - -j
+            - vendor-go
+            - e2e-ci
+            - K8S_VERSION=1.24
+          image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+          resources:
+            requests:
+              cpu: 3500m
+              memory: 12Gi
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+            privileged: true
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"

--- a/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
@@ -1,916 +1,907 @@
 presubmits:
   cert-manager/cert-manager:
-
-  - name: pull-cert-manager-bazel-1.7
-    always_run: true
-    max_concurrency: 8
-    agent: kubernetes
-    decorate: true
-    branches:
-    # release-1.7 was released + built with bazel so we need to run all tests using bazel
-    - release-1.7
-    labels:
-      preset-service-account: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - bazel
-        - test
-        - --jobs=1
-        - //...
-        resources:
-          requests:
-            cpu: 2
-            memory: 4Gi
-      dnsConfig:
-        options:
-          - name: ndots
-            value: "1"
-
-  - name: pull-cert-manager-bazel-1.8
-    always_run: true
-    max_concurrency: 8
-    agent: kubernetes
-    decorate: true
-    branches:
-    # release-1.8 is tested via make, but there were still some leftover tests which were bazel-only
-    # as of the release of 1.8, so we need to run bazel test for 1.8 too.
-    # Still, the unit and integration tests _are_ running in make so we only need to run a subset of tests
-    # here
-    - release-1.8
-    labels:
-      preset-service-account: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - bazel
-        - test
-        - --jobs=1
-        - //hack/...
-        resources:
-          requests:
-            cpu: 1
-            memory: 2Gi
-      dnsConfig:
-        options:
-          - name: ndots
-            value: "1"
-
-  - name: pull-cert-manager-deps
-    always_run: true
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    branches:
-    # this test is not really valuable for release-1.8 since bazel isn't really used there
-    # still, we might as well run it just in case
-    - release-1.8
-    - release-1.7
-    labels:
-      preset-service-account: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - verify_deps
-        resources:
-          requests:
-            cpu: 2
-            memory: 4Gi
-      dnsConfig:
-        options:
-          - name: ndots
-            value: "1"
-
-  # Helm chart verification currently requires Docker.
-  # We maintain a standalone presubmit for running this.
-  # See https://github.com/helm/chart-testing/issues/53
-  - name: pull-cert-manager-chart
-    always_run: true
-    max_concurrency: 8
-    agent: kubernetes
-    decorate: true
-    branches:
-    - release-1.8
-    - release-1.7
-    annotations:
-      testgrid-create-test-group: 'false'
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - verify_chart
-        resources:
-          requests:
-            cpu: 1
-            memory: 1Gi
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-      dnsConfig:
-        options:
-          - name: ndots
-            value: "1"
-
-  - name: pull-cert-manager-make-test
-    always_run: true
-    optional: false
-    max_concurrency: 8
-    agent: kubernetes
-    decorate: true
-    branches:
-    # make testing not supported on release-1.7
-    - release-1.8
-    labels:
-      preset-service-account: "true"
-      preset-make-volumes: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args: # NB: for release-1.9 onwards, we'll also want to run the ci-presubmit target here, but that work is done by bazel for 1.8
-        - runner
-        - make
-        - -j
-        - vendor-go
-        - test-ci
-        resources:
-          requests:
-            cpu: 2
-            memory: 4Gi
-      dnsConfig:
-        options:
-          - name: ndots
-            value: "1"
-
-### E2E tests against all supported Kubernetes versions with all cert-manager alpha/beta feature gates enabled ###
-
-  - name: pull-cert-manager-e2e-v1-18
-    always_run: false
-    optional: true
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    branches:
-    # cert-manager 1.8 supports k8s 1.19+, so no need to run against release-1.8 here
-    - release-1.7
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-cloudflare-credentials: "true"
-      preset-retry-flakey-tests: "true"
-      preset-disable-alpha-enable-output-formats-feature-gates: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-default-e2e-volumes: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - devel/ci-run-e2e.sh
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        env:
-        - name: K8S_VERSION
-          value: "1.18"
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-
-  - name: pull-cert-manager-e2e-v1-19
-    always_run: false
-    optional: true
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    branches:
-    - release-1.7
-    - release-1.8
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-cloudflare-credentials: "true"
-      preset-retry-flakey-tests: "true"
-      preset-enable-all-feature-gates-disable-ssa: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-default-e2e-volumes: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - devel/ci-run-e2e.sh
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        env:
-        - name: K8S_VERSION
-          value: "1.19"
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-
-  - name: pull-cert-manager-e2e-v1-20
-    always_run: false
-    optional: true
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    branches:
-    - release-1.7
-    - release-1.8
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-cloudflare-credentials: "true"
-      preset-retry-flakey-tests: "true"
-      preset-enable-all-feature-gates-disable-ssa: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-default-e2e-volumes: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - devel/ci-run-e2e.sh
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        env:
-        - name: K8S_VERSION
-          value: "1.20"
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-
-  - name: pull-cert-manager-e2e-v1-21
-    always_run: false
-    optional: true
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    branches:
-    - release-1.7
-    - release-1.8
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-cloudflare-credentials: "true"
-      preset-retry-flakey-tests: "true"
-      preset-enable-all-feature-gates-disable-ssa: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-default-e2e-volumes: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - devel/ci-run-e2e.sh
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        env:
-        - name: K8S_VERSION
-          value: "1.21"
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-
-  - name: pull-cert-manager-e2e-v1-22
-    always_run: false
-    optional: true
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    branches:
-    - release-1.7
-    - release-1.8
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-cloudflare-credentials: "true"
-      preset-retry-flakey-tests: "true"
-      preset-enable-all-feature-gates: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-default-e2e-volumes: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - devel/ci-run-e2e.sh
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        env:
-        - name: K8S_VERSION
-          value: "1.22"
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-
-  - name: pull-cert-manager-e2e-v1-23
-    always_run: true
-    optional: false
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    branches:
-    - release-1.7
-    - release-1.8
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-cloudflare-credentials: "true"
-      preset-retry-flakey-tests: "true"
-      preset-enable-all-feature-gates: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-default-e2e-volumes: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - devel/ci-run-e2e.sh
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        env:
-        - name: K8S_VERSION
-          value: "1.23"
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-
-  - name: pull-cert-manager-e2e-v1-24
-    always_run: true
-    optional: false
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    branches:
-    - release-1.8
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-cloudflare-credentials: "true"
-      preset-retry-flakey-tests: "true"
-      preset-enable-all-feature-gates: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-make-volumes: "true"
-      preset-default-e2e-volumes: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.24
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-
-# Run with Bazel for release-1.7 where make was not available yet
-  - name: pull-cert-manager-e2e-v1-24
-    always_run: true
-    optional: false
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    branches:
-    - release-1.7
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-cloudflare-credentials: "true"
-      preset-retry-flakey-tests: "true"
-      preset-enable-all-feature-gates: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-default-e2e-volumes: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - devel/ci-run-e2e.sh
-        env:
-        - name: K8S_VERSION
-          value: "1.24"
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-
-### E2E tests against all supported Kubernetes versions with all cert-manager alpha/beta feature gates disabled ###
-
-  - name: pull-cert-manager-e2e-feature-gates-disabled-24
-    always_run: false
-    optional: true
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    branches:
-    - release-1.7
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-disable-all-alpha-beta-feature-gates: "true"
-      preset-cloudflare-credentials: "true"
-      preset-retry-flakey-tests: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-default-e2e-volumes: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - devel/ci-run-e2e.sh
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        env:
-        - name: K8S_VERSION
-          value: "1.24"
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-
-  - name: pull-cert-manager-e2e-feature-gates-disabled-24
-    always_run: false
-    optional: true
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    branches:
-    - release-1.8
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-disable-all-alpha-beta-feature-gates: "true"
-      preset-cloudflare-credentials: "true"
-      preset-retry-flakey-tests: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-default-e2e-volumes: "true"
-      preset-make-volumes: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.24
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-
-  - name: pull-cert-manager-e2e-feature-gates-disabled-23
-    always_run: false
-    optional: true
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    branches:
-    - release-1.7
-    - release-1.8
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-disable-all-alpha-beta-feature-gates: "true"
-      preset-cloudflare-credentials: "true"
-      preset-retry-flakey-tests: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-default-e2e-volumes: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - devel/ci-run-e2e.sh
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        env:
-        - name: K8S_VERSION
-          value: "1.23"
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-
-  - name: pull-cert-manager-e2e-feature-gates-disabled-22
-    always_run: false
-    optional: true
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    branches:
-    - release-1.7
-    - release-1.8
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-disable-all-alpha-beta-feature-gates: "true"
-      preset-cloudflare-credentials: "true"
-      preset-retry-flakey-tests: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-default-e2e-volumes: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - devel/ci-run-e2e.sh
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        env:
-        - name: K8S_VERSION
-          value: "1.22"
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-
-  - name: pull-cert-manager-e2e-feature-gates-disabled-21
-    always_run: false
-    optional: true
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    branches:
-    - release-1.7
-    - release-1.8
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-disable-all-alpha-beta-feature-gates: "true"
-      preset-cloudflare-credentials: "true"
-      preset-retry-flakey-tests: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-default-e2e-volumes: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - devel/ci-run-e2e.sh
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        env:
-        - name: K8S_VERSION
-          value: "1.21"
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-
-  - name: pull-cert-manager-e2e-feature-gates-disabled-20
-    always_run: false
-    optional: true
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    branches:
-    - release-1.7
-    - release-1.8
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-disable-all-alpha-beta-feature-gates: "true"
-      preset-cloudflare-credentials: "true"
-      preset-retry-flakey-tests: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-default-e2e-volumes: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - devel/ci-run-e2e.sh
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        env:
-        - name: K8S_VERSION
-          value: "1.20"
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-
-  - name: pull-cert-manager-e2e-feature-gates-disabled-19
-    always_run: false
-    optional: true
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    branches:
-    - release-1.7
-    - release-1.8
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-disable-all-alpha-beta-feature-gates: "true"
-      preset-cloudflare-credentials: "true"
-      preset-retry-flakey-tests: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-default-e2e-volumes: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - devel/ci-run-e2e.sh
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        env:
-        - name: K8S_VERSION
-          value: "1.19"
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-
-  - name: pull-cert-manager-e2e-feature-gates-disabled-18
-    always_run: false
-    optional: true
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    branches:
-    # not needed for release-1.8 as cert-manager 1.8 no longer supports Kubernetes 1.8
-    - release-1.7
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-disable-all-alpha-beta-feature-gates: "true"
-      preset-cloudflare-credentials: "true"
-      preset-retry-flakey-tests: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-default-e2e-volumes: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - devel/ci-run-e2e.sh
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        env:
-        - name: K8S_VERSION
-          value: "1.18"
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-
-#### E2E tests that are not included in the default test runs ###
-
-  # An E2E test job to allow us to manually trigger the Venafi Cloud E2E tests
-  # with the following GitHub comment:
-  #
-  #  /test pull-cert-manager-e2e-issuers-venafi-cloud-previous
-  #
-  # The regular presubmit jobs do not run Venafi Cloud e2e tests.
-  #
-  - name: pull-cert-manager-e2e-issuers-venafi-cloud-previous
-    always_run: false
-    optional: true
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    branches:
-    - release-1.8
-    - release-1.7
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-venafi-tpp-credentials: "true"
-      preset-retry-flakey-tests: "true"
-      preset-ginkgo-focus-venafi-tpp: "true"
-      preset-default-e2e-volumes: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - devel/ci-run-e2e.sh
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        env:
-        - name: K8S_VERSION
-          value: "1.23"
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-
-
-  # An E2E test job to allow us to manually trigger the Venafi TPP E2E tests
-  # with the following GitHub comment:
-  #
-  #  /test pull-cert-manager-e2e-issuers-venafi-tpp-previous
-  #
-  # The regular presubmit jobs do not run Venafi TPP e2e tests.
-  #
-  - name: pull-cert-manager-e2e-issuers-venafi-tpp-previous
-    always_run: false
-    optional: true
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    branches:
-    - release-1.8
-    - release-1.7
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-venafi-cloud-credentials: "true"
-      preset-retry-flakey-tests: "true"
-      preset-ginkgo-focus-venafi-cloud: "true"
-      preset-default-e2e-volumes: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - devel/ci-run-e2e.sh
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        env:
-        - name: K8S_VERSION
-          value: "1.23"
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
+    - agent: kubernetes
+      always_run: true
+      branches:
+        # release-1.7 was released + built with bazel so we need to run all tests using bazel
+        - release-1.7
+      decorate: true
+      labels:
+        preset-bazel-remote-cache-enabled: "true"
+        preset-bazel-scratch-dir: "true"
+        preset-service-account: "true"
+      max_concurrency: 8
+      name: pull-cert-manager-bazel-1.7
+      spec:
+        containers:
+          - args:
+              - runner
+              - bazel
+              - test
+              - --jobs=1
+              - //...
+            image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+            resources:
+              requests:
+                cpu: 2
+                memory: 4Gi
+        dnsConfig:
+          options:
+            - name: ndots
+              value: "1"
+    - agent: kubernetes
+      always_run: true
+      branches:
+        # release-1.8 is tested via make, but there were still some leftover tests which were bazel-only
+        # as of the release of 1.8, so we need to run bazel test for 1.8 too.
+        # Still, the unit and integration tests _are_ running in make so we only need to run a subset of tests
+        # here
+        - release-1.8
+      decorate: true
+      labels:
+        preset-bazel-remote-cache-enabled: "true"
+        preset-bazel-scratch-dir: "true"
+        preset-service-account: "true"
+      max_concurrency: 8
+      name: pull-cert-manager-bazel-1.8
+      spec:
+        containers:
+          - args:
+              - runner
+              - bazel
+              - test
+              - --jobs=1
+              - //hack/...
+            image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+            resources:
+              requests:
+                cpu: 1
+                memory: 2Gi
+        dnsConfig:
+          options:
+            - name: ndots
+              value: "1"
+    - agent: kubernetes
+      always_run: true
+      branches:
+        # this test is not really valuable for release-1.8 since bazel isn't really used there
+        # still, we might as well run it just in case
+        - release-1.8
+        - release-1.7
+      decorate: true
+      labels:
+        preset-bazel-remote-cache-enabled: "true"
+        preset-bazel-scratch-dir: "true"
+        preset-service-account: "true"
+      max_concurrency: 4
+      name: pull-cert-manager-deps
+      spec:
+        containers:
+          - args:
+              - runner
+              - make
+              - verify_deps
+            image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+            resources:
+              requests:
+                cpu: 2
+                memory: 4Gi
+        dnsConfig:
+          options:
+            - name: ndots
+              value: "1"
+    # Helm chart verification currently requires Docker.
+    # We maintain a standalone presubmit for running this.
+    # See https://github.com/helm/chart-testing/issues/53
+    - agent: kubernetes
+      always_run: true
+      annotations:
+        testgrid-create-test-group: "false"
+      branches:
+        - release-1.8
+        - release-1.7
+      decorate: true
+      labels:
+        preset-bazel-remote-cache-enabled: "true"
+        preset-bazel-scratch-dir: "true"
+        preset-dind-enabled: "true"
+        preset-service-account: "true"
+      max_concurrency: 8
+      name: pull-cert-manager-chart
+      spec:
+        containers:
+          - args:
+              - runner
+              - make
+              - verify_chart
+            image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+            resources:
+              requests:
+                cpu: 1
+                memory: 1Gi
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+        dnsConfig:
+          options:
+            - name: ndots
+              value: "1"
+    - agent: kubernetes
+      always_run: true
+      branches:
+        # make testing not supported on release-1.7
+        - release-1.8
+      decorate: true
+      labels:
+        preset-make-volumes: "true"
+        preset-service-account: "true"
+      max_concurrency: 8
+      name: pull-cert-manager-make-test
+      optional: false
+      spec:
+        containers:
+          - args: # NB: for release-1.9 onwards, we'll also want to run the ci-presubmit target here, but that work is done by bazel for 1.8
+              - runner
+              - make
+              - -j
+              - vendor-go
+              - test-ci
+            image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+            resources:
+              requests:
+                cpu: 2
+                memory: 4Gi
+        dnsConfig:
+          options:
+            - name: ndots
+              value: "1"
+              ### E2E tests against all supported Kubernetes versions with all cert-manager alpha/beta feature gates enabled ###
+    - agent: kubernetes
+      always_run: false
+      branches:
+        # cert-manager 1.8 supports k8s 1.19+, so no need to run against release-1.8 here
+        - release-1.7
+      decorate: true
+      labels:
+        preset-bazel-remote-cache-enabled: "true"
+        preset-bazel-scratch-dir: "true"
+        preset-cloudflare-credentials: "true"
+        preset-default-e2e-volumes: "true"
+        preset-dind-enabled: "true"
+        preset-disable-alpha-enable-output-formats-feature-gates: "true"
+        preset-ginkgo-skip-default: "true"
+        preset-retry-flakey-tests: "true"
+        preset-service-account: "true"
+      max_concurrency: 4
+      name: pull-cert-manager-e2e-v1-18
+      optional: true
+      spec:
+        containers:
+          - args:
+              - runner
+              - devel/ci-run-e2e.sh
+            env:
+              - name: K8S_VERSION
+                value: "1.18"
+            image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+            resources:
+              requests:
+                cpu: 3500m
+                memory: 12Gi
+            securityContext:
+              capabilities:
+                add:
+                  - SYS_ADMIN
+              privileged: true
+        dnsConfig:
+          options:
+            - name: ndots
+              value: "1"
+    - agent: kubernetes
+      always_run: false
+      branches:
+        - release-1.7
+        - release-1.8
+      decorate: true
+      labels:
+        preset-bazel-remote-cache-enabled: "true"
+        preset-bazel-scratch-dir: "true"
+        preset-cloudflare-credentials: "true"
+        preset-default-e2e-volumes: "true"
+        preset-dind-enabled: "true"
+        preset-enable-all-feature-gates-disable-ssa: "true"
+        preset-ginkgo-skip-default: "true"
+        preset-retry-flakey-tests: "true"
+        preset-service-account: "true"
+      max_concurrency: 4
+      name: pull-cert-manager-e2e-v1-19
+      optional: true
+      spec:
+        containers:
+          - args:
+              - runner
+              - devel/ci-run-e2e.sh
+            env:
+              - name: K8S_VERSION
+                value: "1.19"
+            image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+            resources:
+              requests:
+                cpu: 3500m
+                memory: 12Gi
+            securityContext:
+              capabilities:
+                add:
+                  - SYS_ADMIN
+              privileged: true
+        dnsConfig:
+          options:
+            - name: ndots
+              value: "1"
+    - agent: kubernetes
+      always_run: false
+      branches:
+        - release-1.7
+        - release-1.8
+      decorate: true
+      labels:
+        preset-bazel-remote-cache-enabled: "true"
+        preset-bazel-scratch-dir: "true"
+        preset-cloudflare-credentials: "true"
+        preset-default-e2e-volumes: "true"
+        preset-dind-enabled: "true"
+        preset-enable-all-feature-gates-disable-ssa: "true"
+        preset-ginkgo-skip-default: "true"
+        preset-retry-flakey-tests: "true"
+        preset-service-account: "true"
+      max_concurrency: 4
+      name: pull-cert-manager-e2e-v1-20
+      optional: true
+      spec:
+        containers:
+          - args:
+              - runner
+              - devel/ci-run-e2e.sh
+            env:
+              - name: K8S_VERSION
+                value: "1.20"
+            image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+            resources:
+              requests:
+                cpu: 3500m
+                memory: 12Gi
+            securityContext:
+              capabilities:
+                add:
+                  - SYS_ADMIN
+              privileged: true
+        dnsConfig:
+          options:
+            - name: ndots
+              value: "1"
+    - agent: kubernetes
+      always_run: false
+      branches:
+        - release-1.7
+        - release-1.8
+      decorate: true
+      labels:
+        preset-bazel-remote-cache-enabled: "true"
+        preset-bazel-scratch-dir: "true"
+        preset-cloudflare-credentials: "true"
+        preset-default-e2e-volumes: "true"
+        preset-dind-enabled: "true"
+        preset-enable-all-feature-gates-disable-ssa: "true"
+        preset-ginkgo-skip-default: "true"
+        preset-retry-flakey-tests: "true"
+        preset-service-account: "true"
+      max_concurrency: 4
+      name: pull-cert-manager-e2e-v1-21
+      optional: true
+      spec:
+        containers:
+          - args:
+              - runner
+              - devel/ci-run-e2e.sh
+            env:
+              - name: K8S_VERSION
+                value: "1.21"
+            image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+            resources:
+              requests:
+                cpu: 3500m
+                memory: 12Gi
+            securityContext:
+              capabilities:
+                add:
+                  - SYS_ADMIN
+              privileged: true
+        dnsConfig:
+          options:
+            - name: ndots
+              value: "1"
+    - agent: kubernetes
+      always_run: false
+      branches:
+        - release-1.7
+        - release-1.8
+      decorate: true
+      labels:
+        preset-bazel-remote-cache-enabled: "true"
+        preset-bazel-scratch-dir: "true"
+        preset-cloudflare-credentials: "true"
+        preset-default-e2e-volumes: "true"
+        preset-dind-enabled: "true"
+        preset-enable-all-feature-gates: "true"
+        preset-ginkgo-skip-default: "true"
+        preset-retry-flakey-tests: "true"
+        preset-service-account: "true"
+      max_concurrency: 4
+      name: pull-cert-manager-e2e-v1-22
+      optional: true
+      spec:
+        containers:
+          - args:
+              - runner
+              - devel/ci-run-e2e.sh
+            env:
+              - name: K8S_VERSION
+                value: "1.22"
+            image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+            resources:
+              requests:
+                cpu: 3500m
+                memory: 12Gi
+            securityContext:
+              capabilities:
+                add:
+                  - SYS_ADMIN
+              privileged: true
+        dnsConfig:
+          options:
+            - name: ndots
+              value: "1"
+    - agent: kubernetes
+      always_run: true
+      branches:
+        - release-1.7
+        - release-1.8
+      decorate: true
+      labels:
+        preset-bazel-remote-cache-enabled: "true"
+        preset-bazel-scratch-dir: "true"
+        preset-cloudflare-credentials: "true"
+        preset-default-e2e-volumes: "true"
+        preset-dind-enabled: "true"
+        preset-enable-all-feature-gates: "true"
+        preset-ginkgo-skip-default: "true"
+        preset-retry-flakey-tests: "true"
+        preset-service-account: "true"
+      max_concurrency: 4
+      name: pull-cert-manager-e2e-v1-23
+      optional: false
+      spec:
+        containers:
+          - args:
+              - runner
+              - devel/ci-run-e2e.sh
+            env:
+              - name: K8S_VERSION
+                value: "1.23"
+            image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+            resources:
+              requests:
+                cpu: 3500m
+                memory: 12Gi
+            securityContext:
+              capabilities:
+                add:
+                  - SYS_ADMIN
+              privileged: true
+        dnsConfig:
+          options:
+            - name: ndots
+              value: "1"
+    - agent: kubernetes
+      always_run: true
+      branches:
+        - release-1.8
+      decorate: true
+      labels:
+        preset-cloudflare-credentials: "true"
+        preset-default-e2e-volumes: "true"
+        preset-dind-enabled: "true"
+        preset-enable-all-feature-gates: "true"
+        preset-ginkgo-skip-default: "true"
+        preset-make-volumes: "true"
+        preset-retry-flakey-tests: "true"
+        preset-service-account: "true"
+      max_concurrency: 4
+      name: pull-cert-manager-e2e-v1-24
+      optional: false
+      spec:
+        containers:
+          - args:
+              - runner
+              - make
+              - -j
+              - vendor-go
+              - e2e-ci
+              - K8S_VERSION=1.24
+            image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+            resources:
+              requests:
+                cpu: 3500m
+                memory: 12Gi
+            securityContext:
+              capabilities:
+                add:
+                  - SYS_ADMIN
+              privileged: true
+        dnsConfig:
+          options:
+            - name: ndots
+              value: "1"
+              # Run with Bazel for release-1.7 where make was not available yet
+    - agent: kubernetes
+      always_run: true
+      branches:
+        - release-1.7
+      decorate: true
+      labels:
+        preset-cloudflare-credentials: "true"
+        preset-default-e2e-volumes: "true"
+        preset-dind-enabled: "true"
+        preset-enable-all-feature-gates: "true"
+        preset-ginkgo-skip-default: "true"
+        preset-retry-flakey-tests: "true"
+        preset-service-account: "true"
+      max_concurrency: 4
+      name: pull-cert-manager-e2e-v1-24
+      optional: false
+      spec:
+        containers:
+          - args:
+              - runner
+              - devel/ci-run-e2e.sh
+            env:
+              - name: K8S_VERSION
+                value: "1.24"
+            image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+            resources:
+              requests:
+                cpu: 3500m
+                memory: 12Gi
+            securityContext:
+              capabilities:
+                add:
+                  - SYS_ADMIN
+              privileged: true
+        dnsConfig:
+          options:
+            - name: ndots
+              value: "1"
+              ### E2E tests against all supported Kubernetes versions with all cert-manager alpha/beta feature gates disabled ###
+    - agent: kubernetes
+      always_run: false
+      branches:
+        - release-1.7
+      decorate: true
+      labels:
+        preset-bazel-remote-cache-enabled: "true"
+        preset-bazel-scratch-dir: "true"
+        preset-cloudflare-credentials: "true"
+        preset-default-e2e-volumes: "true"
+        preset-dind-enabled: "true"
+        preset-disable-all-alpha-beta-feature-gates: "true"
+        preset-ginkgo-skip-default: "true"
+        preset-retry-flakey-tests: "true"
+        preset-service-account: "true"
+      max_concurrency: 4
+      name: pull-cert-manager-e2e-feature-gates-disabled-24
+      optional: true
+      spec:
+        containers:
+          - args:
+              - runner
+              - devel/ci-run-e2e.sh
+            env:
+              - name: K8S_VERSION
+                value: "1.24"
+            image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+            resources:
+              requests:
+                cpu: 3500m
+                memory: 12Gi
+            securityContext:
+              capabilities:
+                add:
+                  - SYS_ADMIN
+              privileged: true
+        dnsConfig:
+          options:
+            - name: ndots
+              value: "1"
+    - agent: kubernetes
+      always_run: false
+      branches:
+        - release-1.8
+      decorate: true
+      labels:
+        preset-bazel-remote-cache-enabled: "true"
+        preset-bazel-scratch-dir: "true"
+        preset-cloudflare-credentials: "true"
+        preset-default-e2e-volumes: "true"
+        preset-dind-enabled: "true"
+        preset-disable-all-alpha-beta-feature-gates: "true"
+        preset-ginkgo-skip-default: "true"
+        preset-make-volumes: "true"
+        preset-retry-flakey-tests: "true"
+        preset-service-account: "true"
+      max_concurrency: 4
+      name: pull-cert-manager-e2e-feature-gates-disabled-24
+      optional: true
+      spec:
+        containers:
+          - args:
+              - runner
+              - make
+              - -j
+              - vendor-go
+              - e2e-ci
+              - K8S_VERSION=1.24
+            image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+            resources:
+              requests:
+                cpu: 3500m
+                memory: 12Gi
+            securityContext:
+              capabilities:
+                add:
+                  - SYS_ADMIN
+              privileged: true
+        dnsConfig:
+          options:
+            - name: ndots
+              value: "1"
+    - agent: kubernetes
+      always_run: false
+      branches:
+        - release-1.7
+        - release-1.8
+      decorate: true
+      labels:
+        preset-bazel-remote-cache-enabled: "true"
+        preset-bazel-scratch-dir: "true"
+        preset-cloudflare-credentials: "true"
+        preset-default-e2e-volumes: "true"
+        preset-dind-enabled: "true"
+        preset-disable-all-alpha-beta-feature-gates: "true"
+        preset-ginkgo-skip-default: "true"
+        preset-retry-flakey-tests: "true"
+        preset-service-account: "true"
+      max_concurrency: 4
+      name: pull-cert-manager-e2e-feature-gates-disabled-23
+      optional: true
+      spec:
+        containers:
+          - args:
+              - runner
+              - devel/ci-run-e2e.sh
+            env:
+              - name: K8S_VERSION
+                value: "1.23"
+            image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+            resources:
+              requests:
+                cpu: 3500m
+                memory: 12Gi
+            securityContext:
+              capabilities:
+                add:
+                  - SYS_ADMIN
+              privileged: true
+        dnsConfig:
+          options:
+            - name: ndots
+              value: "1"
+    - agent: kubernetes
+      always_run: false
+      branches:
+        - release-1.7
+        - release-1.8
+      decorate: true
+      labels:
+        preset-bazel-remote-cache-enabled: "true"
+        preset-bazel-scratch-dir: "true"
+        preset-cloudflare-credentials: "true"
+        preset-default-e2e-volumes: "true"
+        preset-dind-enabled: "true"
+        preset-disable-all-alpha-beta-feature-gates: "true"
+        preset-ginkgo-skip-default: "true"
+        preset-retry-flakey-tests: "true"
+        preset-service-account: "true"
+      max_concurrency: 4
+      name: pull-cert-manager-e2e-feature-gates-disabled-22
+      optional: true
+      spec:
+        containers:
+          - args:
+              - runner
+              - devel/ci-run-e2e.sh
+            env:
+              - name: K8S_VERSION
+                value: "1.22"
+            image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+            resources:
+              requests:
+                cpu: 3500m
+                memory: 12Gi
+            securityContext:
+              capabilities:
+                add:
+                  - SYS_ADMIN
+              privileged: true
+        dnsConfig:
+          options:
+            - name: ndots
+              value: "1"
+    - agent: kubernetes
+      always_run: false
+      branches:
+        - release-1.7
+        - release-1.8
+      decorate: true
+      labels:
+        preset-bazel-remote-cache-enabled: "true"
+        preset-bazel-scratch-dir: "true"
+        preset-cloudflare-credentials: "true"
+        preset-default-e2e-volumes: "true"
+        preset-dind-enabled: "true"
+        preset-disable-all-alpha-beta-feature-gates: "true"
+        preset-ginkgo-skip-default: "true"
+        preset-retry-flakey-tests: "true"
+        preset-service-account: "true"
+      max_concurrency: 4
+      name: pull-cert-manager-e2e-feature-gates-disabled-21
+      optional: true
+      spec:
+        containers:
+          - args:
+              - runner
+              - devel/ci-run-e2e.sh
+            env:
+              - name: K8S_VERSION
+                value: "1.21"
+            image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+            resources:
+              requests:
+                cpu: 3500m
+                memory: 12Gi
+            securityContext:
+              capabilities:
+                add:
+                  - SYS_ADMIN
+              privileged: true
+        dnsConfig:
+          options:
+            - name: ndots
+              value: "1"
+    - agent: kubernetes
+      always_run: false
+      branches:
+        - release-1.7
+        - release-1.8
+      decorate: true
+      labels:
+        preset-bazel-remote-cache-enabled: "true"
+        preset-bazel-scratch-dir: "true"
+        preset-cloudflare-credentials: "true"
+        preset-default-e2e-volumes: "true"
+        preset-dind-enabled: "true"
+        preset-disable-all-alpha-beta-feature-gates: "true"
+        preset-ginkgo-skip-default: "true"
+        preset-retry-flakey-tests: "true"
+        preset-service-account: "true"
+      max_concurrency: 4
+      name: pull-cert-manager-e2e-feature-gates-disabled-20
+      optional: true
+      spec:
+        containers:
+          - args:
+              - runner
+              - devel/ci-run-e2e.sh
+            env:
+              - name: K8S_VERSION
+                value: "1.20"
+            image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+            resources:
+              requests:
+                cpu: 3500m
+                memory: 12Gi
+            securityContext:
+              capabilities:
+                add:
+                  - SYS_ADMIN
+              privileged: true
+        dnsConfig:
+          options:
+            - name: ndots
+              value: "1"
+    - agent: kubernetes
+      always_run: false
+      branches:
+        - release-1.7
+        - release-1.8
+      decorate: true
+      labels:
+        preset-bazel-remote-cache-enabled: "true"
+        preset-bazel-scratch-dir: "true"
+        preset-cloudflare-credentials: "true"
+        preset-default-e2e-volumes: "true"
+        preset-dind-enabled: "true"
+        preset-disable-all-alpha-beta-feature-gates: "true"
+        preset-ginkgo-skip-default: "true"
+        preset-retry-flakey-tests: "true"
+        preset-service-account: "true"
+      max_concurrency: 4
+      name: pull-cert-manager-e2e-feature-gates-disabled-19
+      optional: true
+      spec:
+        containers:
+          - args:
+              - runner
+              - devel/ci-run-e2e.sh
+            env:
+              - name: K8S_VERSION
+                value: "1.19"
+            image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+            resources:
+              requests:
+                cpu: 3500m
+                memory: 12Gi
+            securityContext:
+              capabilities:
+                add:
+                  - SYS_ADMIN
+              privileged: true
+        dnsConfig:
+          options:
+            - name: ndots
+              value: "1"
+    - agent: kubernetes
+      always_run: false
+      branches:
+        # not needed for release-1.8 as cert-manager 1.8 no longer supports Kubernetes 1.8
+        - release-1.7
+      decorate: true
+      labels:
+        preset-bazel-remote-cache-enabled: "true"
+        preset-bazel-scratch-dir: "true"
+        preset-cloudflare-credentials: "true"
+        preset-default-e2e-volumes: "true"
+        preset-dind-enabled: "true"
+        preset-disable-all-alpha-beta-feature-gates: "true"
+        preset-ginkgo-skip-default: "true"
+        preset-retry-flakey-tests: "true"
+        preset-service-account: "true"
+      max_concurrency: 4
+      name: pull-cert-manager-e2e-feature-gates-disabled-18
+      optional: true
+      spec:
+        containers:
+          - args:
+              - runner
+              - devel/ci-run-e2e.sh
+            env:
+              - name: K8S_VERSION
+                value: "1.18"
+            image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+            resources:
+              requests:
+                cpu: 3500m
+                memory: 12Gi
+            securityContext:
+              capabilities:
+                add:
+                  - SYS_ADMIN
+              privileged: true
+        dnsConfig:
+          options:
+            - name: ndots
+              value: "1"
+              #### E2E tests that are not included in the default test runs ###
+    # An E2E test job to allow us to manually trigger the Venafi Cloud E2E tests
+    # with the following GitHub comment:
+    #
+    #  /test pull-cert-manager-e2e-issuers-venafi-cloud-previous
+    #
+    # The regular presubmit jobs do not run Venafi Cloud e2e tests.
+    #
+    - agent: kubernetes
+      always_run: false
+      branches:
+        - release-1.8
+        - release-1.7
+      decorate: true
+      labels:
+        preset-bazel-remote-cache-enabled: "true"
+        preset-bazel-scratch-dir: "true"
+        preset-default-e2e-volumes: "true"
+        preset-dind-enabled: "true"
+        preset-ginkgo-focus-venafi-tpp: "true"
+        preset-retry-flakey-tests: "true"
+        preset-service-account: "true"
+        preset-venafi-tpp-credentials: "true"
+      max_concurrency: 4
+      name: pull-cert-manager-e2e-issuers-venafi-cloud-previous
+      optional: true
+      spec:
+        containers:
+          - args:
+              - runner
+              - devel/ci-run-e2e.sh
+            env:
+              - name: K8S_VERSION
+                value: "1.23"
+            image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+            resources:
+              requests:
+                cpu: 3500m
+                memory: 12Gi
+            securityContext:
+              capabilities:
+                add:
+                  - SYS_ADMIN
+              privileged: true
+        dnsConfig:
+          options:
+            - name: ndots
+              value: "1"
+    # An E2E test job to allow us to manually trigger the Venafi TPP E2E tests
+    # with the following GitHub comment:
+    #
+    #  /test pull-cert-manager-e2e-issuers-venafi-tpp-previous
+    #
+    # The regular presubmit jobs do not run Venafi TPP e2e tests.
+    #
+    - agent: kubernetes
+      always_run: false
+      branches:
+        - release-1.8
+        - release-1.7
+      decorate: true
+      labels:
+        preset-bazel-remote-cache-enabled: "true"
+        preset-bazel-scratch-dir: "true"
+        preset-default-e2e-volumes: "true"
+        preset-dind-enabled: "true"
+        preset-ginkgo-focus-venafi-cloud: "true"
+        preset-retry-flakey-tests: "true"
+        preset-service-account: "true"
+        preset-venafi-cloud-credentials: "true"
+      max_concurrency: 4
+      name: pull-cert-manager-e2e-issuers-venafi-tpp-previous
+      optional: true
+      spec:
+        containers:
+          - args:
+              - runner
+              - devel/ci-run-e2e.sh
+            env:
+              - name: K8S_VERSION
+                value: "1.23"
+            image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+            resources:
+              requests:
+                cpu: 3500m
+                memory: 12Gi
+            securityContext:
+              capabilities:
+                add:
+                  - SYS_ADMIN
+              privileged: true
+        dnsConfig:
+          options:
+            - name: ndots
+              value: "1"


### PR DESCRIPTION
This was done using the following `yq` command:

```console
yq -i -P 'sort_keys(..)' filename.yaml
```

this will make it much easier to compare any changes resulting from switching to autogenerated test specs down the line!