### PR TITLE
Test using cron periodics rather than intervals

### DIFF
--- a/config/jobs/cert-manager/cert-manager/cert-manager-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager/cert-manager-periodics.yaml
@@ -394,7 +394,9 @@ periodics:
 #           memory: 12Gi
 
 - name: ci-cert-manager-e2e-feature-gates-disabled-v1-20
-  interval: 24h
+  cron: "25 */24 * * *" # this is a manual test to check if our current prow deployment supports cron style periodics
+                       # instead of only intervals
+  # interval: 24h
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -438,7 +440,9 @@ periodics:
           value: "1"
 
 - name: ci-cert-manager-e2e-feature-gates-disabled-v1-21
-  interval: 24h
+  cron: "20 */24 * * *" # this is a manual test to check if our current prow deployment supports cron style periodics
+                       # instead of only intervals
+  # interval: 24h
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -482,7 +486,9 @@ periodics:
           value: "1"
 
 - name: ci-cert-manager-e2e-feature-gates-disabled-v1-22
-  interval: 24h
+  cron: "15 */24 * * *" # this is a manual test to check if our current prow deployment supports cron style periodics
+                       # instead of only intervals
+  # interval: 24h
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -526,7 +532,9 @@ periodics:
           value: "1"
 
 - name: ci-cert-manager-e2e-feature-gates-disabled-v1-23
-  interval: 24h
+  cron: "10 */24 * * *" # this is a manual test to check if our current prow deployment supports cron style periodics
+                       # instead of only intervals
+  # interval: 24h
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -570,7 +578,9 @@ periodics:
           value: "1"
 
 - name: ci-cert-manager-e2e-feature-gates-disabled-v1-24
-  interval: 24h
+  cron: "5 */24 * * *" # this is a manual test to check if our current prow deployment supports cron style periodics
+                       # instead of only intervals
+  #interval: 24h
   agent: kubernetes
   decorate: true
   extra_refs:


### PR DESCRIPTION
If we move to [generating our tests](https://github.com/cert-manager/release/pull/80), we can have our generator automatically spread periodics throughout the hour using cron-style definitions intead of intervals.

This should ensure that we avoid situations where we have a tonne of tests which all run on the hour causing a spike in resources but leaving the cluster less utilized the rest of the time.

This is a manual test to check that cron-style jobs work on our deployed version of prow today.

The actual test definitions changed here were chosen arbitrarily.