### PR TITLE
Mount bindir appropriately for older release tests

### DIFF
--- a/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-periodics.yaml
@@ -410,7 +410,7 @@ periodics:
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
     preset-default-e2e-volumes: "true"
-    preset-make-volumes: "true"
+    preset-make-volumes-oldbindir: "true"
   spec:
     containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -922,7 +922,7 @@ periodics:
     preset-cloudflare-credentials: "true"
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-retry-flakey-tests: "true"
-    preset-make-volumes: "true"
+    preset-make-volumes-oldbindir: "true"
     preset-default-e2e-volumes: "true"
   spec:
     containers:

--- a/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-previous/cert-manager-release-previous-presubmits.yaml
@@ -142,7 +142,7 @@ presubmits:
     - release-1.8
     labels:
       preset-service-account: "true"
-      preset-make-volumes: "true"
+      preset-make-volumes-oldbindir: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
@@ -424,7 +424,7 @@ presubmits:
       preset-retry-flakey-tests: "true"
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
-      preset-make-volumes: "true"
+      preset-make-volumes-oldbindir: "true"
       preset-default-e2e-volumes: "true"
     spec:
       containers:
@@ -548,7 +548,7 @@ presubmits:
       preset-retry-flakey-tests: "true"
       preset-ginkgo-skip-default: "true"
       preset-default-e2e-volumes: "true"
-      preset-make-volumes: "true"
+      preset-make-volumes-oldbindir: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1

--- a/config/jobs/cert-manager/config.yaml
+++ b/config/jobs/cert-manager/config.yaml
@@ -173,6 +173,32 @@ presets:
       path: /tmp/bindownloaded
       type: DirectoryOrCreate
 
+
+# Similar to preset-make-volumes but mounts the directory as "bin" rather than "_bin", to
+# match how the directories were used for release-1.8
+- labels:
+    preset-make-volumes-oldbindir: "true"
+  volumeMounts:
+  - mountPath: /root/.cache/go-build
+    name: gocache
+  - mountPath: /home/prow/go/pkg/mod
+    name: gopkgmod
+  - mountPath: /home/prow/go/src/github.com/cert-manager/cert-manager/bin/downloaded
+    name: bindownloaded
+  volumes:
+  - name: gocache
+    hostPath:
+      path: /tmp/gocache
+      type: DirectoryOrCreate
+  - name: gopkgmod
+    hostPath:
+      path: /tmp/gopkgmod
+      type: DirectoryOrCreate
+  - name: bindownloaded
+    hostPath:
+      path: /tmp/bindownloaded
+      type: DirectoryOrCreate
+
 # This preset should be added to all e2e tests to ensure Docker (used to spin up
 # Kind clusters) can be set up.
 - labels:


### PR DESCRIPTION
We changed the mount point to _bin for tests against master and new releases because that's the new name of the bindir

The bindir changes weren't backported into release-1.8 and so this means we don't make use of the bin/downloaded cache on release-1.8

This change will allow us to use that same cache for more dependencies