### PR TITLE
Run upgrade test every hour

### DIFF
--- a/config/jobs/cert-manager/cert-manager/release-next/cert-manager-release-next-periodics.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-next/cert-manager-release-next-periodics.yaml
@@ -304,7 +304,7 @@ periodics:
           value: "1"
 
 - name: ci-cert-manager-next-upgrade
-  interval: 8h
+  cron: "45 */1 * * *"
   agent: kubernetes
   decorate: true
   # extra refs specify what repo should be cloned


### PR DESCRIPTION
This is temporary to ensure the test is reliable before we release 1.9

As discussed [on slack](https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1657120059312519)