### PR TITLE
Add cosign to bazel-tools image

### DIFF
--- a/images/bazel-tools/Dockerfile
+++ b/images/bazel-tools/Dockerfile
@@ -22,17 +22,17 @@ LABEL maintainer="cert-manager-maintainers@googlegroups.com"
 COPY semversort.sh /usr/local/bin/semversort
 
 ARG NODE_VERSION
-# install goversion, gcrane, gh cli, jq and node
+# install goversion, gcrane, cosign, gh cli, jq and node
 RUN go install github.com/cert-manager/goversion@v1.3.0 && \
-    go install github.com/google/go-containerregistry/cmd/gcrane@v0.9.0 && \
-    go install github.com/sigstore/cosign/cmd/cosign@v1.10.1 \
+    go install github.com/sigstore/cosign/cmd/cosign@v1.10.1 && \
+    go install github.com/google/go-containerregistry/cmd/gcrane@v0.11.0 && \
     apt-get update && \
     apt-get install -y \
     nodejs=${NODE_VERSION} && \
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
     apt update && \
-    apt install gh=2.13.0
+    apt install gh=2.14.4
 
 # Add GOPATH/bin to PATH
 ENV PATH=/root/go/bin:$PATH

--- a/images/bazel-tools/Dockerfile
+++ b/images/bazel-tools/Dockerfile
@@ -25,6 +25,7 @@ ARG NODE_VERSION
 # install goversion, gcrane, gh cli, jq and node
 RUN go install github.com/cert-manager/goversion@v1.3.0 && \
     go install github.com/google/go-containerregistry/cmd/gcrane@v0.9.0 && \
+    go install github.com/sigstore/cosign/cmd/cosign@v1.10.1 \
     apt-get update && \
     apt-get install -y \
     nodejs=${NODE_VERSION} && \

--- a/images/bazel-tools/build.yaml
+++ b/images/bazel-tools/build.yaml
@@ -3,11 +3,11 @@ name: bazel-tools # Name of the image to be built
 variants:
   "10.24":
     arguments:
-      BASE_IMAGE: "eu.gcr.io/jetstack-build-infra-images/golang-dind@sha256:5f966580a1f9700b03fa2072f65c91ee0711d314163bef13f06f75fd196e92cb"
+      BASE_IMAGE: "eu.gcr.io/jetstack-build-infra-images/golang-dind@sha256:9259980d824f75fd3274ad68115b6b06d64f2db441ae52b58c31542f6e75c616"
       # Version of Bazel that is bundled in the BASE_IMAGE
       BAZEL_VERSION: "4.2.1"
       # Version of Go that is bundled in the BASE_IMAGE
-      GO_VERSION: "1.18"
+      GO_VERSION: "1.19"
       NODE_VERSION: "12.22.12~dfsg-1~deb11u1"
       # This NODE_DOCKER_TAG is the Docker tag that corresponds to the Node version
       # we use. We don't use the Node version directly because it is not a valid


### PR DESCRIPTION
This PR makes a couple changes to 'bazel-tools' image:
- adds cosign
- bumps versions of gcrane and GH CLI
- bumps version of base image (Go 1.18 -> Go 1.19)