### PR TITLE
add gcr.io registry mirror to bazelbuild

### DIFF
--- a/images/bazelbuild/Dockerfile
+++ b/images/bazelbuild/Dockerfile
@@ -53,8 +53,8 @@ RUN apt-get update && \
     && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
 
 
-# Move Docker's storage location & enable experimental features
-RUN echo 'DOCKER_OPTS="${DOCKER_OPTS} --data-root=/docker-graph --experimental"' | \
+# Move Docker's storage location & enable experimental features & add Container Registry cache (see: https://cloud.google.com/container-registry/docs/pulling-cached-images)
+RUN echo 'DOCKER_OPTS="${DOCKER_OPTS} --data-root=/docker-graph --experimental --registry-mirror=https://mirror.gcr.io"' | \
     tee --append /etc/default/docker
 # NOTE this should be mounted and persisted as a volume ideally (!)
 # We will make a fallback one now just in case


### PR DESCRIPTION
This PR updates the bazelbuild image to use `mirror.gcr.io` as a registry mirror, á la https://cloud.google.com/container-registry/docs/pulling-cached-images

This is to fix prow jobs that fail due to temporary Docker Hub service outages, such as:

- https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/logs/ci-cert-manager-release-1.9-e2e-v1-22/1556489054139191296
- https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/logs/ci-cert-manager-master-e2e-v1-24/1556580406508130304

Signed-off-by: Joakim Ahrlin <joakim.ahrlin@gmail.com>