### PR TITLE
update bazelbuild image for cert-manager-master to bazelbuild:20220812-2f64076-4.2.1

### DIFF
--- a/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
+++ b/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
@@ -18,7 +18,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220629-ee75d11-4.2.1
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220812-2f64076-4.2.1
         args:
         - runner
         - make
@@ -53,7 +53,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220629-ee75d11-4.2.1
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220812-2f64076-4.2.1
         args:
         - runner
         - make
@@ -93,7 +93,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220629-ee75d11-4.2.1
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220812-2f64076-4.2.1
         args:
         - runner
         - make
@@ -138,7 +138,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220629-ee75d11-4.2.1
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220812-2f64076-4.2.1
         args:
         - runner
         - make
@@ -183,7 +183,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220629-ee75d11-4.2.1
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220812-2f64076-4.2.1
         args:
         - runner
         - make
@@ -228,7 +228,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220629-ee75d11-4.2.1
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220812-2f64076-4.2.1
         args:
         - runner
         - make
@@ -273,7 +273,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220629-ee75d11-4.2.1
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220812-2f64076-4.2.1
         args:
         - runner
         - make
@@ -314,7 +314,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220629-ee75d11-4.2.1
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220812-2f64076-4.2.1
         args:
         - runner
         - make
@@ -357,7 +357,7 @@ presubmits:
       preset-venafi-tpp-credentials: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220629-ee75d11-4.2.1
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220812-2f64076-4.2.1
         args:
         - runner
         - make
@@ -401,7 +401,7 @@ presubmits:
       preset-venafi-cloud-credentials: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220629-ee75d11-4.2.1
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220812-2f64076-4.2.1
         args:
         - runner
         - make
@@ -446,7 +446,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220629-ee75d11-4.2.1
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220812-2f64076-4.2.1
         args:
         - runner
         - make
@@ -486,7 +486,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220629-ee75d11-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220812-2f64076-4.2.1
       args:
       - runner
       - make
@@ -527,7 +527,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220629-ee75d11-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220812-2f64076-4.2.1
       args:
       - runner
       - make
@@ -573,7 +573,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220629-ee75d11-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220812-2f64076-4.2.1
       args:
       - runner
       - make
@@ -619,7 +619,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220629-ee75d11-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220812-2f64076-4.2.1
       args:
       - runner
       - make
@@ -665,7 +665,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220629-ee75d11-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220812-2f64076-4.2.1
       args:
       - runner
       - make
@@ -711,7 +711,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220629-ee75d11-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220812-2f64076-4.2.1
       args:
       - runner
       - make
@@ -757,7 +757,7 @@ periodics:
     preset-venafi-tpp-credentials: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220629-ee75d11-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220812-2f64076-4.2.1
       args:
       - runner
       - make
@@ -799,7 +799,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220629-ee75d11-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220812-2f64076-4.2.1
       args:
       - runner
       - make
@@ -844,7 +844,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220629-ee75d11-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220812-2f64076-4.2.1
       args:
       - runner
       - make
@@ -890,7 +890,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220629-ee75d11-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220812-2f64076-4.2.1
       args:
       - runner
       - make
@@ -936,7 +936,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220629-ee75d11-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220812-2f64076-4.2.1
       args:
       - runner
       - make
@@ -982,7 +982,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220629-ee75d11-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220812-2f64076-4.2.1
       args:
       - runner
       - make
@@ -1028,7 +1028,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220629-ee75d11-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220812-2f64076-4.2.1
       args:
       - runner
       - make
@@ -1069,7 +1069,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220629-ee75d11-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220812-2f64076-4.2.1
       args:
       - runner
       - make
@@ -1104,7 +1104,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220629-ee75d11-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220812-2f64076-4.2.1
       args:
       - runner
       - make
@@ -1139,7 +1139,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220629-ee75d11-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220812-2f64076-4.2.1
       args:
       - runner
       - make
@@ -1174,7 +1174,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220629-ee75d11-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220812-2f64076-4.2.1
       args:
       - runner
       - make
@@ -1209,7 +1209,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220629-ee75d11-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220812-2f64076-4.2.1
       args:
       - runner
       - make


### PR DESCRIPTION
This PR updates the image used for cert-manager-master periodics to use the latest bazelbuild image, which includes using a registry mirror, see https://github.com/jetstack/testing/pull/739

I'd like to roll it out for these jobs first to make sure it works, and then I'll roll it out for release-1.8 and release-1.9 and I'll update `cmrel` also

Signed-off-by: Joakim Ahrlin <joakim.ahrlin@gmail.com>