### PR TITLE
Change cert-manager/cert-manager required contexts to be per branch.

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -34,12 +34,32 @@ branch-protection:
         - dco
       repos:
         cert-manager:
-          required_status_checks:
-            contexts:
-            - pull-cert-manager-master-chart
-            - pull-cert-manager-master-make-test
-            - pull-cert-manager-master-e2e-v1-24
-            - pull-cert-manager-master-e2e-v1-24-upgrade
+          branches:
+            # cert-manager/cert-manager defines required_status_checks on a per
+            # branch basis, since context names differ. Post release, the
+            # release branches can be updated to allow for cherry picks to the
+            # latest release.
+            release-1.8:
+              required_status_checks:
+                contexts:
+                - pull-cert-manager-release-1.8-chart
+                - pull-cert-manager-release-1.8-make-test
+                - pull-cert-manager-release-1.8-e2e-v1-24
+                - pull-cert-manager-release-1.8-e2e-v1-24-upgrade
+            release-1.9:
+              required_status_checks:
+                contexts:
+                - pull-cert-manager-release-1.9-chart
+                - pull-cert-manager-release-1.9-make-test
+                - pull-cert-manager-release-1.9-e2e-v1-24
+                - pull-cert-manager-release-1.9-e2e-v1-24-upgrade
+            master:
+              required_status_checks:
+                contexts:
+                - pull-cert-manager-master-chart
+                - pull-cert-manager-master-make-test
+                - pull-cert-manager-master-e2e-v1-24
+                - pull-cert-manager-master-e2e-v1-24-upgrade
         website:
           required_status_checks:
             contexts:


### PR DESCRIPTION
PR changes cert-manager/cert-manager branch protection to now define required status checks on a per branch basis. This is allow for the now differing context names, based on the target branch. This basically unblocks merging PRs on older release branches. 

We don't need to update the [release process](https://cert-manager.io/docs/contributing/release-process/#prerequisites) since it is already covered in the post release step 5:

```
(final release only) Open a PR to [jetstack/testing](https://github.com/jetstack/testing) and change Prow's config. To do this, take inspiration from [Maartje's PR example](https://github.com/jetstack/testing/pull/397/files).
```

/assign @munnerz 