### PR TITLE
Revert "Make sure that the "runner" command passes SIGINT down to the command that it calls (bazelbuild image)"

### DIFF
--- a/images/bazelbuild/runner
+++ b/images/bazelbuild/runner
@@ -24,6 +24,7 @@ if [[ "${BAZEL_REMOTE_CACHE_ENABLED}" == "true" ]]; then
     /usr/local/bin/create_bazel_cache_rcs.sh
 fi
 
+
 # used by cleanup_dind to ensure binfmt_misc entries are not persisted
 # TODO(bentheelder): consider moving *all* cleanup into a more robust program
 cleanup_binfmt_misc() {
@@ -41,40 +42,44 @@ cleanup_binfmt_misc() {
     ls -al /proc/sys/fs/binfmt_misc
 }
 
-# Runs custom docker data root cleanup binary and debugs remaining
-# resources.
+# runs custom docker data root cleanup binary and debugs remaining resources
 cleanup_dind() {
+    # list what images and volumes remain
     echo "Remaining docker images and volumes are:"
     docker images --all || true
     docker volume ls || true
-    cleanup_binfmt_misc || true
+    # cleanup binfmt_misc
+    echo "Cleaning up binfmt_misc ..."
+    # note: we run this in a subshell so we can trace it for now
+    (set -x; cleanup_binfmt_misc || true)
 }
 
 if [[ "${DOCKER_CONFIG:-}" != "" ]]; then
-    echo "A writable DOCKER_CONFIG was requested."
+    echo "Building writable DOCKER_CONFIG directory..."
     tmpdir="$(mktemp -d)"
     ln -s "${DOCKER_CONFIG}/config.json" "${tmpdir}/config.json"
     export DOCKER_CONFIG="${tmpdir}"
 fi
 
 if [[ "${EXTRA_DOCKER_OPTS:-}" != "" ]]; then
-    echo "DOCKER_OPTS=\"\${DOCKER_OPTS} ${EXTRA_DOCKER_OPTS}\"" >>/etc/default/docker
+    echo "DOCKER_OPTS=\"\${DOCKER_OPTS} ${EXTRA_DOCKER_OPTS}\"">>/etc/default/docker
 fi
 
+# Check if the job has opted-in to docker-in-docker availability.
 export DOCKER_IN_DOCKER_ENABLED=${DOCKER_IN_DOCKER_ENABLED:-false}
 if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
-    echo "Initializing Docker in Docker."
-
+    echo "Docker in Docker enabled, initializing..."
+    printf '=%.0s' {1..80}; echo
+    # If we have opted in to docker in docker, start the docker daemon,
     service docker start
-    # The service may be marked as ready but the Docker socket may not be
-    # ready yet.
+    # the service can be started but the docker socket not ready, wait for ready
     WAIT_N=0
     MAX_WAIT=5
     while true; do
         # docker ps -q should only work if the daemon is ready
-        docker ps -q >/dev/null 2>&1 && break
+        docker ps -q > /dev/null 2>&1 && break
         if [[ ${WAIT_N} -lt ${MAX_WAIT} ]]; then
-            WAIT_N=$((WAIT_N + 1))
+            WAIT_N=$((WAIT_N+1))
             echo "Waiting for docker to be ready, sleeping for ${WAIT_N} seconds."
             sleep ${WAIT_N}
         else
@@ -83,36 +88,14 @@ if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
         fi
     done
     cleanup_dind
+    printf '=%.0s' {1..80}; echo
+    echo "Done setting up docker in docker."
 fi
 
-# Disable error exit so we can run post-command cleanup.
+# disable error exit so we can run post-command cleanup
 set +o errexit
-
-# Run the actual job.
-"$@" &
-
-# Bash does not "trikle down" UNIX signals. If the Bash script receives SIGINT
-# coming from Prow due to the 2 hours timeout being hit, and that the above
-# command "$@" is running, then SIGINT won't be passed down to the "$@" command.
-# To work around that, we trap SIGINT and SIGTERM and pass then down
-# explicitely. The reasons for handling both SIGTERM and SIGINT is detailed in
-# the following table:
-#
-#  |                          Reason                          |   Signal    |
-#  |----------------------------------------------------------|-------------|
-#  | The 2 hours Prow timeout has been reached                | SIGINT [1]  |
-#  | Google Cloud VM preempted using ACPI shutdown            | SIGTERM [2] |
-#  | GKE worker removed due to scale down using ACPI shutdown | SIGTERM [2] |
-#
-#  [1]: https://github.com/kubernetes/test-infra/blob/ee1e7c8/kubetest/process/process.go#L202
-#  [2]: https://unix.stackexchange.com/questions/499761/what-signal-is-sent-to-running-programs-scripts-on-shutdown
-#
-# shellcheck disable=SC2064
-trap "kill INT $!" INT
-# shellcheck disable=SC2064
-trap "kill TERM $!" TERM
-wait $!
-
+# actually start bootstrap and the job
+"$@"
 EXIT_VALUE=$?
 
 coalesce.py || true
@@ -120,11 +103,9 @@ coalesce.py || true
 # cleanup after job
 if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
     echo "Cleaning up after docker in docker."
-    printf '=%.0s' {1..80}
-    echo
+    printf '=%.0s' {1..80}; echo
     cleanup_dind
-    printf '=%.0s' {1..80}
-    echo
+    printf '=%.0s' {1..80}; echo
     echo "Cleaning up docker containers ..."
     docker ps -aq | xargs -r docker rm -f || true
     echo "Stopping docker ..."


### PR DESCRIPTION
I realized two things:

1. The `kill` commands are missing `-s`.
2. The `SIGINT` signals won't work anyways due to the fact that Bash is run in a non-interactive way, as explained in [Strange problem with trap and SIGINT](https://unix.stackexchange.com/questions/356408/strange-problem-with-trap-and-sigint).

Reverts jetstack/testing#654