### PR TITLE
Make sure that the "runner" command passes SIGINT and SIGTERM down to the command that it calls (bazelbuild image)

### DIFF
--- a/images/bazelbuild/runner
+++ b/images/bazelbuild/runner
@@ -24,7 +24,6 @@ if [[ "${BAZEL_REMOTE_CACHE_ENABLED}" == "true" ]]; then
     /usr/local/bin/create_bazel_cache_rcs.sh
 fi
 
-
 # used by cleanup_dind to ensure binfmt_misc entries are not persisted
 # TODO(bentheelder): consider moving *all* cleanup into a more robust program
 cleanup_binfmt_misc() {
@@ -42,44 +41,40 @@ cleanup_binfmt_misc() {
     ls -al /proc/sys/fs/binfmt_misc
 }
 
-# runs custom docker data root cleanup binary and debugs remaining resources
+# Runs custom docker data root cleanup binary and debugs remaining
+# resources.
 cleanup_dind() {
-    # list what images and volumes remain
     echo "Remaining docker images and volumes are:"
     docker images --all || true
     docker volume ls || true
-    # cleanup binfmt_misc
-    echo "Cleaning up binfmt_misc ..."
-    # note: we run this in a subshell so we can trace it for now
-    (set -x; cleanup_binfmt_misc || true)
+    cleanup_binfmt_misc || true
 }
 
 if [[ "${DOCKER_CONFIG:-}" != "" ]]; then
-    echo "Building writable DOCKER_CONFIG directory..."
+    echo "A writable DOCKER_CONFIG was requested."
     tmpdir="$(mktemp -d)"
     ln -s "${DOCKER_CONFIG}/config.json" "${tmpdir}/config.json"
     export DOCKER_CONFIG="${tmpdir}"
 fi
 
 if [[ "${EXTRA_DOCKER_OPTS:-}" != "" ]]; then
-    echo "DOCKER_OPTS=\"\${DOCKER_OPTS} ${EXTRA_DOCKER_OPTS}\"">>/etc/default/docker
+    echo "DOCKER_OPTS=\"\${DOCKER_OPTS} ${EXTRA_DOCKER_OPTS}\"" >>/etc/default/docker
 fi
 
-# Check if the job has opted-in to docker-in-docker availability.
 export DOCKER_IN_DOCKER_ENABLED=${DOCKER_IN_DOCKER_ENABLED:-false}
 if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
-    echo "Docker in Docker enabled, initializing..."
-    printf '=%.0s' {1..80}; echo
-    # If we have opted in to docker in docker, start the docker daemon,
+    echo "Initializing Docker in Docker."
+
     service docker start
-    # the service can be started but the docker socket not ready, wait for ready
+    # The service may be marked as ready but the Docker socket may not be
+    # ready yet.
     WAIT_N=0
     MAX_WAIT=5
     while true; do
         # docker ps -q should only work if the daemon is ready
-        docker ps -q > /dev/null 2>&1 && break
+        docker ps -q >/dev/null 2>&1 && break
         if [[ ${WAIT_N} -lt ${MAX_WAIT} ]]; then
-            WAIT_N=$((WAIT_N+1))
+            WAIT_N=$((WAIT_N + 1))
             echo "Waiting for docker to be ready, sleeping for ${WAIT_N} seconds."
             sleep ${WAIT_N}
         else
@@ -88,11 +83,9 @@ if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
         fi
     done
     cleanup_dind
-    printf '=%.0s' {1..80}; echo
-    echo "Done setting up docker in docker."
 fi
 
-# disable error exit so we can run post-command cleanup
+# Disable error exit so we can run post-command cleanup.
 set +o errexit
 # actually start bootstrap and the job
 "$@"
@@ -103,9 +96,11 @@ coalesce.py || true
 # cleanup after job
 if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
     echo "Cleaning up after docker in docker."
-    printf '=%.0s' {1..80}; echo
+    printf '=%.0s' {1..80}
+    echo
     cleanup_dind
-    printf '=%.0s' {1..80}; echo
+    printf '=%.0s' {1..80}
+    echo
     echo "Cleaning up docker containers ..."
     docker ps -aq | xargs -r docker rm -f || true
     echo "Stopping docker ..."

--- a/images/bazelbuild/runner
+++ b/images/bazelbuild/runner
@@ -87,8 +87,32 @@ fi
 
 # Disable error exit so we can run post-command cleanup.
 set +o errexit
-# actually start bootstrap and the job
-"$@"
+
+# Run the actual job.
+"$@" &
+
+# Bash does not "trikle down" UNIX signals. If the Bash script receives SIGINT
+# coming from Prow due to the 2 hours timeout being hit, and that the above
+# command "$@" is running, then SIGINT won't be passed down to the "$@" command.
+# To work around that, we trap SIGINT and SIGTERM and pass then down
+# explicitely. The reasons for handling both SIGTERM and SIGINT is detailed in
+# the following table:
+#
+#  |                          Reason                          |   Signal    |
+#  |----------------------------------------------------------|-------------|
+#  | The 2 hours Prow timeout has been reached                | SIGINT [1]  |
+#  | Google Cloud VM preempted using ACPI shutdown            | SIGTERM [2] |
+#  | GKE worker removed due to scale down using ACPI shutdown | SIGTERM [2] |
+#
+#  [1]: https://github.com/kubernetes/test-infra/blob/ee1e7c8/prow/entrypoint/run.go#L242
+#  [2]: https://unix.stackexchange.com/questions/499761/what-signal-is-sent-to-running-programs-scripts-on-shutdown
+#
+# shellcheck disable=SC2064
+trap "kill -s INT $!" INT
+# shellcheck disable=SC2064
+trap "kill -s TERM $!" TERM
+wait $!
+
 EXIT_VALUE=$?
 
 coalesce.py || true


### PR DESCRIPTION
This is my second attempt at fixing #650. The PR #654 was reverted because it was broken due to `-s`. This PR fixes this; I also properly testing the new behavior.

For context, the reason we need this change is because Bash does not "trikle down" UNIX signals. If `runner` (which is a Bash script) receives SIGINT coming from Prow due to the 2 hours timeout being hit, and that the command (line that says `"$@"`) is running, then SIGINT won't be passed down to the running command. To work around that, I trap SIGINT and SIGTERM and pass then down explicitly. The reasons for handling both SIGTERM and SIGINT is detailed in the following table:

 |                          Reason                          |   Signal    |
 |----------------------------------------------------------|-------------|
 | The 2 hours Prow timeout has been reached                | SIGINT [1]  |
 | Google Cloud VM preempted using ACPI shutdown            | SIGTERM [2] |
 | GKE worker removed due to scale down using ACPI shutdown | SIGTERM [2] |

 [1]: https://github.com/kubernetes/test-infra/blob/ee1e7c8/prow/entrypoint/run.go#L242
 [2]: https://unix.stackexchange.com/questions/499761/what-signal-is-sent-to-running-programs-scripts-on-shutdown

## Testing it

In order to test this feature, I could not use Bash (see below comment). I created a Go program that waits until it receives SIGINT or SIGTERM. Let us create it:

```sh
cat > /tmp/sig.go <<'EOF'
package main

import (
    "fmt"
    "os"
    "os/signal"
    "syscall"
)

func main() {
    sigs := make(chan os.Signal, 1)
    signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)

    done := make(chan bool, 1)

    go func() {
        sig := <-sigs
        fmt.Println()
        fmt.Printf("signal received: '%s'\n", sig)
        done <- true
    }()

    fmt.Println("awaiting signal")
    <-done
    fmt.Println("exiting")
}
EOF
go build -o /tmp/sig /tmp/sig.go
```

> ℹ️ The reason I use Go to test this feature is due to a limitation in Bash. At
> first, I thought I would test that this change using Bash. I started with the
> following command that would ensure that `runner` forwards SIGINT:
>
> ```bash
> docker run --rm --name foo foo:v0.0.1 -v /tmp/sig:/sig runner bash -c 'sleep 1000 & trap "echo received; kill -s INT $!" INT; wait $!'
> ```
>
> When running the command:
>
> ```bash
> docker exec -it foo kill -s INT 1
> ```
>
> the container would exit without printing "received", meaning that the trap
> had been silently ignored. This limitation of Bash is detailed in [Strange
> problem with trap and
> SIGINT](https://unix.stackexchange.com/questions/356408/strange-problem-with-trap-and-sigint),
> and does not happen for SIGTERM.

> ℹ️ I also discovered that containers are run as PID 1, but PID 1 is special in
> Linux: SIGTERM does not kill the process 1; the only way to have SIGTERM do
> something is to register a trap. This issue is detailed in the blog post
> [SIGTERM and PID 1: Why does a container linger after receiving a
> SIGTERM.](https://raby.sh/sigterm-and-pid-1-why-does-a-container-linger-after-receiving-a-sigterm.html).
>
> To test this behavior, run the following:
>
> ```bash
> docker run -it --name foo busybox cat
> ```
>
> You will notice that ctrl+C (which sends SIGINT) does not work: this is
> because the process has the PID 1, which means Linux doesn't handle SIGINT or
> SIGTERM by default. Let us test by sending SIGTERM and SIGINT directly:
>
> ```sh
> docker exec -it foo kill -s TERM 1
> docker exec -it foo kill -s INT 1
> ```
>
> None of the above commands is able to stop the process.
>
> The only way to make the process "stoppable" by SIGINT or SIGTERM is to set up
> signal traps.

### Before

With SIGTERM, the command run by the `runner` script isn't receiving the signal:

```sh
docker run -it --rm --name foo -v /tmp/sig:/sig eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1 \
    runner /sig

# In another shell, run:
docker exec -it foo sh -c 'kill -s TERM 1'
# ❌ The "docker run" command hangs at "awaiting signal".
```

Same with SIGINT:

```sh
docker run -it --rm --name foo -v /tmp/sig:/sig eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1 \
    runner /sig


# In another shell, run:
docker exec -it foo sh -c 'kill -s TERM 1'
# ❌ The "docker run" command hangs at "awaiting signal".
```

### After

Let us first build the bazelbuild image:

```sh
docker buildx build --load -t foo:v0.0.1 --build-arg BAZEL_VERSION="4.2.1" --build-arg DEBIAN_VERSION=bullseye --build-arg DOCKER_VERSION=5:20.10.17~3-0~debian-bullseye ./images/bazelbuild
```

With SIGTERM, the command run by the `runner` script is receiving the signal:

```sh
docker run -it --rm --name foo -v /tmp/sig:/sig foo:v0.0.1 \
    runner /sig

# In another shell, run:
docker exec -it foo sh -c 'kill -s TERM 1'
# ✅ The "docker run" command exits with 128 and prints "signal received: 'terminated'".
```

With SIGINT, we see the same thing:

```sh
docker run -it --rm --name foo -v /tmp/sig:/sig foo:v0.0.1 \
    runner /sig

# In another shell, run:
docker exec -it foo sh -c 'kill -s INT 1'
# ✅ The "docker run" command exits with 128 and prints "signal received: 'interrupt'".
```
