### PR TITLE
Adds nix-dind image. Docker image for nix which contains docker in docker functionality.

### DIFF
--- a/config/jobs/testing/testing-trusted.yaml
+++ b/config/jobs/testing/testing-trusted.yaml
@@ -462,3 +462,40 @@ postsubmits:
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
+
+  - name: post-testing-push-nix-dind
+    cluster: trusted
+    run_if_changed: '^images/nix-dind/'
+    branches:
+    - master
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-image-deploy: "true"
+      preset-deployer-service-account: "true"
+      preset-deployer-github-token: "true"
+      preset-deployer-ssh-key: "true"
+    annotations:
+      testgrid-create-test-group: 'true'
+      testgrid-dashboards: jetstack-testing-janitors
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-disable-prowjob-analysis: "true"
+      description: Build and push the 'nix-dind' image
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+        args:
+        # Wrap the release script with the runner so we can use docker-in-docker
+        - runner
+        - images/builder/ci-runner.sh
+        - images/nix-dind
+        - --confirm=true
+        resources:
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]

--- a/images/nix-dind/Dockerfile
+++ b/images/nix-dind/Dockerfile
@@ -1,0 +1,31 @@
+# Copyright 2022 The Jetstack contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Includes docker-in-docker and gcloud
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+LABEL maintainer="cert-manager-maintainers@googlegroups.com"
+
+# xz is required for nix curl install.
+RUN apt-get install -y xz-utils
+
+# install nix.
+ARG NIX_VERSION
+RUN mkdir -m 0755 /nix && groupadd -r nixbld && chown root /nix
+RUN for n in $(seq 1 10); do useradd -c "Nix build user $n" -d /var/empty -g nixbld -G nixbld -M -N -r -s "$(command -v nologin)" "nixbld$n"; done
+RUN mkdir -p /etc/nix && echo "experimental-features = nix-command flakes\nsandbox = false" > /etc/nix/nix.conf
+RUN bash -c "$(curl -L https://releases.nixos.org/nix/nix-${NIX_VERSION}/install) --no-daemon"
+
+# add nix store to path.
+ENV PATH=/root/.nix-profile/bin:$PATH

--- a/images/nix-dind/OWNERS
+++ b/images/nix-dind/OWNERS
@@ -1,0 +1,11 @@
+approvers:
+- munnerz
+- simplyzee
+- joshvanl
+- irbekrm
+- jakexks
+- maelvls
+- wallrj
+- sgtcodfish
+reviewers:
+- joshvanl

--- a/images/nix-dind/OWNERS
+++ b/images/nix-dind/OWNERS
@@ -1,9 +1,7 @@
 approvers:
 - munnerz
-- simplyzee
 - joshvanl
 - irbekrm
-- jakexks
 - maelvls
 - wallrj
 - sgtcodfish

--- a/images/nix-dind/build.yaml
+++ b/images/nix-dind/build.yaml
@@ -1,0 +1,12 @@
+name: nix-dind # Name of the image to be built
+
+variants:
+  "2.11.0":
+    arguments:
+      BASE_IMAGE: "eu.gcr.io/jetstack-build-infra-images/bazelbuild@sha256:4757d0b78814ccc138561b9e2b57c3b84d2b339d2d3c5c796e5520f3cd298aa4"
+      NIX_VERSION: "2.11.0"
+
+# Image names to be tagged and pushed
+images:
+- ${_REGISTRY}/${_NAME}:${_DATE_STAMP}-${_GIT_REF}-${NIX_VERSION}
+- ${_REGISTRY}/${_NAME}:latest-${NIX_VERSION}


### PR DESCRIPTION
I would like to experiment with using nix in the `csi-lib` project for setting up the e2e dependencies. See [here](https://github.com/cert-manager/csi-lib/pull/31#issuecomment-1238257743).