### PR TITLE
e2e test job for cert-manager/csi-lib

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -73,6 +73,10 @@ branch-protection:
             contexts:
             - pull-cert-manager-trust-verify
             - pull-cert-manager-trust-smoke
+        csi-lib:
+          required_status_checks:
+            contexts:
+            - pull-cert-manager-csi-lib-verify
         aws-privateca-issuer:
           protect: false
 sinker:

--- a/config/jobs/cert-manager/csi-lib/cert-manager-csi-lib-presubmits.yaml
+++ b/config/jobs/cert-manager/csi-lib/cert-manager-csi-lib-presubmits.yaml
@@ -26,7 +26,7 @@ presubmits:
             value: "1"
 
   - name: pull-cert-manager-csi-lib-e2e
-    context: pull-cert-manager-approver-policy-smoke
+    context: pull-cert-manager-csi-lib-e2e
     agent: kubernetes
     decorate: true
     # TODO: Keep optional to not block other PRs. Change once e2e test

--- a/config/jobs/cert-manager/csi-lib/cert-manager-csi-lib-presubmits.yaml
+++ b/config/jobs/cert-manager/csi-lib/cert-manager-csi-lib-presubmits.yaml
@@ -24,3 +24,52 @@ presubmits:
         options:
           - name: ndots
             value: "1"
+
+  - name: pull-cert-manager-csi-lib-e2e
+    context: pull-cert-manager-approver-policy-smoke
+    agent: kubernetes
+    decorate: true
+    # TODO: Keep optional to not block other PRs. Change once e2e test
+    # boilerplate code has been merged to main.
+    always_run: false
+    optional: true
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+    spec:
+      containers:
+      - image: # TODO
+        args:
+        - nix
+        - develop
+        - -c
+        - ./hack/run-e2e.sh
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 4Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+

--- a/config/jobs/cert-manager/csi-lib/cert-manager-csi-lib-presubmits.yaml
+++ b/config/jobs/cert-manager/csi-lib/cert-manager-csi-lib-presubmits.yaml
@@ -39,11 +39,8 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: # TODO
+      - image: eu.gcr.io/jetstack-build-infra-images/nix-dind:20220913-fe79bd8-2.11.0
         args:
-        - nix
-        - develop
-        - -c
         - ./hack/run-e2e.sh
         resources:
           requests:


### PR DESCRIPTION
Branched from #749 

Adds optional e2e test job for cert-manager/csi-lib.

Should be changed to non-optional once the e2e test boilerplate has been merged upstream on csi-lib.

The `nix-dind` image is not yet available so has been left as TODO.