### PR TITLE
Upgrade kubernetes version & move lifecycle attr. to e2e tests

### DIFF
--- a/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
+++ b/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
@@ -30,13 +30,6 @@ presubmits:
           requests:
             cpu: 2000m
             memory: 4Gi
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
       dnsConfig:
         options:
         - name: ndots
@@ -117,6 +110,13 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
       dnsConfig:
         options:
         - name: ndots
@@ -162,6 +162,13 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
       dnsConfig:
         options:
         - name: ndots
@@ -207,6 +214,13 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
       dnsConfig:
         options:
         - name: ndots
@@ -252,6 +266,13 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
       dnsConfig:
         options:
         - name: ndots
@@ -297,6 +318,65 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+    branches:
+    - master
+    always_run: false
+    optional: true
+  - name: pull-cert-manager-master-e2e-v1-25
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.25 cluster
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-job-group: "true"
+      testgrid-dashboards: cert-manager-presubmits-master
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-default-e2e-volumes: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-make-volumes: "true"
+      preset-retry-flakey-jobs: "true"
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+        args:
+        - runner
+        - make
+        - -j3
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.25
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
       dnsConfig:
         options:
         - name: ndots
@@ -305,7 +385,7 @@ presubmits:
     - master
     always_run: true
     optional: false
-  - name: pull-cert-manager-master-e2e-v1-24-upgrade
+  - name: pull-cert-manager-master-e2e-v1-25-upgrade
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -325,7 +405,7 @@ presubmits:
         args:
         - runner
         - make
-        - K8S_VERSION=1.24
+        - K8S_VERSION=1.25
         - vendor-go
         - test-upgrade
         resources:
@@ -345,7 +425,7 @@ presubmits:
     - master
     always_run: true
     optional: false
-  - name: pull-cert-manager-master-e2e-v1-24-issuers-venafi-tpp
+  - name: pull-cert-manager-master-e2e-v1-25-issuers-venafi-tpp
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -371,7 +451,7 @@ presubmits:
         - -j3
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.24
+        - K8S_VERSION=1.25
         resources:
           requests:
             cpu: 3500m
@@ -381,6 +461,13 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
       dnsConfig:
         options:
         - name: ndots
@@ -389,7 +476,7 @@ presubmits:
     - master
     always_run: false
     optional: true
-  - name: pull-cert-manager-master-e2e-v1-24-issuers-venafi-cloud
+  - name: pull-cert-manager-master-e2e-v1-25-issuers-venafi-cloud
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -415,7 +502,7 @@ presubmits:
         - -j3
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.24
+        - K8S_VERSION=1.25
         resources:
           requests:
             cpu: 3500m
@@ -425,6 +512,13 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
       dnsConfig:
         options:
         - name: ndots
@@ -433,7 +527,7 @@ presubmits:
     - master
     always_run: false
     optional: true
-  - name: pull-cert-manager-master-e2e-v1-24-feature-gates-disabled
+  - name: pull-cert-manager-master-e2e-v1-25-feature-gates-disabled
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -460,7 +554,7 @@ presubmits:
         - -j3
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.24
+        - K8S_VERSION=1.25
         resources:
           requests:
             cpu: 3500m
@@ -470,6 +564,13 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
       dnsConfig:
         options:
         - name: ndots
@@ -505,13 +606,6 @@ periodics:
         requests:
           cpu: 2000m
           memory: 4Gi
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsConfig:
       options:
       - name: ndots
@@ -558,6 +652,13 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
     dnsConfig:
       options:
       - name: ndots
@@ -604,6 +705,13 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
     dnsConfig:
       options:
       - name: ndots
@@ -650,6 +758,13 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
     dnsConfig:
       options:
       - name: ndots
@@ -696,6 +811,13 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
     dnsConfig:
       options:
       - name: ndots
@@ -742,6 +864,13 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
     dnsConfig:
       options:
       - name: ndots
@@ -751,7 +880,60 @@ periodics:
     repo: cert-manager
     base_ref: master
   interval: 2h
-- name: ci-cert-manager-master-e2e-v1-24-issuers-venafi
+- name: ci-cert-manager-master-e2e-v1-25
+  max_concurrency: 4
+  agent: kubernetes
+  decorate: true
+  annotations:
+    description: Runs the end-to-end test suite against a Kubernetes v1.25 cluster
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-master
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-default-e2e-volumes: "true"
+    preset-dind-enabled: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-make-volumes: "true"
+    preset-retry-flakey-jobs: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+      args:
+      - runner
+      - make
+      - -j3
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.25
+      resources:
+        requests:
+          cpu: 3500m
+          memory: 12Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: master
+  interval: 2h
+- name: ci-cert-manager-master-e2e-v1-25-issuers-venafi
   max_concurrency: 4
   agent: kubernetes
   decorate: true
@@ -778,7 +960,7 @@ periodics:
       - -j3
       - vendor-go
       - e2e-ci
-      - K8S_VERSION=1.24
+      - K8S_VERSION=1.25
       resources:
         requests:
           cpu: 3500m
@@ -788,6 +970,13 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
     dnsConfig:
       options:
       - name: ndots
@@ -797,7 +986,7 @@ periodics:
     repo: cert-manager
     base_ref: master
   interval: 12h
-- name: ci-cert-manager-master-e2e-v1-24-upgrade
+- name: ci-cert-manager-master-e2e-v1-25-upgrade
   max_concurrency: 4
   agent: kubernetes
   decorate: true
@@ -817,7 +1006,7 @@ periodics:
       args:
       - runner
       - make
-      - K8S_VERSION=1.24
+      - K8S_VERSION=1.25
       - vendor-go
       - test-upgrade
       resources:
@@ -875,6 +1064,13 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
     dnsConfig:
       options:
       - name: ndots
@@ -921,6 +1117,13 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
     dnsConfig:
       options:
       - name: ndots
@@ -967,6 +1170,13 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
     dnsConfig:
       options:
       - name: ndots
@@ -1013,6 +1223,13 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
     dnsConfig:
       options:
       - name: ndots
@@ -1059,6 +1276,66 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: master
+  interval: 24h
+- name: ci-cert-manager-master-e2e-v1-25-feature-gates-disabled
+  max_concurrency: 4
+  agent: kubernetes
+  decorate: true
+  annotations:
+    description: Runs the E2E tests with all feature gates disabled
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-master
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-default-e2e-volumes: "true"
+    preset-dind-enabled: "true"
+    preset-disable-all-alpha-beta-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-make-volumes: "true"
+    preset-retry-flakey-jobs: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+      args:
+      - runner
+      - make
+      - -j3
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.25
+      resources:
+        requests:
+          cpu: 3500m
+          memory: 12Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
     dnsConfig:
       options:
       - name: ndots

--- a/config/jobs/cert-manager/cert-manager/release-1.8/cert-manager-release-1.8.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.8/cert-manager-release-1.8.yaml
@@ -101,6 +101,13 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
       dnsConfig:
         options:
         - name: ndots
@@ -143,6 +150,13 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
       dnsConfig:
         options:
         - name: ndots
@@ -185,6 +199,13 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
       dnsConfig:
         options:
         - name: ndots
@@ -227,6 +248,13 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
       dnsConfig:
         options:
         - name: ndots
@@ -269,6 +297,13 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
       dnsConfig:
         options:
         - name: ndots
@@ -311,6 +346,62 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+    branches:
+    - release-1.8
+    always_run: false
+    optional: true
+  - name: pull-cert-manager-release-1.8-e2e-v1-25
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.25 cluster
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-default-e2e-volumes: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-make-volumes: "true"
+      preset-retry-flakey-jobs: "true"
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+        args:
+        - runner
+        - make
+        - -j3
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.25
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
       dnsConfig:
         options:
         - name: ndots
@@ -319,7 +410,7 @@ presubmits:
     - release-1.8
     always_run: true
     optional: false
-  - name: pull-cert-manager-release-1.8-e2e-v1-24-issuers-venafi-tpp
+  - name: pull-cert-manager-release-1.8-e2e-v1-25-issuers-venafi-tpp
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -342,7 +433,7 @@ presubmits:
         - -j3
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.24
+        - K8S_VERSION=1.25
         resources:
           requests:
             cpu: 3500m
@@ -352,6 +443,13 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
       dnsConfig:
         options:
         - name: ndots
@@ -360,7 +458,7 @@ presubmits:
     - release-1.8
     always_run: false
     optional: true
-  - name: pull-cert-manager-release-1.8-e2e-v1-24-issuers-venafi-cloud
+  - name: pull-cert-manager-release-1.8-e2e-v1-25-issuers-venafi-cloud
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -383,7 +481,7 @@ presubmits:
         - -j3
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.24
+        - K8S_VERSION=1.25
         resources:
           requests:
             cpu: 3500m
@@ -393,6 +491,13 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
       dnsConfig:
         options:
         - name: ndots
@@ -401,7 +506,7 @@ presubmits:
     - release-1.8
     always_run: false
     optional: true
-  - name: pull-cert-manager-release-1.8-e2e-v1-24-feature-gates-disabled
+  - name: pull-cert-manager-release-1.8-e2e-v1-25-feature-gates-disabled
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -425,7 +530,7 @@ presubmits:
         - -j3
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.24
+        - K8S_VERSION=1.25
         resources:
           requests:
             cpu: 3500m
@@ -435,6 +540,13 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
       dnsConfig:
         options:
         - name: ndots
@@ -516,6 +628,13 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
     dnsConfig:
       options:
       - name: ndots
@@ -562,6 +681,13 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
     dnsConfig:
       options:
       - name: ndots
@@ -608,6 +734,13 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
     dnsConfig:
       options:
       - name: ndots
@@ -654,6 +787,13 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
     dnsConfig:
       options:
       - name: ndots
@@ -700,6 +840,13 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
     dnsConfig:
       options:
       - name: ndots
@@ -746,6 +893,13 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
     dnsConfig:
       options:
       - name: ndots
@@ -755,7 +909,60 @@ periodics:
     repo: cert-manager
     base_ref: release-1.8
   interval: 2h
-- name: ci-cert-manager-release-1.8-e2e-v1-24-issuers-venafi
+- name: ci-cert-manager-release-1.8-e2e-v1-25
+  max_concurrency: 4
+  agent: kubernetes
+  decorate: true
+  annotations:
+    description: Runs the end-to-end test suite against a Kubernetes v1.25 cluster
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.8
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-default-e2e-volumes: "true"
+    preset-dind-enabled: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-make-volumes: "true"
+    preset-retry-flakey-jobs: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+      args:
+      - runner
+      - make
+      - -j3
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.25
+      resources:
+        requests:
+          cpu: 3500m
+          memory: 12Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.8
+  interval: 2h
+- name: ci-cert-manager-release-1.8-e2e-v1-25-issuers-venafi
   max_concurrency: 4
   agent: kubernetes
   decorate: true
@@ -782,7 +989,7 @@ periodics:
       - -j3
       - vendor-go
       - e2e-ci
-      - K8S_VERSION=1.24
+      - K8S_VERSION=1.25
       resources:
         requests:
           cpu: 3500m
@@ -792,6 +999,13 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
     dnsConfig:
       options:
       - name: ndots
@@ -838,6 +1052,13 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
     dnsConfig:
       options:
       - name: ndots
@@ -884,6 +1105,13 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
     dnsConfig:
       options:
       - name: ndots
@@ -930,6 +1158,13 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
     dnsConfig:
       options:
       - name: ndots
@@ -976,6 +1211,13 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
     dnsConfig:
       options:
       - name: ndots
@@ -1022,6 +1264,13 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
     dnsConfig:
       options:
       - name: ndots
@@ -1068,6 +1317,66 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.8
+  interval: 24h
+- name: ci-cert-manager-release-1.8-e2e-v1-25-feature-gates-disabled
+  max_concurrency: 4
+  agent: kubernetes
+  decorate: true
+  annotations:
+    description: Runs the E2E tests with all feature gates disabled
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.8
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-default-e2e-volumes: "true"
+    preset-dind-enabled: "true"
+    preset-disable-all-alpha-beta-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-make-volumes: "true"
+    preset-retry-flakey-jobs: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+      args:
+      - runner
+      - make
+      - -j3
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.25
+      resources:
+        requests:
+          cpu: 3500m
+          memory: 12Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
     dnsConfig:
       options:
       - name: ndots

--- a/config/jobs/cert-manager/cert-manager/release-1.9/cert-manager-release-1.9.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.9/cert-manager-release-1.9.yaml
@@ -101,6 +101,13 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
       dnsConfig:
         options:
         - name: ndots
@@ -143,6 +150,13 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
       dnsConfig:
         options:
         - name: ndots
@@ -185,6 +199,13 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
       dnsConfig:
         options:
         - name: ndots
@@ -227,6 +248,13 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
       dnsConfig:
         options:
         - name: ndots
@@ -269,6 +297,62 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+    branches:
+    - release-1.9
+    always_run: false
+    optional: true
+  - name: pull-cert-manager-release-1.9-e2e-v1-25
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.25 cluster
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-default-e2e-volumes: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-make-volumes: "true"
+      preset-retry-flakey-jobs: "true"
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+        args:
+        - runner
+        - make
+        - -j3
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.25
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
       dnsConfig:
         options:
         - name: ndots
@@ -277,7 +361,7 @@ presubmits:
     - release-1.9
     always_run: true
     optional: false
-  - name: pull-cert-manager-release-1.9-e2e-v1-24-upgrade
+  - name: pull-cert-manager-release-1.9-e2e-v1-25-upgrade
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -294,7 +378,7 @@ presubmits:
         args:
         - runner
         - make
-        - K8S_VERSION=1.24
+        - K8S_VERSION=1.25
         - vendor-go
         - test-upgrade
         resources:
@@ -314,7 +398,7 @@ presubmits:
     - release-1.9
     always_run: true
     optional: false
-  - name: pull-cert-manager-release-1.9-e2e-v1-24-issuers-venafi-tpp
+  - name: pull-cert-manager-release-1.9-e2e-v1-25-issuers-venafi-tpp
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -337,7 +421,7 @@ presubmits:
         - -j3
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.24
+        - K8S_VERSION=1.25
         resources:
           requests:
             cpu: 3500m
@@ -347,6 +431,13 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
       dnsConfig:
         options:
         - name: ndots
@@ -355,7 +446,7 @@ presubmits:
     - release-1.9
     always_run: false
     optional: true
-  - name: pull-cert-manager-release-1.9-e2e-v1-24-issuers-venafi-cloud
+  - name: pull-cert-manager-release-1.9-e2e-v1-25-issuers-venafi-cloud
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -378,7 +469,7 @@ presubmits:
         - -j3
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.24
+        - K8S_VERSION=1.25
         resources:
           requests:
             cpu: 3500m
@@ -388,6 +479,13 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
       dnsConfig:
         options:
         - name: ndots
@@ -396,7 +494,7 @@ presubmits:
     - release-1.9
     always_run: false
     optional: true
-  - name: pull-cert-manager-release-1.9-e2e-v1-24-feature-gates-disabled
+  - name: pull-cert-manager-release-1.9-e2e-v1-25-feature-gates-disabled
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -420,7 +518,7 @@ presubmits:
         - -j3
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.24
+        - K8S_VERSION=1.25
         resources:
           requests:
             cpu: 3500m
@@ -430,6 +528,13 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
       dnsConfig:
         options:
         - name: ndots
@@ -511,6 +616,13 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
     dnsConfig:
       options:
       - name: ndots
@@ -557,6 +669,13 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
     dnsConfig:
       options:
       - name: ndots
@@ -603,6 +722,13 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
     dnsConfig:
       options:
       - name: ndots
@@ -649,6 +775,13 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
     dnsConfig:
       options:
       - name: ndots
@@ -695,6 +828,13 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
     dnsConfig:
       options:
       - name: ndots
@@ -704,7 +844,60 @@ periodics:
     repo: cert-manager
     base_ref: release-1.9
   interval: 2h
-- name: ci-cert-manager-release-1.9-e2e-v1-24-issuers-venafi
+- name: ci-cert-manager-release-1.9-e2e-v1-25
+  max_concurrency: 4
+  agent: kubernetes
+  decorate: true
+  annotations:
+    description: Runs the end-to-end test suite against a Kubernetes v1.25 cluster
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.9
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-default-e2e-volumes: "true"
+    preset-dind-enabled: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-make-volumes: "true"
+    preset-retry-flakey-jobs: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+      args:
+      - runner
+      - make
+      - -j3
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.25
+      resources:
+        requests:
+          cpu: 3500m
+          memory: 12Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.9
+  interval: 2h
+- name: ci-cert-manager-release-1.9-e2e-v1-25-issuers-venafi
   max_concurrency: 4
   agent: kubernetes
   decorate: true
@@ -731,7 +924,7 @@ periodics:
       - -j3
       - vendor-go
       - e2e-ci
-      - K8S_VERSION=1.24
+      - K8S_VERSION=1.25
       resources:
         requests:
           cpu: 3500m
@@ -741,6 +934,13 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
     dnsConfig:
       options:
       - name: ndots
@@ -750,7 +950,7 @@ periodics:
     repo: cert-manager
     base_ref: release-1.9
   interval: 12h
-- name: ci-cert-manager-release-1.9-e2e-v1-24-upgrade
+- name: ci-cert-manager-release-1.9-e2e-v1-25-upgrade
   max_concurrency: 4
   agent: kubernetes
   decorate: true
@@ -770,7 +970,7 @@ periodics:
       args:
       - runner
       - make
-      - K8S_VERSION=1.24
+      - K8S_VERSION=1.25
       - vendor-go
       - test-upgrade
       resources:
@@ -828,6 +1028,13 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
     dnsConfig:
       options:
       - name: ndots
@@ -874,6 +1081,13 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
     dnsConfig:
       options:
       - name: ndots
@@ -920,6 +1134,13 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
     dnsConfig:
       options:
       - name: ndots
@@ -966,6 +1187,13 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
     dnsConfig:
       options:
       - name: ndots
@@ -1012,6 +1240,66 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.9
+  interval: 24h
+- name: ci-cert-manager-release-1.9-e2e-v1-25-feature-gates-disabled
+  max_concurrency: 4
+  agent: kubernetes
+  decorate: true
+  annotations:
+    description: Runs the E2E tests with all feature gates disabled
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.9
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-default-e2e-volumes: "true"
+    preset-dind-enabled: "true"
+    preset-disable-all-alpha-beta-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-make-volumes: "true"
+    preset-retry-flakey-jobs: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+      args:
+      - runner
+      - make
+      - -j3
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.25
+      resources:
+        requests:
+          cpu: 3500m
+          memory: 12Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
     dnsConfig:
       options:
       - name: ndots


### PR DESCRIPTION
This PR contains the code generated by the https://github.com/cert-manager/release/pull/97, https://github.com/cert-manager/release/pull/102 and https://github.com/cert-manager/release/pull/98 PRs in the release repo.
Generation was done as follows:
```shell
$ gh --repo https://github.com/cert-manager/release run download
$ git apply prow-config.patch
```

Signed-off-by: Tim Ramlot <42113979+inteon@users.noreply.github.com>