### PR TITLE
Add Joakim and Tim to the OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,3 +8,5 @@ approvers:
 - munnerz
 - meyskens
 - simplyzee
+- inteon
+- jahrlin


### PR DESCRIPTION
Tim and Joakim were added to the OWNERS files of cert-manager/release (https://github.com/cert-manager/release/pull/99), but not in jetstack/testing. This PR fixes that.

