### PR TITLE
cert-manager/csi-lib: e2e: Adds `nix` as the root command of `flake check -L`

### DIFF
--- a/config/jobs/cert-manager/csi-lib/cert-manager-csi-lib-presubmits.yaml
+++ b/config/jobs/cert-manager/csi-lib/cert-manager-csi-lib-presubmits.yaml
@@ -42,6 +42,7 @@ presubmits:
       - image: eu.gcr.io/jetstack-build-infra-images/nix-dind:20220913-fe79bd8-2.11.0
         args:
         - runner
+        - nix
         - flake
         - check
         - -L


### PR DESCRIPTION
/assign @charlieegan3 