### PR TITLE
Update image used in csi-lib e2e runner to use nix image with kvm system-feature

### DIFF
--- a/config/jobs/cert-manager/csi-lib/cert-manager-csi-lib-presubmits.yaml
+++ b/config/jobs/cert-manager/csi-lib/cert-manager-csi-lib-presubmits.yaml
@@ -39,7 +39,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/nix-dind:20220913-fe79bd8-2.11.0
+      - image: eu.gcr.io/jetstack-build-infra-images/nix-dind:20220921-789387a-2.11.0
         args:
         - runner
         - nix


### PR DESCRIPTION
/assign @charlieegan3 