### PR TITLE
Set default kubernetes version to k8s 1.24 instead of 1.25

### DIFF
--- a/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
+++ b/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
@@ -281,58 +281,6 @@ presubmits:
     - master
     always_run: false
     optional: true
-  - name: pull-cert-manager-master-e2e-v1-24
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    annotations:
-      description: Runs the end-to-end test suite against a Kubernetes v1.24 cluster
-      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-      testgrid-create-job-group: "true"
-      testgrid-dashboards: cert-manager-presubmits-master
-    labels:
-      preset-cloudflare-credentials: "true"
-      preset-default-e2e-volumes: "true"
-      preset-dind-enabled: "true"
-      preset-enable-all-feature-gates: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-make-volumes: "true"
-      preset-retry-flakey-jobs: "true"
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
-        args:
-        - runner
-        - make
-        - -j3
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.24
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add:
-            - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-    branches:
-    - master
-    always_run: false
-    optional: true
   - name: pull-cert-manager-master-e2e-v1-25
     max_concurrency: 4
     agent: kubernetes
@@ -383,9 +331,61 @@ presubmits:
           value: "1"
     branches:
     - master
+    always_run: false
+    optional: true
+  - name: pull-cert-manager-master-e2e-v1-24
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.24 cluster
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-job-group: "true"
+      testgrid-dashboards: cert-manager-presubmits-master
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-default-e2e-volumes: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-make-volumes: "true"
+      preset-retry-flakey-jobs: "true"
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+        args:
+        - runner
+        - make
+        - -j3
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.24
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+    branches:
+    - master
     always_run: true
     optional: false
-  - name: pull-cert-manager-master-e2e-v1-25-upgrade
+  - name: pull-cert-manager-master-e2e-v1-24-upgrade
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -405,7 +405,7 @@ presubmits:
         args:
         - runner
         - make
-        - K8S_VERSION=1.25
+        - K8S_VERSION=1.24
         - vendor-go
         - test-upgrade
         resources:
@@ -425,7 +425,7 @@ presubmits:
     - master
     always_run: true
     optional: false
-  - name: pull-cert-manager-master-e2e-v1-25-issuers-venafi-tpp
+  - name: pull-cert-manager-master-e2e-v1-24-issuers-venafi-tpp
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -451,7 +451,7 @@ presubmits:
         - -j3
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.25
+        - K8S_VERSION=1.24
         resources:
           requests:
             cpu: 3500m
@@ -476,7 +476,7 @@ presubmits:
     - master
     always_run: false
     optional: true
-  - name: pull-cert-manager-master-e2e-v1-25-issuers-venafi-cloud
+  - name: pull-cert-manager-master-e2e-v1-24-issuers-venafi-cloud
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -502,7 +502,7 @@ presubmits:
         - -j3
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.25
+        - K8S_VERSION=1.24
         resources:
           requests:
             cpu: 3500m
@@ -527,7 +527,7 @@ presubmits:
     - master
     always_run: false
     optional: true
-  - name: pull-cert-manager-master-e2e-v1-25-feature-gates-disabled
+  - name: pull-cert-manager-master-e2e-v1-24-feature-gates-disabled
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -554,7 +554,7 @@ presubmits:
         - -j3
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.25
+        - K8S_VERSION=1.24
         resources:
           requests:
             cpu: 3500m
@@ -827,59 +827,6 @@ periodics:
     repo: cert-manager
     base_ref: master
   interval: 2h
-- name: ci-cert-manager-master-e2e-v1-24
-  max_concurrency: 4
-  agent: kubernetes
-  decorate: true
-  annotations:
-    description: Runs the end-to-end test suite against a Kubernetes v1.24 cluster
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-master
-  labels:
-    preset-cloudflare-credentials: "true"
-    preset-default-e2e-volumes: "true"
-    preset-dind-enabled: "true"
-    preset-enable-all-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-make-volumes: "true"
-    preset-retry-flakey-jobs: "true"
-    preset-service-account: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
-      args:
-      - runner
-      - make
-      - -j3
-      - vendor-go
-      - e2e-ci
-      - K8S_VERSION=1.24
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 12Gi
-      securityContext:
-        privileged: true
-        capabilities:
-          add:
-          - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: master
-  interval: 2h
 - name: ci-cert-manager-master-e2e-v1-25
   max_concurrency: 4
   agent: kubernetes
@@ -933,7 +880,60 @@ periodics:
     repo: cert-manager
     base_ref: master
   interval: 2h
-- name: ci-cert-manager-master-e2e-v1-25-issuers-venafi
+- name: ci-cert-manager-master-e2e-v1-24
+  max_concurrency: 4
+  agent: kubernetes
+  decorate: true
+  annotations:
+    description: Runs the end-to-end test suite against a Kubernetes v1.24 cluster
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-master
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-default-e2e-volumes: "true"
+    preset-dind-enabled: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-make-volumes: "true"
+    preset-retry-flakey-jobs: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+      args:
+      - runner
+      - make
+      - -j3
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.24
+      resources:
+        requests:
+          cpu: 3500m
+          memory: 12Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: master
+  interval: 2h
+- name: ci-cert-manager-master-e2e-v1-24-issuers-venafi
   max_concurrency: 4
   agent: kubernetes
   decorate: true
@@ -960,7 +960,7 @@ periodics:
       - -j3
       - vendor-go
       - e2e-ci
-      - K8S_VERSION=1.25
+      - K8S_VERSION=1.24
       resources:
         requests:
           cpu: 3500m
@@ -986,7 +986,7 @@ periodics:
     repo: cert-manager
     base_ref: master
   interval: 12h
-- name: ci-cert-manager-master-e2e-v1-25-upgrade
+- name: ci-cert-manager-master-e2e-v1-24-upgrade
   max_concurrency: 4
   agent: kubernetes
   decorate: true
@@ -1006,7 +1006,7 @@ periodics:
       args:
       - runner
       - make
-      - K8S_VERSION=1.25
+      - K8S_VERSION=1.24
       - vendor-go
       - test-upgrade
       resources:
@@ -1239,59 +1239,6 @@ periodics:
     repo: cert-manager
     base_ref: master
   interval: 24h
-- name: ci-cert-manager-master-e2e-v1-24-feature-gates-disabled
-  max_concurrency: 4
-  agent: kubernetes
-  decorate: true
-  annotations:
-    description: Runs the E2E tests with all feature gates disabled
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-master
-  labels:
-    preset-cloudflare-credentials: "true"
-    preset-default-e2e-volumes: "true"
-    preset-dind-enabled: "true"
-    preset-disable-all-alpha-beta-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-make-volumes: "true"
-    preset-retry-flakey-jobs: "true"
-    preset-service-account: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
-      args:
-      - runner
-      - make
-      - -j3
-      - vendor-go
-      - e2e-ci
-      - K8S_VERSION=1.24
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 12Gi
-      securityContext:
-        privileged: true
-        capabilities:
-          add:
-          - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: master
-  interval: 24h
 - name: ci-cert-manager-master-e2e-v1-25-feature-gates-disabled
   max_concurrency: 4
   agent: kubernetes
@@ -1320,6 +1267,59 @@ periodics:
       - vendor-go
       - e2e-ci
       - K8S_VERSION=1.25
+      resources:
+        requests:
+          cpu: 3500m
+          memory: 12Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: master
+  interval: 24h
+- name: ci-cert-manager-master-e2e-v1-24-feature-gates-disabled
+  max_concurrency: 4
+  agent: kubernetes
+  decorate: true
+  annotations:
+    description: Runs the E2E tests with all feature gates disabled
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-master
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-default-e2e-volumes: "true"
+    preset-dind-enabled: "true"
+    preset-disable-all-alpha-beta-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-make-volumes: "true"
+    preset-retry-flakey-jobs: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+      args:
+      - runner
+      - make
+      - -j3
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.24
       resources:
         requests:
           cpu: 3500m

--- a/config/jobs/cert-manager/cert-manager/release-1.8/cert-manager-release-1.8.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.8/cert-manager-release-1.8.yaml
@@ -312,55 +312,6 @@ presubmits:
     - release-1.8
     always_run: false
     optional: true
-  - name: pull-cert-manager-release-1.8-e2e-v1-24
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    annotations:
-      description: Runs the end-to-end test suite against a Kubernetes v1.24 cluster
-    labels:
-      preset-cloudflare-credentials: "true"
-      preset-default-e2e-volumes: "true"
-      preset-dind-enabled: "true"
-      preset-enable-all-feature-gates: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-make-volumes: "true"
-      preset-retry-flakey-jobs: "true"
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j3
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.24
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add:
-            - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-    branches:
-    - release-1.8
-    always_run: false
-    optional: true
   - name: pull-cert-manager-release-1.8-e2e-v1-25
     max_concurrency: 4
     agent: kubernetes
@@ -408,9 +359,58 @@ presubmits:
           value: "1"
     branches:
     - release-1.8
+    always_run: false
+    optional: true
+  - name: pull-cert-manager-release-1.8-e2e-v1-24
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.24 cluster
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-default-e2e-volumes: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-make-volumes: "true"
+      preset-retry-flakey-jobs: "true"
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+        args:
+        - runner
+        - make
+        - -j3
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.24
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+    branches:
+    - release-1.8
     always_run: true
     optional: false
-  - name: pull-cert-manager-release-1.8-e2e-v1-25-issuers-venafi-tpp
+  - name: pull-cert-manager-release-1.8-e2e-v1-24-issuers-venafi-tpp
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -433,7 +433,7 @@ presubmits:
         - -j3
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.25
+        - K8S_VERSION=1.24
         resources:
           requests:
             cpu: 3500m
@@ -458,7 +458,7 @@ presubmits:
     - release-1.8
     always_run: false
     optional: true
-  - name: pull-cert-manager-release-1.8-e2e-v1-25-issuers-venafi-cloud
+  - name: pull-cert-manager-release-1.8-e2e-v1-24-issuers-venafi-cloud
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -481,7 +481,7 @@ presubmits:
         - -j3
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.25
+        - K8S_VERSION=1.24
         resources:
           requests:
             cpu: 3500m
@@ -506,7 +506,7 @@ presubmits:
     - release-1.8
     always_run: false
     optional: true
-  - name: pull-cert-manager-release-1.8-e2e-v1-25-feature-gates-disabled
+  - name: pull-cert-manager-release-1.8-e2e-v1-24-feature-gates-disabled
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -530,7 +530,7 @@ presubmits:
         - -j3
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.25
+        - K8S_VERSION=1.24
         resources:
           requests:
             cpu: 3500m
@@ -856,59 +856,6 @@ periodics:
     repo: cert-manager
     base_ref: release-1.8
   interval: 2h
-- name: ci-cert-manager-release-1.8-e2e-v1-24
-  max_concurrency: 4
-  agent: kubernetes
-  decorate: true
-  annotations:
-    description: Runs the end-to-end test suite against a Kubernetes v1.24 cluster
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-release-1.8
-  labels:
-    preset-cloudflare-credentials: "true"
-    preset-default-e2e-volumes: "true"
-    preset-dind-enabled: "true"
-    preset-enable-all-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-make-volumes: "true"
-    preset-retry-flakey-jobs: "true"
-    preset-service-account: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-      args:
-      - runner
-      - make
-      - -j3
-      - vendor-go
-      - e2e-ci
-      - K8S_VERSION=1.24
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 12Gi
-      securityContext:
-        privileged: true
-        capabilities:
-          add:
-          - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: release-1.8
-  interval: 2h
 - name: ci-cert-manager-release-1.8-e2e-v1-25
   max_concurrency: 4
   agent: kubernetes
@@ -962,7 +909,60 @@ periodics:
     repo: cert-manager
     base_ref: release-1.8
   interval: 2h
-- name: ci-cert-manager-release-1.8-e2e-v1-25-issuers-venafi
+- name: ci-cert-manager-release-1.8-e2e-v1-24
+  max_concurrency: 4
+  agent: kubernetes
+  decorate: true
+  annotations:
+    description: Runs the end-to-end test suite against a Kubernetes v1.24 cluster
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.8
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-default-e2e-volumes: "true"
+    preset-dind-enabled: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-make-volumes: "true"
+    preset-retry-flakey-jobs: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+      args:
+      - runner
+      - make
+      - -j3
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.24
+      resources:
+        requests:
+          cpu: 3500m
+          memory: 12Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.8
+  interval: 2h
+- name: ci-cert-manager-release-1.8-e2e-v1-24-issuers-venafi
   max_concurrency: 4
   agent: kubernetes
   decorate: true
@@ -989,7 +989,7 @@ periodics:
       - -j3
       - vendor-go
       - e2e-ci
-      - K8S_VERSION=1.25
+      - K8S_VERSION=1.24
       resources:
         requests:
           cpu: 3500m
@@ -1280,59 +1280,6 @@ periodics:
     repo: cert-manager
     base_ref: release-1.8
   interval: 24h
-- name: ci-cert-manager-release-1.8-e2e-v1-24-feature-gates-disabled
-  max_concurrency: 4
-  agent: kubernetes
-  decorate: true
-  annotations:
-    description: Runs the E2E tests with all feature gates disabled
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-release-1.8
-  labels:
-    preset-cloudflare-credentials: "true"
-    preset-default-e2e-volumes: "true"
-    preset-dind-enabled: "true"
-    preset-disable-all-alpha-beta-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-make-volumes: "true"
-    preset-retry-flakey-jobs: "true"
-    preset-service-account: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-      args:
-      - runner
-      - make
-      - -j3
-      - vendor-go
-      - e2e-ci
-      - K8S_VERSION=1.24
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 12Gi
-      securityContext:
-        privileged: true
-        capabilities:
-          add:
-          - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: release-1.8
-  interval: 24h
 - name: ci-cert-manager-release-1.8-e2e-v1-25-feature-gates-disabled
   max_concurrency: 4
   agent: kubernetes
@@ -1361,6 +1308,59 @@ periodics:
       - vendor-go
       - e2e-ci
       - K8S_VERSION=1.25
+      resources:
+        requests:
+          cpu: 3500m
+          memory: 12Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.8
+  interval: 24h
+- name: ci-cert-manager-release-1.8-e2e-v1-24-feature-gates-disabled
+  max_concurrency: 4
+  agent: kubernetes
+  decorate: true
+  annotations:
+    description: Runs the E2E tests with all feature gates disabled
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.8
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-default-e2e-volumes: "true"
+    preset-dind-enabled: "true"
+    preset-disable-all-alpha-beta-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-make-volumes: "true"
+    preset-retry-flakey-jobs: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+      args:
+      - runner
+      - make
+      - -j3
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.24
       resources:
         requests:
           cpu: 3500m

--- a/config/jobs/cert-manager/cert-manager/release-1.9/cert-manager-release-1.9.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.9/cert-manager-release-1.9.yaml
@@ -263,55 +263,6 @@ presubmits:
     - release-1.9
     always_run: false
     optional: true
-  - name: pull-cert-manager-release-1.9-e2e-v1-24
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    annotations:
-      description: Runs the end-to-end test suite against a Kubernetes v1.24 cluster
-    labels:
-      preset-cloudflare-credentials: "true"
-      preset-default-e2e-volumes: "true"
-      preset-dind-enabled: "true"
-      preset-enable-all-feature-gates: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-make-volumes: "true"
-      preset-retry-flakey-jobs: "true"
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j3
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.24
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add:
-            - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-    branches:
-    - release-1.9
-    always_run: false
-    optional: true
   - name: pull-cert-manager-release-1.9-e2e-v1-25
     max_concurrency: 4
     agent: kubernetes
@@ -359,9 +310,58 @@ presubmits:
           value: "1"
     branches:
     - release-1.9
+    always_run: false
+    optional: true
+  - name: pull-cert-manager-release-1.9-e2e-v1-24
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.24 cluster
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-default-e2e-volumes: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-make-volumes: "true"
+      preset-retry-flakey-jobs: "true"
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+        args:
+        - runner
+        - make
+        - -j3
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.24
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+    branches:
+    - release-1.9
     always_run: true
     optional: false
-  - name: pull-cert-manager-release-1.9-e2e-v1-25-upgrade
+  - name: pull-cert-manager-release-1.9-e2e-v1-24-upgrade
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -378,7 +378,7 @@ presubmits:
         args:
         - runner
         - make
-        - K8S_VERSION=1.25
+        - K8S_VERSION=1.24
         - vendor-go
         - test-upgrade
         resources:
@@ -398,7 +398,7 @@ presubmits:
     - release-1.9
     always_run: true
     optional: false
-  - name: pull-cert-manager-release-1.9-e2e-v1-25-issuers-venafi-tpp
+  - name: pull-cert-manager-release-1.9-e2e-v1-24-issuers-venafi-tpp
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -421,7 +421,7 @@ presubmits:
         - -j3
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.25
+        - K8S_VERSION=1.24
         resources:
           requests:
             cpu: 3500m
@@ -446,7 +446,7 @@ presubmits:
     - release-1.9
     always_run: false
     optional: true
-  - name: pull-cert-manager-release-1.9-e2e-v1-25-issuers-venafi-cloud
+  - name: pull-cert-manager-release-1.9-e2e-v1-24-issuers-venafi-cloud
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -469,7 +469,7 @@ presubmits:
         - -j3
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.25
+        - K8S_VERSION=1.24
         resources:
           requests:
             cpu: 3500m
@@ -494,7 +494,7 @@ presubmits:
     - release-1.9
     always_run: false
     optional: true
-  - name: pull-cert-manager-release-1.9-e2e-v1-25-feature-gates-disabled
+  - name: pull-cert-manager-release-1.9-e2e-v1-24-feature-gates-disabled
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -518,7 +518,7 @@ presubmits:
         - -j3
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.25
+        - K8S_VERSION=1.24
         resources:
           requests:
             cpu: 3500m
@@ -791,59 +791,6 @@ periodics:
     repo: cert-manager
     base_ref: release-1.9
   interval: 2h
-- name: ci-cert-manager-release-1.9-e2e-v1-24
-  max_concurrency: 4
-  agent: kubernetes
-  decorate: true
-  annotations:
-    description: Runs the end-to-end test suite against a Kubernetes v1.24 cluster
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-release-1.9
-  labels:
-    preset-cloudflare-credentials: "true"
-    preset-default-e2e-volumes: "true"
-    preset-dind-enabled: "true"
-    preset-enable-all-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-make-volumes: "true"
-    preset-retry-flakey-jobs: "true"
-    preset-service-account: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-      args:
-      - runner
-      - make
-      - -j3
-      - vendor-go
-      - e2e-ci
-      - K8S_VERSION=1.24
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 12Gi
-      securityContext:
-        privileged: true
-        capabilities:
-          add:
-          - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: release-1.9
-  interval: 2h
 - name: ci-cert-manager-release-1.9-e2e-v1-25
   max_concurrency: 4
   agent: kubernetes
@@ -897,7 +844,60 @@ periodics:
     repo: cert-manager
     base_ref: release-1.9
   interval: 2h
-- name: ci-cert-manager-release-1.9-e2e-v1-25-issuers-venafi
+- name: ci-cert-manager-release-1.9-e2e-v1-24
+  max_concurrency: 4
+  agent: kubernetes
+  decorate: true
+  annotations:
+    description: Runs the end-to-end test suite against a Kubernetes v1.24 cluster
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.9
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-default-e2e-volumes: "true"
+    preset-dind-enabled: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-make-volumes: "true"
+    preset-retry-flakey-jobs: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+      args:
+      - runner
+      - make
+      - -j3
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.24
+      resources:
+        requests:
+          cpu: 3500m
+          memory: 12Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.9
+  interval: 2h
+- name: ci-cert-manager-release-1.9-e2e-v1-24-issuers-venafi
   max_concurrency: 4
   agent: kubernetes
   decorate: true
@@ -924,7 +924,7 @@ periodics:
       - -j3
       - vendor-go
       - e2e-ci
-      - K8S_VERSION=1.25
+      - K8S_VERSION=1.24
       resources:
         requests:
           cpu: 3500m
@@ -950,7 +950,7 @@ periodics:
     repo: cert-manager
     base_ref: release-1.9
   interval: 12h
-- name: ci-cert-manager-release-1.9-e2e-v1-25-upgrade
+- name: ci-cert-manager-release-1.9-e2e-v1-24-upgrade
   max_concurrency: 4
   agent: kubernetes
   decorate: true
@@ -970,7 +970,7 @@ periodics:
       args:
       - runner
       - make
-      - K8S_VERSION=1.25
+      - K8S_VERSION=1.24
       - vendor-go
       - test-upgrade
       resources:
@@ -1203,59 +1203,6 @@ periodics:
     repo: cert-manager
     base_ref: release-1.9
   interval: 24h
-- name: ci-cert-manager-release-1.9-e2e-v1-24-feature-gates-disabled
-  max_concurrency: 4
-  agent: kubernetes
-  decorate: true
-  annotations:
-    description: Runs the E2E tests with all feature gates disabled
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-release-1.9
-  labels:
-    preset-cloudflare-credentials: "true"
-    preset-default-e2e-volumes: "true"
-    preset-dind-enabled: "true"
-    preset-disable-all-alpha-beta-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-make-volumes: "true"
-    preset-retry-flakey-jobs: "true"
-    preset-service-account: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-      args:
-      - runner
-      - make
-      - -j3
-      - vendor-go
-      - e2e-ci
-      - K8S_VERSION=1.24
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 12Gi
-      securityContext:
-        privileged: true
-        capabilities:
-          add:
-          - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: release-1.9
-  interval: 24h
 - name: ci-cert-manager-release-1.9-e2e-v1-25-feature-gates-disabled
   max_concurrency: 4
   agent: kubernetes
@@ -1284,6 +1231,59 @@ periodics:
       - vendor-go
       - e2e-ci
       - K8S_VERSION=1.25
+      resources:
+        requests:
+          cpu: 3500m
+          memory: 12Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.9
+  interval: 24h
+- name: ci-cert-manager-release-1.9-e2e-v1-24-feature-gates-disabled
+  max_concurrency: 4
+  agent: kubernetes
+  decorate: true
+  annotations:
+    description: Runs the E2E tests with all feature gates disabled
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.9
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-default-e2e-volumes: "true"
+    preset-dind-enabled: "true"
+    preset-disable-all-alpha-beta-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-make-volumes: "true"
+    preset-retry-flakey-jobs: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
+      args:
+      - runner
+      - make
+      - -j3
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.24
       resources:
         requests:
           cpu: 3500m


### PR DESCRIPTION
@jahrlin informed me that we switched to k8s 1.25 too early.
After the 1.10 cert-manager release, we will switch to kubernetes 1.25 for all our default tests.
This PR contains the changes generated by this commit: https://github.com/cert-manager/release/commit/9906389648939e3aef97c0edabd2f19c50a96620.