### PR TITLE
Remove 1.25 tests from  cert-manager/cert-manager release 1.8 & 1.9

### DIFF
--- a/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
+++ b/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
@@ -1,6 +1,6 @@
 # THIS FILE HAS BEEN AUTOMATICALLY GENERATED
 # Don't manually edit it; instead edit the "cmrel" tool which generated it
-# Generated with: cmrel generate-prow --branch * -o file
+# Generated with: cmrel generate-prow -o file --branch=*
 
 presubmits:
   cert-manager/cert-manager:

--- a/config/jobs/cert-manager/cert-manager/release-1.8/cert-manager-release-1.8.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.8/cert-manager-release-1.8.yaml
@@ -1,6 +1,6 @@
 # THIS FILE HAS BEEN AUTOMATICALLY GENERATED
 # Don't manually edit it; instead edit the "cmrel" tool which generated it
-# Generated with: cmrel generate-prow --branch * -o file
+# Generated with: cmrel generate-prow -o file --branch=*
 
 presubmits:
   cert-manager/cert-manager:
@@ -288,55 +288,6 @@ presubmits:
         - vendor-go
         - e2e-ci
         - K8S_VERSION=1.23
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add:
-            - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-    branches:
-    - release-1.8
-    always_run: false
-    optional: true
-  - name: pull-cert-manager-release-1.8-e2e-v1-25
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    annotations:
-      description: Runs the end-to-end test suite against a Kubernetes v1.25 cluster
-    labels:
-      preset-cloudflare-credentials: "true"
-      preset-default-e2e-volumes: "true"
-      preset-dind-enabled: "true"
-      preset-enable-all-feature-gates: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-make-volumes: "true"
-      preset-retry-flakey-jobs: "true"
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j3
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.25
         resources:
           requests:
             cpu: 3500m
@@ -856,59 +807,6 @@ periodics:
     repo: cert-manager
     base_ref: release-1.8
   interval: 2h
-- name: ci-cert-manager-release-1.8-e2e-v1-25
-  max_concurrency: 4
-  agent: kubernetes
-  decorate: true
-  annotations:
-    description: Runs the end-to-end test suite against a Kubernetes v1.25 cluster
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-release-1.8
-  labels:
-    preset-cloudflare-credentials: "true"
-    preset-default-e2e-volumes: "true"
-    preset-dind-enabled: "true"
-    preset-enable-all-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-make-volumes: "true"
-    preset-retry-flakey-jobs: "true"
-    preset-service-account: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-      args:
-      - runner
-      - make
-      - -j3
-      - vendor-go
-      - e2e-ci
-      - K8S_VERSION=1.25
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 12Gi
-      securityContext:
-        privileged: true
-        capabilities:
-          add:
-          - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: release-1.8
-  interval: 2h
 - name: ci-cert-manager-release-1.8-e2e-v1-24
   max_concurrency: 4
   agent: kubernetes
@@ -1255,59 +1153,6 @@ periodics:
       - vendor-go
       - e2e-ci
       - K8S_VERSION=1.23
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 12Gi
-      securityContext:
-        privileged: true
-        capabilities:
-          add:
-          - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: release-1.8
-  interval: 24h
-- name: ci-cert-manager-release-1.8-e2e-v1-25-feature-gates-disabled
-  max_concurrency: 4
-  agent: kubernetes
-  decorate: true
-  annotations:
-    description: Runs the E2E tests with all feature gates disabled
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-release-1.8
-  labels:
-    preset-cloudflare-credentials: "true"
-    preset-default-e2e-volumes: "true"
-    preset-dind-enabled: "true"
-    preset-disable-all-alpha-beta-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-make-volumes: "true"
-    preset-retry-flakey-jobs: "true"
-    preset-service-account: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-      args:
-      - runner
-      - make
-      - -j3
-      - vendor-go
-      - e2e-ci
-      - K8S_VERSION=1.25
       resources:
         requests:
           cpu: 3500m

--- a/config/jobs/cert-manager/cert-manager/release-1.9/cert-manager-release-1.9.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.9/cert-manager-release-1.9.yaml
@@ -1,6 +1,6 @@
 # THIS FILE HAS BEEN AUTOMATICALLY GENERATED
 # Don't manually edit it; instead edit the "cmrel" tool which generated it
-# Generated with: cmrel generate-prow --branch * -o file
+# Generated with: cmrel generate-prow -o file --branch=*
 
 presubmits:
   cert-manager/cert-manager:
@@ -239,55 +239,6 @@ presubmits:
         - vendor-go
         - e2e-ci
         - K8S_VERSION=1.23
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add:
-            - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-    branches:
-    - release-1.9
-    always_run: false
-    optional: true
-  - name: pull-cert-manager-release-1.9-e2e-v1-25
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    annotations:
-      description: Runs the end-to-end test suite against a Kubernetes v1.25 cluster
-    labels:
-      preset-cloudflare-credentials: "true"
-      preset-default-e2e-volumes: "true"
-      preset-dind-enabled: "true"
-      preset-enable-all-feature-gates: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-make-volumes: "true"
-      preset-retry-flakey-jobs: "true"
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-        args:
-        - runner
-        - make
-        - -j3
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.25
         resources:
           requests:
             cpu: 3500m
@@ -791,59 +742,6 @@ periodics:
     repo: cert-manager
     base_ref: release-1.9
   interval: 2h
-- name: ci-cert-manager-release-1.9-e2e-v1-25
-  max_concurrency: 4
-  agent: kubernetes
-  decorate: true
-  annotations:
-    description: Runs the end-to-end test suite against a Kubernetes v1.25 cluster
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-release-1.9
-  labels:
-    preset-cloudflare-credentials: "true"
-    preset-default-e2e-volumes: "true"
-    preset-dind-enabled: "true"
-    preset-enable-all-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-make-volumes: "true"
-    preset-retry-flakey-jobs: "true"
-    preset-service-account: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-      args:
-      - runner
-      - make
-      - -j3
-      - vendor-go
-      - e2e-ci
-      - K8S_VERSION=1.25
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 12Gi
-      securityContext:
-        privileged: true
-        capabilities:
-          add:
-          - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: release-1.9
-  interval: 2h
 - name: ci-cert-manager-release-1.9-e2e-v1-24
   max_concurrency: 4
   agent: kubernetes
@@ -1178,59 +1076,6 @@ periodics:
       - vendor-go
       - e2e-ci
       - K8S_VERSION=1.23
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 12Gi
-      securityContext:
-        privileged: true
-        capabilities:
-          add:
-          - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: release-1.9
-  interval: 24h
-- name: ci-cert-manager-release-1.9-e2e-v1-25-feature-gates-disabled
-  max_concurrency: 4
-  agent: kubernetes
-  decorate: true
-  annotations:
-    description: Runs the E2E tests with all feature gates disabled
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-release-1.9
-  labels:
-    preset-cloudflare-credentials: "true"
-    preset-default-e2e-volumes: "true"
-    preset-dind-enabled: "true"
-    preset-disable-all-alpha-beta-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-make-volumes: "true"
-    preset-retry-flakey-jobs: "true"
-    preset-service-account: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220512-b6ea825-4.2.1
-      args:
-      - runner
-      - make
-      - -j3
-      - vendor-go
-      - e2e-ci
-      - K8S_VERSION=1.25
       resources:
         requests:
           cpu: 3500m


### PR DESCRIPTION
Based on https://github.com/cert-manager/release/pull/103
