### PR TITLE
make k8s 1.25 default

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -57,8 +57,8 @@ branch-protection:
                 contexts:
                 - pull-cert-manager-master-chart
                 - pull-cert-manager-master-make-test
-                - pull-cert-manager-master-e2e-v1-24
-                - pull-cert-manager-master-e2e-v1-24-upgrade
+                - pull-cert-manager-master-e2e-v1-25
+                - pull-cert-manager-master-e2e-v1-25-upgrade
         website:
           required_status_checks:
             contexts:

--- a/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
+++ b/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
@@ -281,58 +281,6 @@ presubmits:
     - master
     always_run: false
     optional: true
-  - name: pull-cert-manager-master-e2e-v1-25
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    annotations:
-      description: Runs the end-to-end test suite against a Kubernetes v1.25 cluster
-      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-      testgrid-create-job-group: "true"
-      testgrid-dashboards: cert-manager-presubmits-master
-    labels:
-      preset-cloudflare-credentials: "true"
-      preset-default-e2e-volumes: "true"
-      preset-dind-enabled: "true"
-      preset-enable-all-feature-gates: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-make-volumes: "true"
-      preset-retry-flakey-jobs: "true"
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
-        args:
-        - runner
-        - make
-        - -j3
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.25
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add:
-            - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-    branches:
-    - master
-    always_run: false
-    optional: true
   - name: pull-cert-manager-master-e2e-v1-24
     max_concurrency: 4
     agent: kubernetes
@@ -383,9 +331,61 @@ presubmits:
           value: "1"
     branches:
     - master
+    always_run: false
+    optional: true
+  - name: pull-cert-manager-master-e2e-v1-25
+    max_concurrency: 4
+    agent: kubernetes
+    decorate: true
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.25 cluster
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-job-group: "true"
+      testgrid-dashboards: cert-manager-presubmits-master
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-default-e2e-volumes: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-make-volumes: "true"
+      preset-retry-flakey-jobs: "true"
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+        args:
+        - runner
+        - make
+        - -j3
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.25
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 12Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+    branches:
+    - master
     always_run: true
     optional: false
-  - name: pull-cert-manager-master-e2e-v1-24-upgrade
+  - name: pull-cert-manager-master-e2e-v1-25-upgrade
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -405,7 +405,7 @@ presubmits:
         args:
         - runner
         - make
-        - K8S_VERSION=1.24
+        - K8S_VERSION=1.25
         - vendor-go
         - test-upgrade
         resources:
@@ -425,7 +425,7 @@ presubmits:
     - master
     always_run: true
     optional: false
-  - name: pull-cert-manager-master-e2e-v1-24-issuers-venafi-tpp
+  - name: pull-cert-manager-master-e2e-v1-25-issuers-venafi-tpp
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -451,7 +451,7 @@ presubmits:
         - -j3
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.24
+        - K8S_VERSION=1.25
         resources:
           requests:
             cpu: 3500m
@@ -476,7 +476,7 @@ presubmits:
     - master
     always_run: false
     optional: true
-  - name: pull-cert-manager-master-e2e-v1-24-issuers-venafi-cloud
+  - name: pull-cert-manager-master-e2e-v1-25-issuers-venafi-cloud
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -502,7 +502,7 @@ presubmits:
         - -j3
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.24
+        - K8S_VERSION=1.25
         resources:
           requests:
             cpu: 3500m
@@ -527,7 +527,7 @@ presubmits:
     - master
     always_run: false
     optional: true
-  - name: pull-cert-manager-master-e2e-v1-24-feature-gates-disabled
+  - name: pull-cert-manager-master-e2e-v1-25-feature-gates-disabled
     max_concurrency: 4
     agent: kubernetes
     decorate: true
@@ -554,7 +554,7 @@ presubmits:
         - -j3
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.24
+        - K8S_VERSION=1.25
         resources:
           requests:
             cpu: 3500m
@@ -827,59 +827,6 @@ periodics:
     repo: cert-manager
     base_ref: master
   interval: 2h
-- name: ci-cert-manager-master-e2e-v1-25
-  max_concurrency: 4
-  agent: kubernetes
-  decorate: true
-  annotations:
-    description: Runs the end-to-end test suite against a Kubernetes v1.25 cluster
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-master
-  labels:
-    preset-cloudflare-credentials: "true"
-    preset-default-e2e-volumes: "true"
-    preset-dind-enabled: "true"
-    preset-enable-all-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-make-volumes: "true"
-    preset-retry-flakey-jobs: "true"
-    preset-service-account: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
-      args:
-      - runner
-      - make
-      - -j3
-      - vendor-go
-      - e2e-ci
-      - K8S_VERSION=1.25
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 12Gi
-      securityContext:
-        privileged: true
-        capabilities:
-          add:
-          - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: master
-  interval: 2h
 - name: ci-cert-manager-master-e2e-v1-24
   max_concurrency: 4
   agent: kubernetes
@@ -933,7 +880,60 @@ periodics:
     repo: cert-manager
     base_ref: master
   interval: 2h
-- name: ci-cert-manager-master-e2e-v1-24-issuers-venafi
+- name: ci-cert-manager-master-e2e-v1-25
+  max_concurrency: 4
+  agent: kubernetes
+  decorate: true
+  annotations:
+    description: Runs the end-to-end test suite against a Kubernetes v1.25 cluster
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-master
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-default-e2e-volumes: "true"
+    preset-dind-enabled: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-make-volumes: "true"
+    preset-retry-flakey-jobs: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+      args:
+      - runner
+      - make
+      - -j3
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.25
+      resources:
+        requests:
+          cpu: 3500m
+          memory: 12Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: master
+  interval: 2h
+- name: ci-cert-manager-master-e2e-v1-25-issuers-venafi
   max_concurrency: 4
   agent: kubernetes
   decorate: true
@@ -960,7 +960,7 @@ periodics:
       - -j3
       - vendor-go
       - e2e-ci
-      - K8S_VERSION=1.24
+      - K8S_VERSION=1.25
       resources:
         requests:
           cpu: 3500m
@@ -986,7 +986,7 @@ periodics:
     repo: cert-manager
     base_ref: master
   interval: 12h
-- name: ci-cert-manager-master-e2e-v1-24-upgrade
+- name: ci-cert-manager-master-e2e-v1-25-upgrade
   max_concurrency: 4
   agent: kubernetes
   decorate: true
@@ -1006,7 +1006,7 @@ periodics:
       args:
       - runner
       - make
-      - K8S_VERSION=1.24
+      - K8S_VERSION=1.25
       - vendor-go
       - test-upgrade
       resources:
@@ -1239,59 +1239,6 @@ periodics:
     repo: cert-manager
     base_ref: master
   interval: 24h
-- name: ci-cert-manager-master-e2e-v1-25-feature-gates-disabled
-  max_concurrency: 4
-  agent: kubernetes
-  decorate: true
-  annotations:
-    description: Runs the E2E tests with all feature gates disabled
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-master
-  labels:
-    preset-cloudflare-credentials: "true"
-    preset-default-e2e-volumes: "true"
-    preset-dind-enabled: "true"
-    preset-disable-all-alpha-beta-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-make-volumes: "true"
-    preset-retry-flakey-jobs: "true"
-    preset-service-account: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
-      args:
-      - runner
-      - make
-      - -j3
-      - vendor-go
-      - e2e-ci
-      - K8S_VERSION=1.25
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 12Gi
-      securityContext:
-        privileged: true
-        capabilities:
-          add:
-          - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: master
-  interval: 24h
 - name: ci-cert-manager-master-e2e-v1-24-feature-gates-disabled
   max_concurrency: 4
   agent: kubernetes
@@ -1320,6 +1267,59 @@ periodics:
       - vendor-go
       - e2e-ci
       - K8S_VERSION=1.24
+      resources:
+        requests:
+          cpu: 3500m
+          memory: 12Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: master
+  interval: 24h
+- name: ci-cert-manager-master-e2e-v1-25-feature-gates-disabled
+  max_concurrency: 4
+  agent: kubernetes
+  decorate: true
+  annotations:
+    description: Runs the E2E tests with all feature gates disabled
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-master
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-default-e2e-volumes: "true"
+    preset-dind-enabled: "true"
+    preset-disable-all-alpha-beta-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-make-volumes: "true"
+    preset-retry-flakey-jobs: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+      args:
+      - runner
+      - make
+      - -j3
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.25
       resources:
         requests:
           cpu: 3500m


### PR DESCRIPTION
This makes K8s v1.25 the default version for presubmits on master

generated from https://github.com/cert-manager/release/pull/104

Signed-off-by: Joakim Ahrlin <joakim.ahrlin@gmail.com>