### PR TITLE
Rename trust to trust-manager

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -68,11 +68,11 @@ branch-protection:
           required_status_checks:
             contexts:
             - pull-cert-manager-webhook-example-verify
-        trust:
+        trust-manager:
           required_status_checks:
             contexts:
-            - pull-cert-manager-trust-verify
-            - pull-cert-manager-trust-smoke
+            - pull-trust-manager-verify
+            - pull-trust-manager-smoke
         csi-lib:
           required_status_checks:
             contexts:

--- a/config/jobs/cert-manager/trust-manager/OWNERS
+++ b/config/jobs/cert-manager/trust-manager/OWNERS
@@ -3,4 +3,4 @@ approvers:
 reviewers:
 - joshvanl
 labels:
-- area/cert-manager-trust
+- area/trust-manager

--- a/config/jobs/cert-manager/trust-manager/trust-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/trust-manager/trust-manager-presubmits.yaml
@@ -1,7 +1,7 @@
 presubmits:
-  cert-manager/trust:
+  cert-manager/trust-manager:
 
-  - name: pull-cert-manager-trust-verify
+  - name: pull-trust-manager-verify
     agent: kubernetes
     decorate: true
     always_run: true
@@ -19,9 +19,9 @@ presubmits:
             cpu: 1
             memory: 1Gi
 
-  # kind based cert-manager-trust smoke job
-  - name: pull-cert-manager-trust-smoke
-    context: pull-cert-manager-trust-smoke
+  # kind based trust-manager smoke job
+  - name: pull-trust-manager-smoke
+    context: pull-trust-manager-smoke
     # Match everything except PRs that only touch docs/
     always_run: true
     optional: false

--- a/config/labels.yaml
+++ b/config/labels.yaml
@@ -83,7 +83,7 @@ repos:
       target: both
       addedBy: prow
 
-  cert-manager/trust:
+  cert-manager/trust-manager:
     labels:
     - color: 0052cc
       description: Indicates a PR modifies deployment configuration

--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -24,7 +24,7 @@ triggers:
 - repos:
   - cert-manager/cert-manager
   - cert-manager/website
-  - cert-manager/trust
+  - cert-manager/trust-manager
   only_org_members: true
 
 blunderbuss:
@@ -61,7 +61,7 @@ repo_milestone:
     # https://github.com/orgs/cert-manager/teams/milestone-maintainers
     maintainers_id: 2805308
     maintainers_team: milestone-maintainers
-  cert-manager/trust:
+  cert-manager/trust-manager:
     # https://github.com/orgs/cert-manager/teams/milestone-maintainers
     maintainers_id: 2805308
     maintainers_team: milestone-maintainers
@@ -92,7 +92,7 @@ milestone_applier:
     master: v0.2
     release-0.1: v0.1
     release-0.2: v0.2
-  cert-manager/trust:
+  cert-manager/trust-manager:
     master: v0.1
 
 config_updater:


### PR DESCRIPTION
The testing configuration needs to be updated since the project name changed.