### PR TITLE
add trivy tests for release-1.10 branch

### DIFF
--- a/config/jobs/cert-manager/cert-manager/release-1.10/cert-manager-release-1.10.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.10/cert-manager-release-1.10.yaml
@@ -1309,3 +1309,188 @@ periodics:
     repo: cert-manager
     base_ref: release-1.10
   interval: 24h
+- name: ci-cert-manager-release-1.10-trivy-test-controller
+  max_concurrency: 2
+  agent: kubernetes
+  decorate: true
+  annotations:
+    description: Runs a Trivy scan against the controller container
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.10
+  labels:
+    preset-dind-enabled: "true"
+    preset-make-volumes: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+      args:
+      - runner
+      - make
+      - -j1
+      - vendor-go
+      - trivy-scan-controller
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 2Gi
+      securityContext:
+        privileged: true
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.10
+  interval: 24h
+- name: ci-cert-manager-release-1.10-trivy-test-acmesolver
+  max_concurrency: 2
+  agent: kubernetes
+  decorate: true
+  annotations:
+    description: Runs a Trivy scan against the acmesolver container
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.10
+  labels:
+    preset-dind-enabled: "true"
+    preset-make-volumes: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+      args:
+      - runner
+      - make
+      - -j1
+      - vendor-go
+      - trivy-scan-acmesolver
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 2Gi
+      securityContext:
+        privileged: true
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.10
+  interval: 24h
+- name: ci-cert-manager-release-1.10-trivy-test-ctl
+  max_concurrency: 2
+  agent: kubernetes
+  decorate: true
+  annotations:
+    description: Runs a Trivy scan against the ctl container
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.10
+  labels:
+    preset-dind-enabled: "true"
+    preset-make-volumes: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+      args:
+      - runner
+      - make
+      - -j1
+      - vendor-go
+      - trivy-scan-ctl
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 2Gi
+      securityContext:
+        privileged: true
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.10
+  interval: 24h
+- name: ci-cert-manager-release-1.10-trivy-test-cainjector
+  max_concurrency: 2
+  agent: kubernetes
+  decorate: true
+  annotations:
+    description: Runs a Trivy scan against the cainjector container
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.10
+  labels:
+    preset-dind-enabled: "true"
+    preset-make-volumes: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+      args:
+      - runner
+      - make
+      - -j1
+      - vendor-go
+      - trivy-scan-cainjector
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 2Gi
+      securityContext:
+        privileged: true
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.10
+  interval: 24h
+- name: ci-cert-manager-release-1.10-trivy-test-webhook
+  max_concurrency: 2
+  agent: kubernetes
+  decorate: true
+  annotations:
+    description: Runs a Trivy scan against the webhook container
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.10
+  labels:
+    preset-dind-enabled: "true"
+    preset-make-volumes: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+      args:
+      - runner
+      - make
+      - -j1
+      - vendor-go
+      - trivy-scan-webhook
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 2Gi
+      securityContext:
+        privileged: true
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.10
+  interval: 24h


### PR DESCRIPTION
Should be merged after https://github.com/cert-manager/release/pull/110 which adds the generation for these tests