### PR TITLE
Bump Go version for example-webhook test

### DIFF
--- a/config/jobs/cert-manager/webhook-example/cert-manager-webhook-example-presubmits.yaml
+++ b/config/jobs/cert-manager/webhook-example/cert-manager-webhook-example-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: golang:1.17-buster
+      - image: golang:1.19-buster
         args:
         - make
         - test


### PR DESCRIPTION
Bump Go version for example-webhook test https://github.com/cert-manager/webhook-example

This will be using Go 1.19 as of https://github.com/cert-manager/webhook-example/pull/45 - this PR is needed to get the linked one to pass tests

Signed-off-by: irbekrm <irbekrm@gmail.com>