### PR TITLE
Prevent administrators from accidentally pushing directly to protected branches

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -31,6 +31,10 @@ branch-protection:
   orgs:
     cert-manager:
       protect: true
+      # Prevent administrators from accidentally pushing directly to protected branches.
+      # Causes the "Include Administrators" checkbox to be ticked in the GitHub branch protection UI.
+      # See https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#do-not-allow-bypassing-the-above-settings
+      enforce_admins: true
       required_status_checks:
         contexts:
         - dco


### PR DESCRIPTION
Causes the "Do not allow bypassing the above settings" checkbox to be ticked in the GitHub branch protection UI. See
* https://github.com/kubernetes/test-infra/blob/4afb74fe039d8d98b07397c1caba238f4bbf5fd1/prow/config/prow-config-documented.yaml#L16-L17
* https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#do-not-allow-bypassing-the-above-settings

![image](https://user-images.githubusercontent.com/978965/215067177-db43588d-f443-47f5-8f6e-9ab3b1227c4e.png)


One problem with this is that I expect it will prevent us fast forwarding the release branches during alpha releases and first beta release.
1. ~~The work around would be to create a PR merging master into the release branch, but that will cause a DCO problem because the merge commit will not be signed odd.~~
2. ~~Alternatively I could apply this new setting only to the master / main branches in the individual repos.~~
3. Disable branch protection temporarily during releases. This was the preferred solution when we discussed it during the standup, so I have documented it here:
  * https://github.com/cert-manager/website/pull/1173