### PR TITLE
Update triageparty config

### DIFF
--- a/triage_party/triageparty_configmap.yaml
+++ b/triage_party/triageparty_configmap.yaml
@@ -31,6 +31,11 @@ data:
         - https://github.com/cert-manager/trust-manager
         - https://github.com/cert-manager/csi-driver
         - https://github.com/cert-manager/csi-driver-spiffe
+        - https://github.com/cert-manager/openshift-routes
+        - https://github.com/cert-manager/cert-manager-olm
+        - https://github.com/cert-manager/webhook-lib
+        - https://github.com/cert-manager/csi-lib
+        - https://github.com/cert-manager/sample-external-issuer
 
     collections:
       - id: daily

--- a/triage_party/triageparty_configmap.yaml
+++ b/triage_party/triageparty_configmap.yaml
@@ -26,6 +26,11 @@ data:
         - https://github.com/cert-manager/cert-manager
         - https://github.com/cert-manager/website
         - https://github.com/cert-manager/release
+        - https://github.com/cert-manager/istio-csr
+        - https://github.com/cert-manager/approver-policy
+        - https://github.com/cert-manager/trust-manager
+        - https://github.com/cert-manager/csi-driver
+        - https://github.com/cert-manager/csi-driver-spiffe
 
     collections:
       - id: daily

--- a/triage_party/triageparty_deployment.yaml
+++ b/triage_party/triageparty_deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: triageparty
-        image: triageparty/triage-party:1.3.0
+        image: triageparty/triage-party:1.4.0
         env:
         - name: GITHUB_TOKEN
           valueFrom:


### PR DESCRIPTION
This PR:
- Adds approver-policy, istio-csr, csi-driver, csi-driver-spiffe and trust-manager as projects whose issues will appear in triage party
- Bumps triage party version

I've already applied this change as this is currently deployed from local state with Bazel and you can see the updated triage party in https://triage.build-infra.jetstack.net/s/daily