### PR TITLE
Removes 1.21 tests

### DIFF
--- a/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
+++ b/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
@@ -1,6 +1,6 @@
 # THIS FILE HAS BEEN AUTOMATICALLY GENERATED
 # Don't manually edit it; instead edit the "cmrel" tool which generated it
-# Generated with: cmrel generate-prow --branch * -o file
+# Generated with: main generate-prow --branch master
 
 presubmits:
   cert-manager/cert-manager:
@@ -73,58 +73,6 @@ presubmits:
     - master
     always_run: true
     optional: false
-  - name: pull-cert-manager-master-e2e-v1-21
-    max_concurrency: 4
-    agent: kubernetes
-    decorate: true
-    annotations:
-      description: Runs the end-to-end test suite against a Kubernetes v1.21 cluster
-      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-      testgrid-create-job-group: "true"
-      testgrid-dashboards: cert-manager-presubmits-master
-    labels:
-      preset-cloudflare-credentials: "true"
-      preset-default-e2e-volumes: "true"
-      preset-dind-enabled: "true"
-      preset-enable-all-feature-gates-disable-ssa: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-make-volumes: "true"
-      preset-retry-flakey-jobs: "true"
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
-        args:
-        - runner
-        - make
-        - -j3
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.21
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add:
-            - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-    branches:
-    - master
-    always_run: false
-    optional: true
   - name: pull-cert-manager-master-e2e-v1-22
     max_concurrency: 4
     agent: kubernetes
@@ -703,59 +651,6 @@ periodics:
     repo: cert-manager
     base_ref: master
   interval: 2h
-- name: ci-cert-manager-master-e2e-v1-21
-  max_concurrency: 4
-  agent: kubernetes
-  decorate: true
-  annotations:
-    description: Runs the end-to-end test suite against a Kubernetes v1.21 cluster
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-master
-  labels:
-    preset-cloudflare-credentials: "true"
-    preset-default-e2e-volumes: "true"
-    preset-dind-enabled: "true"
-    preset-enable-all-feature-gates-disable-ssa: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-make-volumes: "true"
-    preset-retry-flakey-jobs: "true"
-    preset-service-account: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
-      args:
-      - runner
-      - make
-      - -j3
-      - vendor-go
-      - e2e-ci
-      - K8S_VERSION=1.21
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 12Gi
-      securityContext:
-        privileged: true
-        capabilities:
-          add:
-          - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: master
-  interval: 2h
 - name: ci-cert-manager-master-e2e-v1-22
   max_concurrency: 4
   agent: kubernetes
@@ -1145,59 +1040,6 @@ periodics:
       - vendor-go
       - e2e-ci
       - K8S_VERSION=1.26
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 12Gi
-      securityContext:
-        privileged: true
-        capabilities:
-          add:
-          - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: master
-  interval: 24h
-- name: ci-cert-manager-master-e2e-v1-21-feature-gates-disabled
-  max_concurrency: 4
-  agent: kubernetes
-  decorate: true
-  annotations:
-    description: Runs the E2E tests with all feature gates disabled
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-master
-  labels:
-    preset-cloudflare-credentials: "true"
-    preset-default-e2e-volumes: "true"
-    preset-dind-enabled: "true"
-    preset-disable-all-alpha-beta-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-make-volumes: "true"
-    preset-retry-flakey-jobs: "true"
-    preset-service-account: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
-      args:
-      - runner
-      - make
-      - -j3
-      - vendor-go
-      - e2e-ci
-      - K8S_VERSION=1.21
       resources:
         requests:
           cpu: 3500m


### PR DESCRIPTION
As cert-manager v1.12 will not support Kubernetes 1.21 see https://cert-manager.io/docs/installation/supported-releases/

The change in this PR was generated from the change in cmrel https://github.com/cert-manager/release/pull/119

Note: I wonder whether it wouldn't make sense to get the cmrel command that generates Prow configs to read dynamic config params like kube version from a yaml file that we could commit to this repo. That way only one PR would be needed to do things like bump kube version.

Signed-off-by: irbekrm <irbekrm@gmail.com>