### PR TITLE
Adds 'test' presubmit separate from the 'verify' target.

### DIFF
--- a/config/jobs/cert-manager/approver-policy/cert-manager-approver-policy-presubmits.yaml
+++ b/config/jobs/cert-manager/approver-policy/cert-manager-approver-policy-presubmits.yaml
@@ -20,6 +20,25 @@ presubmits:
             cpu: 1
             memory: 1Gi
 
+  - name: pull-cert-manager-approver-policy-test
+    context: pull-cert-manager-approver-policy-test
+    agent: kubernetes
+    decorate: true
+    always_run: true
+    max_concurrency: 8
+    annotations:
+      testgrid-create-test-group: 'false'
+    spec:
+      containers:
+      - image: golang:1.19
+        args:
+        - make
+        - test
+        resources:
+          requests:
+            cpu: 1
+            memory: 1Gi
+
   - name: pull-cert-manager-approver-policy-smoke
     context: pull-cert-manager-approver-policy-smoke
     agent: kubernetes


### PR DESCRIPTION
In https://github.com/cert-manager/approver-policy/pull/201, I remove the tests from the 'verify' make target and move them to the 'test' target instead. It was quite confusing to me that the 'verify' target was also running tests.