### PR TITLE
Bump go version to 1.19 in istio-csr presubmits

### DIFF
--- a/config/jobs/cert-manager/istio-csr/cert-manager-istio-csr-presubmits.yaml
+++ b/config/jobs/cert-manager/istio-csr/cert-manager-istio-csr-presubmits.yaml
@@ -12,7 +12,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: golang:1.18
+      - image: golang:1.19
         args:
         - make
         - verify
@@ -34,7 +34,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20220809-0643a25-1.18
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20220809-0643a25-1.19
         args:
         - runner
         - make
@@ -82,7 +82,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20220809-0643a25-1.18
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20220809-0643a25-1.19
         args:
         - runner
         - make
@@ -135,7 +135,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20220809-0643a25-1.18
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20220809-0643a25-1.19
         args:
         - runner
         - make
@@ -188,7 +188,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20220809-0643a25-1.18
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20220809-0643a25-1.19
         args:
         - runner
         - make
@@ -241,7 +241,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20220809-0643a25-1.18
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20220809-0643a25-1.19
         args:
         - runner
         - make
@@ -294,7 +294,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20220809-0643a25-1.18
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20220809-0643a25-1.19
         args:
         - runner
         - make


### PR DESCRIPTION
Signed-off-by: Michael Malov <14035243+malovme@users.noreply.github.com>