### PR TITLE
Use k8s 1.26 and istio 1.15, 1.16, 1.17 for istio-csr tests

### DIFF
--- a/config/jobs/cert-manager/istio-csr/cert-manager-istio-csr-presubmits.yaml
+++ b/config/jobs/cert-manager/istio-csr/cert-manager-istio-csr-presubmits.yaml
@@ -67,9 +67,9 @@ presubmits:
         - name: ndots
           value: "1"
 
-  # kind based istio-csr e2e job for Kubernetes v1.24, istio v1.10
-  - name: pull-cert-manager-istio-csr-k8s-v1-24-istio-v1-10
-    context: pull-cert-manager-istio-csr-k8s-v1-24-istio-v1-10
+  # kind based istio-csr e2e job for Kubernetes v1.26, istio v1.15
+  - name: pull-cert-manager-istio-csr-k8s-v1-26-istio-v1-15
+    context: pull-cert-manager-istio-csr-k8s-v1-26-istio-v1-15
     always_run: true
     optional: false
     max_concurrency: 8
@@ -93,9 +93,9 @@ presubmits:
             memory: 12Gi
         env:
         - name: K8S_VERSION
-          value: "1.24.1"
+          value: "1.26.1"
         - name: ISTIO_VERSION
-          value: "1.10.0"
+          value: "1.15.5"
         securityContext:
           privileged: true
           capabilities:
@@ -120,9 +120,9 @@ presubmits:
           - name: ndots
             value: "1"
 
-  # kind based istio-csr e2e job for Kubernetes v1.24, istio v1.11
-  - name: pull-cert-manager-istio-csr-k8s-v1-24-istio-v1-11
-    context: pull-cert-manager-istio-csr-k8s-v1-24-istio-v1-11
+  # kind based istio-csr e2e job for Kubernetes v1.26, istio v1.16
+  - name: pull-cert-manager-istio-csr-k8s-v1-26-istio-v1-16
+    context: pull-cert-manager-istio-csr-k8s-v1-26-istio-v1-16
     always_run: true
     optional: false
     max_concurrency: 8
@@ -146,9 +146,9 @@ presubmits:
             memory: 12Gi
         env:
         - name: K8S_VERSION
-          value: "1.24.1"
+          value: "1.26.1"
         - name: ISTIO_VERSION
-          value: "1.11.4"
+          value: "1.16.2"
         securityContext:
           privileged: true
           capabilities:
@@ -173,9 +173,9 @@ presubmits:
           - name: ndots
             value: "1"
 
-  # kind based istio-csr e2e job for Kubernetes v1.24, istio v1.12
-  - name: pull-cert-manager-istio-csr-k8s-v1-24-istio-v1-12
-    context: pull-cert-manager-istio-csr-k8s-v1-24-istio-v1-12
+  # kind based istio-csr e2e job for Kubernetes v1.26, istio v1.17
+  - name: pull-cert-manager-istio-csr-k8s-v1-26-istio-v1-17
+    context: pull-cert-manager-istio-csr-k8s-v1-26-istio-v1-17
     always_run: true
     optional: false
     max_concurrency: 8
@@ -199,115 +199,9 @@ presubmits:
             memory: 12Gi
         env:
         - name: K8S_VERSION
-          value: "1.24.1"
+          value: "1.26.1"
         - name: ISTIO_VERSION
-          value: "1.12.2"
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-      dnsConfig:
-        options:
-          - name: ndots
-            value: "1"
-
-  # kind based istio-csr e2e job for Kubernetes v1.24, istio v1.13
-  - name: pull-cert-manager-istio-csr-k8s-v1-24-istio-v1-13
-    context: pull-cert-manager-istio-csr-k8s-v1-24-istio-v1-13
-    always_run: true
-    optional: false
-    max_concurrency: 8
-    agent: kubernetes
-    decorate: true
-    branches:
-    - ^main$
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20220809-0643a25-1.19
-        args:
-        - runner
-        - make
-        - e2e
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        env:
-        - name: K8S_VERSION
-          value: "1.24.1"
-        - name: ISTIO_VERSION
-          value: "1.13.4"
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-      dnsConfig:
-        options:
-          - name: ndots
-            value: "1"
-
-  # kind based istio-csr e2e job for Kubernetes v1.24, istio v1.14
-  - name: pull-cert-manager-istio-csr-k8s-v1-24-istio-v1-14
-    context: pull-cert-manager-istio-csr-k8s-v1-24-istio-v1-14
-    always_run: true
-    optional: false
-    max_concurrency: 8
-    agent: kubernetes
-    decorate: true
-    branches:
-    - ^main$
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20220809-0643a25-1.19
-        args:
-        - runner
-        - make
-        - e2e
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 12Gi
-        env:
-        - name: K8S_VERSION
-          value: "1.24.1"
-        - name: ISTIO_VERSION
-          value: "1.14.1"
+          value: "1.17.0"
         securityContext:
           privileged: true
           capabilities:


### PR DESCRIPTION
Bump k8s version to 1.26 and istio versions to 1.12-1.16 in istio-csr presubmits

Signed-off-by: Michael Malov <14035243+malovme@users.noreply.github.com>