### PR TITLE
Bump go version to 1.19 for csi-lib test

### DIFF
--- a/config/jobs/cert-manager/csi-lib/cert-manager-csi-lib-presubmits.yaml
+++ b/config/jobs/cert-manager/csi-lib/cert-manager-csi-lib-presubmits.yaml
@@ -13,7 +13,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: golang:1.18.1
+      - image: golang:1.19
         args:
         - ./hack/verify-all.sh
         resources:


### PR DESCRIPTION
Pre-requisite for https://github.com/cert-manager/csi-lib/pull/43