### PR TITLE
Bump golang-dind and add build env for golang 1.19.7

### DIFF
--- a/images/golang-dind/build.yaml
+++ b/images/golang-dind/build.yaml
@@ -3,8 +3,8 @@ name: golang-dind # Name of the image to be built
 variants:
   "1.19":
     arguments:
-      BASE_IMAGE: "eu.gcr.io/jetstack-build-infra-images/bazelbuild@sha256:4757d0b78814ccc138561b9e2b57c3b84d2b339d2d3c5c796e5520f3cd298aa4"
-      GO_VERSION: "1.19"
+      BASE_IMAGE: "eu.gcr.io/jetstack-build-infra-images/bazelbuild@sha256:6409016944bf6d601062062a91d283bea64834fa1f6074430d16007366a1f89c"
+      GO_VERSION: "1.19.7"
   "1.18":
     arguments:
       BASE_IMAGE: "eu.gcr.io/jetstack-build-infra-images/bazelbuild@sha256:4757d0b78814ccc138561b9e2b57c3b84d2b339d2d3c5c796e5520f3cd298aa4"


### PR DESCRIPTION
This follows on from #799 and creates a new golang-dind image based on the bazelbuild image created in that PR.

There'll be one more followup to use the new golang-dind image for the cmrel jobs.

```console
$ crane digest eu.gcr.io/jetstack-build-infra-images/bazelbuild:20230323-d2dfab2-4.2.3
sha256:6409016944bf6d601062062a91d283bea64834fa1f6074430d16007366a1f89c
```