### PR TITLE
Add make-dind image

### DIFF
--- a/config/jobs/testing/testing-trusted.yaml
+++ b/config/jobs/testing/testing-trusted.yaml
@@ -134,6 +134,43 @@ postsubmits:
           capabilities:
             add: ["SYS_ADMIN"]
 
+  - name: post-testing-push-make-dind
+    cluster: trusted
+    run_if_changed: '^images/make-dind/'
+    branches:
+    - master
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-image-deploy: "true"
+      preset-deployer-service-account: "true"
+      preset-deployer-github-token: "true"
+      preset-deployer-ssh-key: "true"
+    annotations:
+      testgrid-create-test-group: 'true'
+      testgrid-dashboards: jetstack-testing-janitors
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-disable-prowjob-analysis: "true"
+      description: Build and push the 'make-dind' image
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20210831-4cf7b0b-4.2.1
+        args:
+        # Wrap the release script with the runner so we can use docker-in-docker
+        - runner
+        - images/builder/ci-runner.sh
+        - images/make-dind
+        - --confirm=true
+        resources:
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+
   - name: post-testing-push-golang-dind
     cluster: trusted
     run_if_changed: '^images/golang-dind/'

--- a/images/make-dind/Dockerfile
+++ b/images/make-dind/Dockerfile
@@ -1,0 +1,98 @@
+# Copyright 2023 The Jetstack contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Includes make, docker-in-docker and gcloud
+ARG DEBIAN_VERSION
+FROM debian:"${DEBIAN_VERSION}"
+
+LABEL maintainer="cert-manager-maintainers@googlegroups.com"
+
+#
+# BEGIN: DOCKER IN DOCKER SETUP
+#
+
+# Install Docker deps, some of these are already installed in the image but
+# that's fine since they won't re-install and we can reuse the code below
+# for another image someday.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        apt-transport-https \
+        ca-certificates \
+        curl \
+        gnupg2 \
+        software-properties-common \
+        lsb-release \
+    && apt-get clean
+
+# Add the Docker apt-repository
+RUN mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
+    && echo "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" \
+    | tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+# Install Docker
+# TODO(bentheelder): the `sed` is a bit of a hack, look into alternatives.
+# Why this exists: `docker service start` on debian runs a `cgroupfs_mount` method,
+# We're already inside docker though so we can be sure these are already mounted.
+# Trying to remount these makes for a very noisy error block in the beginning of
+# the pod logs, so we just comment out the call to it... :shrug:
+ARG DOCKER_VERSION
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends docker-ce="${DOCKER_VERSION}" \
+    && apt-get clean \
+    && sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker \
+    && update-alternatives --set iptables /usr/sbin/iptables-legacy \
+    && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+
+# Move Docker's storage location & enable experimental features & add Container Registry cache (see: https://cloud.google.com/container-registry/docs/pulling-cached-images)
+RUN echo 'DOCKER_OPTS="${DOCKER_OPTS} --data-root=/docker-graph --experimental --registry-mirror=https://mirror.gcr.io"' | \
+    tee --append /etc/default/docker
+
+# NOTE this should be mounted and persisted as a volume ideally (!)
+VOLUME /docker-graph
+
+#
+# END: DOCKER IN DOCKER SETUP
+#
+
+# Add the google-cloud-sdk apt-repository
+RUN mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /etc/apt/keyrings/cloud.google.gpg \
+    && echo "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt "cloud-sdk-$(. /etc/os-release && echo "$VERSION_CODENAME")" main" \
+    | tee /etc/apt/sources.list.d/google-cloud-sdk.list > /dev/null
+
+# make is installed simply because a lot of things use it - it is not required
+# by Bazel
+# moreutils is used to get timestamping on stdout
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        google-cloud-sdk \
+        zip \
+        unzip \
+        python \
+        python3-pip \
+        wget \
+        ca-certificates \
+        git \
+        make \
+        rsync \
+        patch \
+    && apt-get clean \
+    && python3 -m pip install --upgrade pip setuptools wheel
+
+WORKDIR /workspace
+
+COPY runner /usr/local/bin/runner
+
+ENTRYPOINT ["/usr/local/bin/runner"]

--- a/images/make-dind/README.md
+++ b/images/make-dind/README.md
@@ -1,0 +1,5 @@
+# make-dind
+
+A slim image containing Docker-in-Docker, gcloud and Make.
+
+This image can be used as a basis for any make-based project.

--- a/images/make-dind/build.yaml
+++ b/images/make-dind/build.yaml
@@ -1,0 +1,14 @@
+name: make-dind # Name of the image to be built
+
+# Variants allow multiple images to be built in a single build step, with
+# different build arguments for each build.
+variants:
+  bullseye:
+    arguments:
+      DEBIAN_VERSION: bullseye-slim
+      DOCKER_VERSION: 5:23.0.1-1~debian.11~bullseye
+
+# Image names to be tagged and pushed
+images:
+- ${_REGISTRY}/${_NAME}:${_DATE_STAMP}-${_GIT_REF}-${_VARIANT}
+- ${_REGISTRY}/${_NAME}:latest-${_VARIANT}

--- a/images/make-dind/runner
+++ b/images/make-dind/runner
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# generic runner script, handles DIND, etc.
+
+export DOCKER_IN_DOCKER_ENABLED=${DOCKER_IN_DOCKER_ENABLED:-false}
+
+if [[ "${DOCKER_CONFIG:-}" != "" ]]; then
+    if [[ "${DOCKER_IN_DOCKER_ENABLED}" != "true" ]]; then
+        echo >&2 "DOCKER_CONFIG was requested but DOCKER_IN_DOCKER_ENABLED is not true."
+        exit 1
+    fi
+
+    echo "A writable DOCKER_CONFIG was requested."
+    tmpdir="$(mktemp -d)"
+    ln -s "${DOCKER_CONFIG}/config.json" "${tmpdir}/config.json"
+    export DOCKER_CONFIG="${tmpdir}"
+fi
+
+if [[ "${EXTRA_DOCKER_OPTS:-}" != "" ]]; then
+    if [[ "${DOCKER_IN_DOCKER_ENABLED}" != "true" ]]; then
+        echo >&2 "EXTRA_DOCKER_OPTS was requested but DOCKER_IN_DOCKER_ENABLED is not true."
+        exit 1
+    fi
+
+    echo "DOCKER_OPTS=\"\${DOCKER_OPTS} ${EXTRA_DOCKER_OPTS}\"" >>/etc/default/docker
+fi
+
+if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
+    echo >&2 "Initializing Docker in Docker."
+
+    service docker start
+    # The service may be marked as ready but the Docker socket may not be
+    # ready yet.
+    WAIT_N=0
+    MAX_WAIT=5
+    while true; do
+        # docker ps -q should only work if the daemon is ready
+        docker ps -q >/dev/null 2>&1 && break
+        if [[ ${WAIT_N} -lt ${MAX_WAIT} ]]; then
+            WAIT_N=$((WAIT_N + 1))
+            echo >&2 "Waiting for docker to be ready, sleeping for ${WAIT_N} seconds."
+            sleep ${WAIT_N}
+        else
+            echo >&2 "Reached maximum attempts, not waiting any longer..."
+            break
+        fi
+    done
+fi
+
+# Disable error exit so we can run post-command cleanup.
+set +o errexit
+
+# Run the actual job.
+"$@" &
+
+# Bash does not "trikle down" UNIX signals. If the Bash script receives SIGINT
+# coming from Prow due to the 2 hours timeout being hit, and that the above
+# command "$@" is running, then SIGINT won't be passed down to the "$@" command.
+# To work around that, we trap SIGINT and SIGTERM and pass then down
+# explicitely. The reasons for handling both SIGTERM and SIGINT is detailed in
+# the following table:
+#
+#  |                          Reason                          |   Signal    |
+#  |----------------------------------------------------------|-------------|
+#  | The 2 hours Prow timeout has been reached                | SIGINT [1]  |
+#  | Google Cloud VM preempted using ACPI shutdown            | SIGTERM [2] |
+#  | GKE worker removed due to scale down using ACPI shutdown | SIGTERM [2] |
+#
+#  [1]: https://github.com/kubernetes/test-infra/blob/ee1e7c8/prow/entrypoint/run.go#L242
+#  [2]: https://unix.stackexchange.com/questions/499761/what-signal-is-sent-to-running-programs-scripts-on-shutdown
+#
+# shellcheck disable=SC2064
+trap "kill -s INT $!" INT
+# shellcheck disable=SC2064
+trap "kill -s TERM $!" TERM
+wait $!
+
+EXIT_VALUE=$?
+
+# cleanup after job
+if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
+    echo "Stopping docker ..."
+    service docker stop || true
+fi
+
+# preserve exit value from job / bootstrap
+exit ${EXIT_VALUE}


### PR DESCRIPTION
The `make-dind` image is a minimal debian image with Make, Docker and google-cloud-sdk installed.
Next step is to use this as the base of some of our golang image and use that golang image as a replacement for bazelbuild for builing images.
For testing of eg. cert-manager, this image should be a working replacement for bazelbuild.