### PR TITLE
Re-add GH required check for website

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -80,6 +80,7 @@ branch-protection:
           required_status_checks:
             contexts:
             - netlify/cert-manager-website/deploy-preview # See https://github.com/cert-manager/infrastructure#netlify
+            - pull-cert-manager-website-verify
         webhook-example:
           required_status_checks:
             contexts:


### PR DESCRIPTION
In https://github.com/jetstack/testing/commit/c66818e542d23a43fdbf2b89f52b31be2daad51e, we incorrectly removed this check. We are still using the same check name however, now it is just a GH action.