### PR TITLE
Switch to make-dind for our tests

### DIFF
--- a/config/jobs/cert-manager/approver-policy/cert-manager-approver-policy-presubmits.yaml
+++ b/config/jobs/cert-manager/approver-policy/cert-manager-approver-policy-presubmits.yaml
@@ -50,7 +50,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20230323-f4c9aec-1.19.7
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make

--- a/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
+++ b/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
@@ -18,7 +18,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20230323-d2dfab2-4.2.3
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -53,7 +53,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20230323-d2dfab2-4.2.3
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -93,7 +93,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20230323-d2dfab2-4.2.3
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -145,7 +145,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20230323-d2dfab2-4.2.3
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -197,7 +197,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20230323-d2dfab2-4.2.3
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -249,7 +249,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20230323-d2dfab2-4.2.3
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -301,7 +301,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20230323-d2dfab2-4.2.3
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -349,7 +349,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20230323-d2dfab2-4.2.3
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -388,7 +388,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20230323-d2dfab2-4.2.3
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -426,7 +426,7 @@ presubmits:
       preset-venafi-tpp-credentials: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20230323-d2dfab2-4.2.3
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -477,7 +477,7 @@ presubmits:
       preset-venafi-cloud-credentials: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20230323-d2dfab2-4.2.3
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -529,7 +529,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20230323-d2dfab2-4.2.3
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -583,7 +583,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20230323-d2dfab2-4.2.3
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -630,7 +630,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20230323-d2dfab2-4.2.3
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -671,7 +671,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20230323-d2dfab2-4.2.3
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -724,7 +724,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20230323-d2dfab2-4.2.3
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -777,7 +777,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20230323-d2dfab2-4.2.3
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -830,7 +830,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20230323-d2dfab2-4.2.3
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -883,7 +883,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20230323-d2dfab2-4.2.3
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -936,7 +936,7 @@ periodics:
     preset-venafi-tpp-credentials: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20230323-d2dfab2-4.2.3
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -985,7 +985,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20230323-d2dfab2-4.2.3
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -1032,7 +1032,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20230323-d2dfab2-4.2.3
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -1085,7 +1085,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20230323-d2dfab2-4.2.3
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -1138,7 +1138,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20230323-d2dfab2-4.2.3
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -1191,7 +1191,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20230323-d2dfab2-4.2.3
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -1244,7 +1244,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20230323-d2dfab2-4.2.3
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -1297,7 +1297,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20230323-d2dfab2-4.2.3
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -1347,7 +1347,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20230323-d2dfab2-4.2.3
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -1386,7 +1386,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20230323-d2dfab2-4.2.3
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -1425,7 +1425,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20230323-d2dfab2-4.2.3
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -1464,7 +1464,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20230323-d2dfab2-4.2.3
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -1503,7 +1503,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20230323-d2dfab2-4.2.3
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make

--- a/config/jobs/cert-manager/cert-manager/release-1.10/cert-manager-release-1.10.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.10/cert-manager-release-1.10.yaml
@@ -15,7 +15,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -47,7 +47,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -84,7 +84,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -133,7 +133,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -182,7 +182,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -231,7 +231,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -280,7 +280,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -329,7 +329,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -378,7 +378,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -423,7 +423,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -459,7 +459,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -494,7 +494,7 @@ presubmits:
       preset-venafi-tpp-credentials: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -542,7 +542,7 @@ presubmits:
       preset-venafi-cloud-credentials: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -591,7 +591,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -642,7 +642,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -689,7 +689,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -730,7 +730,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -783,7 +783,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -836,7 +836,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -889,7 +889,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -942,7 +942,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -995,7 +995,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -1048,7 +1048,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -1101,7 +1101,7 @@ periodics:
     preset-venafi-tpp-credentials: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -1150,7 +1150,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -1197,7 +1197,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -1250,7 +1250,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -1303,7 +1303,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -1356,7 +1356,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -1409,7 +1409,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -1462,7 +1462,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -1515,7 +1515,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -1568,7 +1568,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -1618,7 +1618,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -1657,7 +1657,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -1696,7 +1696,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -1735,7 +1735,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -1774,7 +1774,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make

--- a/config/jobs/cert-manager/cert-manager/release-1.11/cert-manager-release-1.11.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.11/cert-manager-release-1.11.yaml
@@ -15,7 +15,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -47,7 +47,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -84,7 +84,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -133,7 +133,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -182,7 +182,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -231,7 +231,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -280,7 +280,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -329,7 +329,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -374,7 +374,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -410,7 +410,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -445,7 +445,7 @@ presubmits:
       preset-venafi-tpp-credentials: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -493,7 +493,7 @@ presubmits:
       preset-venafi-cloud-credentials: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -542,7 +542,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -593,7 +593,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -640,7 +640,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -681,7 +681,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -734,7 +734,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -787,7 +787,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -840,7 +840,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -893,7 +893,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -946,7 +946,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -999,7 +999,7 @@ periodics:
     preset-venafi-tpp-credentials: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -1048,7 +1048,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -1095,7 +1095,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -1148,7 +1148,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -1201,7 +1201,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -1254,7 +1254,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -1307,7 +1307,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -1360,7 +1360,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -1413,7 +1413,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -1463,7 +1463,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -1502,7 +1502,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -1541,7 +1541,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -1580,7 +1580,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make
@@ -1619,7 +1619,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20220830-c65cd19-4.2.1
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
       args:
       - runner
       - make

--- a/config/jobs/cert-manager/csi-driver-spiffe/cert-manager-csi-driver-spiffe-presubmits.yaml
+++ b/config/jobs/cert-manager/csi-driver-spiffe/cert-manager-csi-driver-spiffe-presubmits.yaml
@@ -36,7 +36,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20230323-f4c9aec-1.19.7
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make

--- a/config/jobs/cert-manager/csi-driver/cert-manager-csi-driver-presubmits.yaml
+++ b/config/jobs/cert-manager/csi-driver/cert-manager-csi-driver-presubmits.yaml
@@ -33,7 +33,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20230323-f4c9aec-1.19.7
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make

--- a/config/jobs/cert-manager/istio-csr/cert-manager-istio-csr-presubmits.yaml
+++ b/config/jobs/cert-manager/istio-csr/cert-manager-istio-csr-presubmits.yaml
@@ -34,7 +34,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20230323-f4c9aec-1.19.7
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -82,7 +82,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20230323-f4c9aec-1.19.7
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -135,7 +135,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20230323-f4c9aec-1.19.7
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -188,7 +188,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20230323-f4c9aec-1.19.7
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make

--- a/config/jobs/cert-manager/release/cert-manager-release-presubmits.yaml
+++ b/config/jobs/cert-manager/release/cert-manager-release-presubmits.yaml
@@ -14,7 +14,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20230323-f4c9aec-1.19.7
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make

--- a/config/jobs/cert-manager/trust-manager/trust-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/trust-manager/trust-manager-presubmits.yaml
@@ -13,7 +13,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20230323-f4c9aec-1.19.7
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make
@@ -62,7 +62,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20230323-f4c9aec-1.19.7
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230405-38c1b22-bullseye
         args:
         - runner
         - make


### PR DESCRIPTION
This PR switches all our tests from the bazelbuild to the make-dind image.

**I verified that `pull-cert-manager-master-make-test` works with this new image.**