### PR TITLE
Rename cherrypick to cherrypicker in external_plugins

### DIFF
--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -36,7 +36,7 @@ external_plugins:
   - name: needs-rebase
     events:
     - pull_request
-  - name: cherrypick
+  - name: cherrypicker
     events:
     - issue_comment
     - pull_request
@@ -44,7 +44,7 @@ external_plugins:
   - name: needs-rebase
     events:
     - pull_request
-  - name: cherrypick
+  - name: cherrypicker
     events:
     - issue_comment
     - pull_request


### PR DESCRIPTION
this was missing from #815

Since we rename the deployment and service from `cherrypick` to `cherrypicker`, we also have to rename `external_plugins`.