### PR TITLE
Replace bazelbuild with make-dind (test)

### DIFF
--- a/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
+++ b/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
@@ -18,9 +18,8 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:20230323-d2dfab2-4.2.3
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230330-83ce2fd-bullseye
         args:
-        - runner
         - make
         - -j2
         - vendor-go


### PR DESCRIPTION
This PR switches one test from the bazelbuild to the make-dind image.

We do not need the `runner` argument, because this script is already the entrypoint.