### PR TITLE
Add missing jq tool to make-dind

### DIFF
--- a/images/make-dind/Dockerfile
+++ b/images/make-dind/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get update \
         make \
         rsync \
         patch \
+        jq \
     && apt-get clean \
     && python3 -m pip install --upgrade pip setuptools wheel
 


### PR DESCRIPTION
The make-dind image is missing the jq tool.