### PR TITLE
Add logic for local cache in make-dind

### DIFF
--- a/images/make-dind/runner
+++ b/images/make-dind/runner
@@ -16,6 +16,37 @@
 
 # generic runner script, handles DIND, etc.
 
+
+# Check if the job has opted-in to local caching and if so check for a cache and
+# copy the cache to prepopulate the local cache. After the job is done, change the
+# latest cache directory to the local cache directory.
+export LOCAL_CACHE_ENABLED=${LOCAL_CACHE_ENABLED:-false}
+
+if [[ "${LOCAL_CACHE_ENABLED}" == "true" ]]; then
+    if [[ "${SHARED_CACHE_DIR}" == "" ]]; then
+        echo >&2 "LOCAL_CACHE_ENABLED was enabled but SHARED_CACHE_DIR is empty."
+        exit 1
+    fi
+    
+    if [[ "${LOCAL_CACHE_DIR}" == "" ]]; then
+        echo >&2 "LOCAL_CACHE_ENABLED was enabled but LOCAL_CACHE_DIR is empty."
+        exit 1
+    fi
+
+    echo "Local cache is enabled, checking for cache ..."
+
+    # Obtain the name of the latest cache directory.
+    LATEST_CACHE_DIR=$(cat "${SHARED_CACHE_DIR}/latest")
+
+    mkdir -p "${LOCAL_CACHE_DIR}"
+
+    # Copying the latest cache to our local cache ...
+    cp -rp "${LATEST_CACHE_DIR}" "${LOCAL_CACHE_DIR}"
+
+    echo "Local cache is enabled, provisioned ${LOCAL_CACHE_DIR}"
+fi
+
+# Check if the job has opted-in to docker in docker and if so start the docker daemon
 export DOCKER_IN_DOCKER_ENABLED=${DOCKER_IN_DOCKER_ENABLED:-false}
 
 if [[ "${DOCKER_CONFIG:-}" != "" ]]; then
@@ -95,6 +126,31 @@ EXIT_VALUE=$?
 if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
     echo "Stopping docker ..."
     service docker stop || true
+fi
+
+if [[ "${LOCAL_CACHE_ENABLED}" == "true" ]]; then
+    if [[ $EXIT_VALUE == 0 ]]; then
+        cache_unique_id="cache_$(date +"%F_H%H-M%M-S%S")_$(head -c 8 /proc/sys/kernel/random/uuid)"
+
+        # Move the local cache directory to the shared cache directory.
+        echo "Moving local cache to shared cache ..."
+        mv "${LOCAL_CACHE_DIR}" "${SHARED_CACHE_DIR}/${cache_unique_id}"
+
+        # Update the latest cache directory to the local cache directory.
+        echo "Updating latest cache directory to ${SHARED_CACHE_DIR}/${cache_unique_id}"
+        echo "${SHARED_CACHE_DIR}/${cache_unique_id}" > "${SHARED_CACHE_DIR}/latest"
+
+        # Remove the old cache directories to save disk space. Keep the
+        # last 4 cache directories because they may be used by other
+        # jobs that are still copying from these directories.
+        echo "Removing old caches ..."
+        find "${SHARED_CACHE_DIR}" -maxdepth 1 -type d -name 'cache_*' -printf '%f\n' | \
+            sort -r | \
+            tail -n +4 | \
+            xargs -I{} rm -rf "${SHARED_CACHE_DIR}/{}"
+    else
+        echo "Job failed, not updating cache."
+    fi
 fi
 
 # preserve exit value from job / bootstrap


### PR DESCRIPTION
In this PR, the runner script tries to prevent any concurrency caching issues by only using atomic operations when working on shared files & folders.

The main purpose of this caching solution is to allow concurrent caching: if one test is still downloading file A, we don't want another test to think that file is ready already and start executing a half-downloaded file.

For this reason we are taking the following approach:
1. on startup, we look for the location of the latest finished cache in the "${SHARED_CACHE_DIR}/latest" file
2. we copy the contents of this cache folder to our local cache
3. ... running test ...
4. on successful completion, we move our local cache to a newly created unique folder in the shared cache mount
5. after the cache is successfully moved, we update the "${SHARED_CACHE_DIR}/latest" file with the location of this moved cache
6. this moved cache won't be altered, so it is safe to be read from multiple concurrent tests
7. at some point the "${SHARED_CACHE_DIR}/latest" value will point to another cache
8. some tests might still be copying (step 2) an older cache from a location that differs from "${SHARED_CACHE_DIR}/latest"
9. to make sure we don't break any of those copies, we keep the 4 newest caches and remove all the older caches to limit disk usage