### PR TITLE
Add GOCACHE to cert-manager tests

### DIFF
--- a/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
+++ b/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
@@ -14,6 +14,7 @@ presubmits:
       testgrid-dashboards: cert-manager-presubmits-master
     labels:
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-service-account: "true"
     spec:
       containers:
@@ -48,6 +49,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-service-account: "true"
     spec:
       containers:
@@ -85,6 +87,7 @@ presubmits:
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-retry-flakey-jobs: "true"
       preset-service-account: "true"
     spec:
@@ -135,6 +138,7 @@ presubmits:
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-retry-flakey-jobs: "true"
       preset-service-account: "true"
     spec:
@@ -185,6 +189,7 @@ presubmits:
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-retry-flakey-jobs: "true"
       preset-service-account: "true"
     spec:
@@ -235,6 +240,7 @@ presubmits:
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-retry-flakey-jobs: "true"
       preset-service-account: "true"
     spec:
@@ -285,6 +291,7 @@ presubmits:
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-retry-flakey-jobs: "true"
       preset-service-account: "true"
     spec:
@@ -332,6 +339,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-service-account: "true"
     spec:
       containers:
@@ -370,6 +378,7 @@ presubmits:
       testgrid-dashboards: cert-manager-presubmits-master
     labels:
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-service-account: "true"
     spec:
       containers:
@@ -404,6 +413,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-ginkgo-focus-venafi-tpp: "true"
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-retry-flakey-jobs: "true"
       preset-service-account: "true"
       preset-venafi-tpp-credentials: "true"
@@ -453,6 +463,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-ginkgo-focus-venafi-cloud: "true"
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-retry-flakey-jobs: "true"
       preset-service-account: "true"
       preset-venafi-cloud-credentials: "true"
@@ -504,6 +515,7 @@ presubmits:
       preset-disable-all-alpha-beta-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-retry-flakey-jobs: "true"
       preset-service-account: "true"
     spec:
@@ -556,6 +568,7 @@ presubmits:
       preset-disable-all-alpha-beta-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-retry-flakey-jobs: "true"
       preset-service-account: "true"
     spec:
@@ -603,6 +616,7 @@ periodics:
     testgrid-dashboards: cert-manager-periodics-master
   labels:
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-service-account: "true"
   spec:
     containers:
@@ -641,6 +655,7 @@ periodics:
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
   spec:
@@ -692,6 +707,7 @@ periodics:
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
   spec:
@@ -743,6 +759,7 @@ periodics:
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
   spec:
@@ -794,6 +811,7 @@ periodics:
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
   spec:
@@ -845,6 +863,7 @@ periodics:
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
   spec:
@@ -894,6 +913,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-ginkgo-focus-venafi: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
     preset-venafi-cloud-credentials: "true"
@@ -944,6 +964,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-service-account: "true"
   spec:
     containers:
@@ -988,6 +1009,7 @@ periodics:
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
   spec:
@@ -1039,6 +1061,7 @@ periodics:
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
   spec:
@@ -1090,6 +1113,7 @@ periodics:
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
   spec:
@@ -1141,6 +1165,7 @@ periodics:
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
   spec:
@@ -1192,6 +1217,7 @@ periodics:
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
   spec:
@@ -1243,6 +1269,7 @@ periodics:
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
   spec:
@@ -1293,6 +1320,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-service-account: "true"
   spec:
     containers:
@@ -1331,6 +1359,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-service-account: "true"
   spec:
     containers:
@@ -1369,6 +1398,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-service-account: "true"
   spec:
     containers:
@@ -1407,6 +1437,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-service-account: "true"
   spec:
     containers:
@@ -1445,6 +1476,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-service-account: "true"
   spec:
     containers:

--- a/config/jobs/cert-manager/cert-manager/release-1.10/cert-manager-release-1.10.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.10/cert-manager-release-1.10.yaml
@@ -11,6 +11,7 @@ presubmits:
       description: Runs unit and integration tests and verification scripts
     labels:
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-service-account: "true"
     spec:
       containers:
@@ -42,6 +43,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-service-account: "true"
     spec:
       containers:
@@ -76,6 +78,7 @@ presubmits:
       preset-enable-all-feature-gates-disable-ssa: "true"
       preset-ginkgo-skip-default: "true"
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-retry-flakey-jobs: "true"
       preset-service-account: "true"
     spec:
@@ -123,6 +126,7 @@ presubmits:
       preset-enable-all-feature-gates-disable-ssa: "true"
       preset-ginkgo-skip-default: "true"
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-retry-flakey-jobs: "true"
       preset-service-account: "true"
     spec:
@@ -170,6 +174,7 @@ presubmits:
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-retry-flakey-jobs: "true"
       preset-service-account: "true"
     spec:
@@ -217,6 +222,7 @@ presubmits:
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-retry-flakey-jobs: "true"
       preset-service-account: "true"
     spec:
@@ -264,6 +270,7 @@ presubmits:
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-retry-flakey-jobs: "true"
       preset-service-account: "true"
     spec:
@@ -311,6 +318,7 @@ presubmits:
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-retry-flakey-jobs: "true"
       preset-service-account: "true"
     spec:
@@ -358,6 +366,7 @@ presubmits:
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-retry-flakey-jobs: "true"
       preset-service-account: "true"
     spec:
@@ -402,6 +411,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-service-account: "true"
     spec:
       containers:
@@ -437,6 +447,7 @@ presubmits:
         has changed
     labels:
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-service-account: "true"
     spec:
       containers:
@@ -468,6 +479,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-ginkgo-focus-venafi-tpp: "true"
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-retry-flakey-jobs: "true"
       preset-service-account: "true"
       preset-venafi-tpp-credentials: "true"
@@ -514,6 +526,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-ginkgo-focus-venafi-cloud: "true"
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-retry-flakey-jobs: "true"
       preset-service-account: "true"
       preset-venafi-cloud-credentials: "true"
@@ -562,6 +575,7 @@ presubmits:
       preset-disable-all-alpha-beta-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-retry-flakey-jobs: "true"
       preset-service-account: "true"
     spec:
@@ -611,6 +625,7 @@ presubmits:
       preset-disable-all-alpha-beta-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-retry-flakey-jobs: "true"
       preset-service-account: "true"
     spec:
@@ -658,6 +673,7 @@ periodics:
     testgrid-dashboards: cert-manager-periodics-release-1.10
   labels:
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-service-account: "true"
   spec:
     containers:
@@ -696,6 +712,7 @@ periodics:
     preset-enable-all-feature-gates-disable-ssa: "true"
     preset-ginkgo-skip-default: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
   spec:
@@ -747,6 +764,7 @@ periodics:
     preset-enable-all-feature-gates-disable-ssa: "true"
     preset-ginkgo-skip-default: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
   spec:
@@ -798,6 +816,7 @@ periodics:
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
   spec:
@@ -849,6 +868,7 @@ periodics:
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
   spec:
@@ -900,6 +920,7 @@ periodics:
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
   spec:
@@ -951,6 +972,7 @@ periodics:
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
   spec:
@@ -1002,6 +1024,7 @@ periodics:
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
   spec:
@@ -1051,6 +1074,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-ginkgo-focus-venafi: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
     preset-venafi-cloud-credentials: "true"
@@ -1101,6 +1125,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-service-account: "true"
   spec:
     containers:
@@ -1145,6 +1170,7 @@ periodics:
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
   spec:
@@ -1196,6 +1222,7 @@ periodics:
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
   spec:
@@ -1247,6 +1274,7 @@ periodics:
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
   spec:
@@ -1298,6 +1326,7 @@ periodics:
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
   spec:
@@ -1349,6 +1378,7 @@ periodics:
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
   spec:
@@ -1400,6 +1430,7 @@ periodics:
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
   spec:
@@ -1451,6 +1482,7 @@ periodics:
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
   spec:
@@ -1502,6 +1534,7 @@ periodics:
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
   spec:
@@ -1552,6 +1585,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-service-account: "true"
   spec:
     containers:
@@ -1590,6 +1624,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-service-account: "true"
   spec:
     containers:
@@ -1628,6 +1663,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-service-account: "true"
   spec:
     containers:
@@ -1666,6 +1702,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-service-account: "true"
   spec:
     containers:
@@ -1704,6 +1741,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-service-account: "true"
   spec:
     containers:

--- a/config/jobs/cert-manager/cert-manager/release-1.11/cert-manager-release-1.11.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.11/cert-manager-release-1.11.yaml
@@ -11,6 +11,7 @@ presubmits:
       description: Runs unit and integration tests and verification scripts
     labels:
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-service-account: "true"
     spec:
       containers:
@@ -42,6 +43,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-service-account: "true"
     spec:
       containers:
@@ -76,6 +78,7 @@ presubmits:
       preset-enable-all-feature-gates-disable-ssa: "true"
       preset-ginkgo-skip-default: "true"
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-retry-flakey-jobs: "true"
       preset-service-account: "true"
     spec:
@@ -123,6 +126,7 @@ presubmits:
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-retry-flakey-jobs: "true"
       preset-service-account: "true"
     spec:
@@ -170,6 +174,7 @@ presubmits:
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-retry-flakey-jobs: "true"
       preset-service-account: "true"
     spec:
@@ -217,6 +222,7 @@ presubmits:
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-retry-flakey-jobs: "true"
       preset-service-account: "true"
     spec:
@@ -264,6 +270,7 @@ presubmits:
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-retry-flakey-jobs: "true"
       preset-service-account: "true"
     spec:
@@ -311,6 +318,7 @@ presubmits:
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-retry-flakey-jobs: "true"
       preset-service-account: "true"
     spec:
@@ -355,6 +363,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-service-account: "true"
     spec:
       containers:
@@ -390,6 +399,7 @@ presubmits:
         has changed
     labels:
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-service-account: "true"
     spec:
       containers:
@@ -421,6 +431,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-ginkgo-focus-venafi-tpp: "true"
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-retry-flakey-jobs: "true"
       preset-service-account: "true"
       preset-venafi-tpp-credentials: "true"
@@ -467,6 +478,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-ginkgo-focus-venafi-cloud: "true"
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-retry-flakey-jobs: "true"
       preset-service-account: "true"
       preset-venafi-cloud-credentials: "true"
@@ -515,6 +527,7 @@ presubmits:
       preset-disable-all-alpha-beta-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-retry-flakey-jobs: "true"
       preset-service-account: "true"
     spec:
@@ -564,6 +577,7 @@ presubmits:
       preset-disable-all-alpha-beta-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
       preset-make-volumes: "true"
+      preset-go-cache: "true"
       preset-retry-flakey-jobs: "true"
       preset-service-account: "true"
     spec:
@@ -611,6 +625,7 @@ periodics:
     testgrid-dashboards: cert-manager-periodics-release-1.11
   labels:
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-service-account: "true"
   spec:
     containers:
@@ -649,6 +664,7 @@ periodics:
     preset-enable-all-feature-gates-disable-ssa: "true"
     preset-ginkgo-skip-default: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
   spec:
@@ -700,6 +716,7 @@ periodics:
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
   spec:
@@ -751,6 +768,7 @@ periodics:
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
   spec:
@@ -802,6 +820,7 @@ periodics:
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
   spec:
@@ -853,6 +872,7 @@ periodics:
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
   spec:
@@ -904,6 +924,7 @@ periodics:
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
   spec:
@@ -953,6 +974,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-ginkgo-focus-venafi: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
     preset-venafi-cloud-credentials: "true"
@@ -1003,6 +1025,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-service-account: "true"
   spec:
     containers:
@@ -1047,6 +1070,7 @@ periodics:
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
   spec:
@@ -1098,6 +1122,7 @@ periodics:
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
   spec:
@@ -1149,6 +1174,7 @@ periodics:
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
   spec:
@@ -1200,6 +1226,7 @@ periodics:
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
   spec:
@@ -1251,6 +1278,7 @@ periodics:
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
   spec:
@@ -1302,6 +1330,7 @@ periodics:
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
   spec:
@@ -1353,6 +1382,7 @@ periodics:
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-service-account: "true"
   spec:
@@ -1403,6 +1433,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-service-account: "true"
   spec:
     containers:
@@ -1441,6 +1472,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-service-account: "true"
   spec:
     containers:
@@ -1479,6 +1511,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-service-account: "true"
   spec:
     containers:
@@ -1517,6 +1550,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-service-account: "true"
   spec:
     containers:
@@ -1555,6 +1589,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-make-volumes: "true"
+    preset-go-cache: "true"
     preset-service-account: "true"
   spec:
     containers:

--- a/config/jobs/cert-manager/config.yaml
+++ b/config/jobs/cert-manager/config.yaml
@@ -177,6 +177,20 @@ presets:
 #      path: /tmp/bindownloaded
 #      type: DirectoryOrCreate
 
+- labels:
+    preset-go-cache: "true"
+  env:
+  - name: GOCACHE
+    value: /root/.prow_go_cache/
+  volumeMounts:
+    - mountPath: /root/.prow_go_cache/
+      name: go_cache
+  volumes:
+    - name: go_cache
+      hostPath:
+        path: /tmp/go_cache
+        type: DirectoryOrCreate
+
 # A preset which causes make e2e-setup to install cert-manager in accordance
 # with https://cert-manager.io/docs/installation/best-practice/.
 #


### PR DESCRIPTION
Adds a preset for enabling a persistent go cache. This cache is a shared folder on the host machine, concurrent use of the GOCACHE is allowed, so we can just point all tests to the same cache.