### PR TITLE
Don't use underscore in volume name

### DIFF
--- a/config/jobs/cert-manager/config.yaml
+++ b/config/jobs/cert-manager/config.yaml
@@ -184,9 +184,9 @@ presets:
     value: /root/.prow_go_cache/
   volumeMounts:
     - mountPath: /root/.prow_go_cache/
-      name: go_cache
+      name: go-cache
   volumes:
-    - name: go_cache
+    - name: go-cache
       hostPath:
         path: /tmp/go_cache
         type: DirectoryOrCreate


### PR DESCRIPTION
```
Pod can not be created: create pod test-pods/025d8ba3-d486-11ed-99f5-92cefd7dbb24
    in cluster default: Pod "025d8ba3-d486-11ed-99f5-92cefd7dbb24" is invalid: [spec.volumes[2].name:
    Invalid value: "go_cache": a lowercase RFC 1123 label must consist of lower case
    alphanumeric characters or ''-'', and must start and end with an alphanumeric
    character (e.g. ''my-name'',  or ''123-abc'', regex used for validation is ''[a-z0-9]([-a-z0-9]*[a-z0-9])?''),
    spec.containers[0].volumeMounts[2].name: Not found: "go_cache"]
```