### PR TITLE
Reduce requested memory usage of e2e jobs

### DIFF
--- a/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
+++ b/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
@@ -103,7 +103,7 @@ presubmits:
         resources:
           requests:
             cpu: 3500m
-            memory: 12Gi
+            memory: 6Gi
         securityContext:
           privileged: true
           capabilities:
@@ -154,7 +154,7 @@ presubmits:
         resources:
           requests:
             cpu: 3500m
-            memory: 12Gi
+            memory: 6Gi
         securityContext:
           privileged: true
           capabilities:
@@ -205,7 +205,7 @@ presubmits:
         resources:
           requests:
             cpu: 3500m
-            memory: 12Gi
+            memory: 6Gi
         securityContext:
           privileged: true
           capabilities:
@@ -256,7 +256,7 @@ presubmits:
         resources:
           requests:
             cpu: 3500m
-            memory: 12Gi
+            memory: 6Gi
         securityContext:
           privileged: true
           capabilities:
@@ -307,7 +307,7 @@ presubmits:
         resources:
           requests:
             cpu: 3500m
-            memory: 12Gi
+            memory: 6Gi
         securityContext:
           privileged: true
           capabilities:
@@ -353,7 +353,7 @@ presubmits:
         resources:
           requests:
             cpu: 3500m
-            memory: 12Gi
+            memory: 6Gi
         securityContext:
           privileged: true
           capabilities:
@@ -430,7 +430,7 @@ presubmits:
         resources:
           requests:
             cpu: 3500m
-            memory: 12Gi
+            memory: 6Gi
         securityContext:
           privileged: true
           capabilities:
@@ -480,7 +480,7 @@ presubmits:
         resources:
           requests:
             cpu: 3500m
-            memory: 12Gi
+            memory: 6Gi
         securityContext:
           privileged: true
           capabilities:
@@ -531,7 +531,7 @@ presubmits:
         resources:
           requests:
             cpu: 3500m
-            memory: 12Gi
+            memory: 6Gi
         securityContext:
           privileged: true
           capabilities:
@@ -584,7 +584,7 @@ presubmits:
         resources:
           requests:
             cpu: 3500m
-            memory: 12Gi
+            memory: 6Gi
         securityContext:
           privileged: true
           capabilities:
@@ -671,7 +671,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -723,7 +723,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -775,7 +775,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -827,7 +827,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -879,7 +879,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -931,7 +931,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -978,7 +978,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -1025,7 +1025,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -1077,7 +1077,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -1129,7 +1129,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -1181,7 +1181,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -1233,7 +1233,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -1285,7 +1285,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:

--- a/config/jobs/cert-manager/cert-manager/release-1.10/cert-manager-release-1.10.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.10/cert-manager-release-1.10.yaml
@@ -94,7 +94,7 @@ presubmits:
         resources:
           requests:
             cpu: 3500m
-            memory: 12Gi
+            memory: 6Gi
         securityContext:
           privileged: true
           capabilities:
@@ -142,7 +142,7 @@ presubmits:
         resources:
           requests:
             cpu: 3500m
-            memory: 12Gi
+            memory: 6Gi
         securityContext:
           privileged: true
           capabilities:
@@ -190,7 +190,7 @@ presubmits:
         resources:
           requests:
             cpu: 3500m
-            memory: 12Gi
+            memory: 6Gi
         securityContext:
           privileged: true
           capabilities:
@@ -238,7 +238,7 @@ presubmits:
         resources:
           requests:
             cpu: 3500m
-            memory: 12Gi
+            memory: 6Gi
         securityContext:
           privileged: true
           capabilities:
@@ -286,7 +286,7 @@ presubmits:
         resources:
           requests:
             cpu: 3500m
-            memory: 12Gi
+            memory: 6Gi
         securityContext:
           privileged: true
           capabilities:
@@ -334,7 +334,7 @@ presubmits:
         resources:
           requests:
             cpu: 3500m
-            memory: 12Gi
+            memory: 6Gi
         securityContext:
           privileged: true
           capabilities:
@@ -382,7 +382,7 @@ presubmits:
         resources:
           requests:
             cpu: 3500m
-            memory: 12Gi
+            memory: 6Gi
         securityContext:
           privileged: true
           capabilities:
@@ -425,7 +425,7 @@ presubmits:
         resources:
           requests:
             cpu: 3500m
-            memory: 12Gi
+            memory: 6Gi
         securityContext:
           privileged: true
           capabilities:
@@ -496,7 +496,7 @@ presubmits:
         resources:
           requests:
             cpu: 3500m
-            memory: 12Gi
+            memory: 6Gi
         securityContext:
           privileged: true
           capabilities:
@@ -543,7 +543,7 @@ presubmits:
         resources:
           requests:
             cpu: 3500m
-            memory: 12Gi
+            memory: 6Gi
         securityContext:
           privileged: true
           capabilities:
@@ -591,7 +591,7 @@ presubmits:
         resources:
           requests:
             cpu: 3500m
-            memory: 12Gi
+            memory: 6Gi
         securityContext:
           privileged: true
           capabilities:
@@ -641,7 +641,7 @@ presubmits:
         resources:
           requests:
             cpu: 3500m
-            memory: 12Gi
+            memory: 6Gi
         securityContext:
           privileged: true
           capabilities:
@@ -728,7 +728,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -780,7 +780,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -832,7 +832,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -884,7 +884,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -936,7 +936,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -988,7 +988,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -1040,7 +1040,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -1092,7 +1092,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -1139,7 +1139,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -1186,7 +1186,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -1238,7 +1238,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -1290,7 +1290,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -1342,7 +1342,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -1394,7 +1394,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -1446,7 +1446,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -1498,7 +1498,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -1550,7 +1550,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:

--- a/config/jobs/cert-manager/cert-manager/release-1.11/cert-manager-release-1.11.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.11/cert-manager-release-1.11.yaml
@@ -94,7 +94,7 @@ presubmits:
         resources:
           requests:
             cpu: 3500m
-            memory: 12Gi
+            memory: 6Gi
         securityContext:
           privileged: true
           capabilities:
@@ -142,7 +142,7 @@ presubmits:
         resources:
           requests:
             cpu: 3500m
-            memory: 12Gi
+            memory: 6Gi
         securityContext:
           privileged: true
           capabilities:
@@ -190,7 +190,7 @@ presubmits:
         resources:
           requests:
             cpu: 3500m
-            memory: 12Gi
+            memory: 6Gi
         securityContext:
           privileged: true
           capabilities:
@@ -238,7 +238,7 @@ presubmits:
         resources:
           requests:
             cpu: 3500m
-            memory: 12Gi
+            memory: 6Gi
         securityContext:
           privileged: true
           capabilities:
@@ -286,7 +286,7 @@ presubmits:
         resources:
           requests:
             cpu: 3500m
-            memory: 12Gi
+            memory: 6Gi
         securityContext:
           privileged: true
           capabilities:
@@ -334,7 +334,7 @@ presubmits:
         resources:
           requests:
             cpu: 3500m
-            memory: 12Gi
+            memory: 6Gi
         securityContext:
           privileged: true
           capabilities:
@@ -377,7 +377,7 @@ presubmits:
         resources:
           requests:
             cpu: 3500m
-            memory: 12Gi
+            memory: 6Gi
         securityContext:
           privileged: true
           capabilities:
@@ -448,7 +448,7 @@ presubmits:
         resources:
           requests:
             cpu: 3500m
-            memory: 12Gi
+            memory: 6Gi
         securityContext:
           privileged: true
           capabilities:
@@ -495,7 +495,7 @@ presubmits:
         resources:
           requests:
             cpu: 3500m
-            memory: 12Gi
+            memory: 6Gi
         securityContext:
           privileged: true
           capabilities:
@@ -543,7 +543,7 @@ presubmits:
         resources:
           requests:
             cpu: 3500m
-            memory: 12Gi
+            memory: 6Gi
         securityContext:
           privileged: true
           capabilities:
@@ -593,7 +593,7 @@ presubmits:
         resources:
           requests:
             cpu: 3500m
-            memory: 12Gi
+            memory: 6Gi
         securityContext:
           privileged: true
           capabilities:
@@ -680,7 +680,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -732,7 +732,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -784,7 +784,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -836,7 +836,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -888,7 +888,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -940,7 +940,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -992,7 +992,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -1039,7 +1039,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -1086,7 +1086,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -1138,7 +1138,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -1190,7 +1190,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -1242,7 +1242,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -1294,7 +1294,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -1346,7 +1346,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:
@@ -1398,7 +1398,7 @@ periodics:
       resources:
         requests:
           cpu: 3500m
-          memory: 12Gi
+          memory: 6Gi
       securityContext:
         privileged: true
         capabilities:

--- a/config/jobs/cert-manager/csi-driver-spiffe/cert-manager-csi-driver-spiffe-presubmits.yaml
+++ b/config/jobs/cert-manager/csi-driver-spiffe/cert-manager-csi-driver-spiffe-presubmits.yaml
@@ -40,7 +40,7 @@ presubmits:
         resources:
           requests:
             cpu: 3500m
-            memory: 12Gi
+            memory: 6Gi
         securityContext:
           privileged: true
           capabilities:

--- a/config/jobs/cert-manager/csi-driver/cert-manager-csi-driver-presubmits.yaml
+++ b/config/jobs/cert-manager/csi-driver/cert-manager-csi-driver-presubmits.yaml
@@ -37,7 +37,7 @@ presubmits:
         resources:
           requests:
             cpu: 3500m
-            memory: 12Gi
+            memory: 6Gi
         securityContext:
           privileged: true
           capabilities:

--- a/config/jobs/cert-manager/istio-csr/cert-manager-istio-csr-presubmits.yaml
+++ b/config/jobs/cert-manager/istio-csr/cert-manager-istio-csr-presubmits.yaml
@@ -70,7 +70,7 @@ presubmits:
         resources:
           requests:
             cpu: 3500m
-            memory: 12Gi
+            memory: 6Gi
         env:
         - name: K8S_VERSION
           value: "1.26.1"
@@ -106,7 +106,7 @@ presubmits:
         resources:
           requests:
             cpu: 3500m
-            memory: 12Gi
+            memory: 6Gi
         env:
         - name: K8S_VERSION
           value: "1.26.1"
@@ -142,7 +142,7 @@ presubmits:
         resources:
           requests:
             cpu: 3500m
-            memory: 12Gi
+            memory: 6Gi
         env:
         - name: K8S_VERSION
           value: "1.26.1"


### PR DESCRIPTION
Based on what we are seeing in GCP, we don't need 12 Gi.
We only use 4-5 Gi. Thus we can set the requested amount to 6 Gi without any problems.
<img width="254" alt="image" src="https://user-images.githubusercontent.com/42113979/230593325-df6d0280-2ba0-492f-9673-0f087b32c79e.png">
