### PR TITLE
Fix entrypoint for checkconfig image

### DIFF
--- a/config/jobs/testing/testing-presubmits.yaml
+++ b/config/jobs/testing/testing-presubmits.yaml
@@ -9,8 +9,9 @@ presubmits:
     spec:
       containers:
       - image: gcr.io/k8s-prow/checkconfig:v20230407-e8b3bf711e
+        command:
+        - checkconfig
         args:
-        - /app/prow/cmd/checkconfig/app.binary
         - -strict=true
         - -config-path=config/config.yaml
         - -job-config-path=config/jobs


### PR DESCRIPTION
The entrypoint has moved for the latest checkconfig images.