### PR TITLE
Revert "circumvent DCO check for generic auto-bumper"

### DIFF
--- a/config/autobump-config/testing-autobump-config.yaml
+++ b/config/autobump-config/testing-autobump-config.yaml
@@ -16,9 +16,6 @@ includedConfigPaths:
 extraFiles:
   - "config/config.yaml"
 targetVersion: "latest"
-labels:
-  # circumvent the DCO check for this bot, does not seem to be supported by generic auto-bumper
-  - "dco-signoff: yes"
 prefixes:
   - name: "k8s-prow images"
     prefix: "gcr.io/k8s-prow/"


### PR DESCRIPTION
This reverts commit 2fe023aa7fc0b4fd70b7cc303da5ebfd3978e50a because the DCO workaround is not working.