### PR TITLE
ghproxy: don't use legacy cache structure; fixes a warning on startup

### DIFF
--- a/prow/cluster/ghproxy.yaml
+++ b/prow/cluster/ghproxy.yaml
@@ -59,6 +59,7 @@ spec:
         - --cache-sizeGB=99
         - --push-gateway=pushgateway
         - --serve-metrics=true
+        - --legacy-disable-disk-cache-partitions-by-auth-header=false
         ports:
         - name: main
           containerPort: 8888


### PR DESCRIPTION
`legacy-disable-disk-cache-partitions-by-auth-header` defaults to true.
This PR sets it to false to fix a warning message on startup.