### PR TITLE
Remove gs:// prefix from config

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -17,7 +17,7 @@ plank:
         entrypoint: "gcr.io/k8s-prow/entrypoint:v20230410-e1db1a99f8"
         sidecar: "gcr.io/k8s-prow/sidecar:v20230410-e1db1a99f8"
       gcs_configuration:
-        bucket: gs://jetstack-logs
+        bucket: jetstack-logs
         path_strategy: "legacy"
         # Leave this as k/k so that all logs use org_repo in the path
         default_org: "kubernetes"


### PR DESCRIPTION
Was introduced as part of #853 based on comments in the config.
After testing, it turns out that this breaks our testgrid links, these link to broken links eg. https://prow.build-infra.jetstack.net/view/gs/gs:/jetstack-logs/logs/ci-cert-manager-master-make-test/1645782628332212224.