### PR TITLE
Copy prowgen from cert-manager/release

### DIFF
--- a/config/prowgen/go.mod
+++ b/config/prowgen/go.mod
@@ -1,0 +1,11 @@
+module prowgen
+
+go 1.20
+
+require (
+	github.com/spf13/cobra v1.7.0
+	github.com/spf13/pflag v1.0.5
+	gopkg.in/yaml.v2 v2.4.0
+)
+
+require github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/config/prowgen/go.sum
+++ b/config/prowgen/go.sum
@@ -1,0 +1,13 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
+github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/config/prowgen/main.go
+++ b/config/prowgen/main.go
@@ -1,0 +1,175 @@
+// +skip_license_check
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+// Note for developers:
+// If you want to edit how tests are generated, change: ./pkg/
+// If you want to edit which tests are generated on each branch / k8s version, change: ./prowspecs/
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
+	"gopkg.in/yaml.v2"
+
+	"prowgen/prowspecs"
+)
+
+const (
+	generateProwCommand         = "prowgen"
+	generateProwDescription     = "Generate YAML specifying prow tests for cert-manager"
+	generateProwLongDescription = `prowgen creates prow test specifications for a given cert-manager release branch. These specifications
+define the Prow tests available to be run against a given branch.
+
+Generated tests include both presubmit tests (tests that can be run against PRs) and periodic
+tests (tests which are run on a schedule, independently of PRs).
+
+By generating this config we avoid the need for humans to edit YAML manually
+which is error-prone.
+
+If --output-format is set to "file", the generated YAML will be written to the
+file with the correct directory format which prow expects. Otherwise, generated
+output will be written to stdout.
+`
+)
+
+var (
+	generateProwExample = fmt.Sprintf(`
+To generate tests for the a branch called foo:
+
+	%s --branch=foo
+`, generateProwCommand)
+)
+
+type generateProwOptions struct {
+	// Branch specifies the name of the branch whose tests should be generated
+	Branch string
+
+	// OutputFormat specifies the format of the output. Either one of 'stdout' or
+	// 'file'.
+	OutputFormat string
+}
+
+func (o *generateProwOptions) AddFlags(fs *flag.FlagSet, markRequired func(string)) {
+	fs.StringVar(&o.Branch, "branch", "", fmt.Sprintf("Type of tests to generate; one of ('*' generates all branches) %v", append(prowspecs.KnownBranches(), "*")))
+	fs.StringVarP(&o.OutputFormat, "output-format", "o", "stdout", "Output format; one of 'stdout' or 'file'. Any other option prints to stdout.")
+
+	markRequired("branch")
+}
+
+func generateProwCmd() *cobra.Command {
+	o := &generateProwOptions{}
+
+	cmd := &cobra.Command{
+		Use:          generateProwCommand,
+		Short:        generateProwDescription,
+		Long:         generateProwLongDescription,
+		Example:      generateProwExample,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if o.Branch == "*" {
+				for _, branch := range prowspecs.KnownBranches() {
+					if err := o.runGenerateProw(branch); err != nil {
+						return err
+					}
+				}
+				return nil
+			}
+			return o.runGenerateProw(o.Branch)
+		},
+	}
+
+	o.AddFlags(cmd.Flags(), func(s string) {
+		if err := cmd.MarkFlagRequired(s); err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	})
+
+	return cmd
+}
+
+// sanitizedArgs strips the path from the command which was used to invoke the script,
+// so we don't include things like "/home/workspace/release/bin/prowgen"
+func sanitizedArgs() []string {
+	args := os.Args[:]
+	args[0] = filepath.Base(args[0])
+
+	return args
+}
+
+func (o *generateProwOptions) runGenerateProw(branch string) error {
+	spec, err := prowspecs.SpecForBranch(branch)
+	if err != nil {
+		return err
+	}
+
+	jobFile := spec.GenerateJobFile()
+
+	out, err := yaml.Marshal(jobFile)
+	if err != nil {
+		return err
+	}
+
+	prelude := fmt.Sprintf(
+		`# THIS FILE HAS BEEN AUTOMATICALLY GENERATED
+# Don't manually edit it; instead edit the "prowgen" tool which generated it
+# Generated with: %s
+
+`,
+		strings.Join(sanitizedArgs(), " "),
+	)
+
+	data := prelude + string(out)
+
+	switch strings.ToLower(o.OutputFormat) {
+	case "file":
+		if err := os.MkdirAll(branch, 0755); err != nil {
+			return err
+		}
+
+		path := filepath.Join(branch, fmt.Sprintf("cert-manager-%s.yaml", branch))
+		f, err := os.Create(path)
+		if err != nil {
+			return err
+		}
+
+		if _, err := io.Copy(f, strings.NewReader(data)); err != nil {
+			return err
+		}
+
+	default:
+		fmt.Println(data)
+	}
+
+	return nil
+}
+
+func main() {
+	cmd := generateProwCmd()
+
+	if err := cmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/config/prowgen/pkg/configurers.go
+++ b/config/prowgen/pkg/configurers.go
@@ -1,0 +1,155 @@
+// +skip_license_check
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pkg
+
+import "fmt"
+
+type JobConfigurer func(*Job)
+
+// jobTemplate defines a 'default' job, where standard parameters can be set. All jobs
+// should have a name and a friendly description of what they do.
+// Callers can also pass a list of "configurers" which will modify the template before
+// it's returned for use.
+func jobTemplate(name string, description string, configurers ...JobConfigurer) *Job {
+	job := &Job{
+		Name:     name,
+		Decorate: true,
+		Annotations: map[string]string{
+			"description": description,
+		},
+		Labels: make(map[string]string),
+		Spec: JobSpec{
+			DNSConfig: DefaultDNSConfig(),
+		},
+	}
+
+	for _, c := range configurers {
+		c(job)
+	}
+
+	return job
+}
+
+func addLocalCacheLabel(job *Job) {
+	job.Labels["preset-local-cache"] = "true"
+}
+
+func addGoCacheLabel(job *Job) {
+	job.Labels["preset-go-cache"] = "true"
+}
+
+func addServiceAccountLabel(job *Job) {
+	job.Labels["preset-service-account"] = "true"
+}
+
+func addDindLabel(job *Job) {
+	job.Labels["preset-dind-enabled"] = "true"
+}
+
+func addCloudflareCredentialsLabel(job *Job) {
+	job.Labels["preset-cloudflare-credentials"] = "true"
+}
+
+func addRetryFlakesLabel(job *Job) {
+	job.Labels["preset-retry-flakey-jobs"] = "true"
+}
+
+func addGinkgoSkipDefaultLabel(job *Job) {
+	job.Labels["preset-ginkgo-skip-default"] = "true"
+}
+
+func addDisableFeatureGatesLabel(job *Job) {
+	job.Labels["preset-disable-all-alpha-beta-feature-gates"] = "true"
+}
+
+func addVenafiTPPLabels(job *Job) {
+	job.Labels["preset-ginkgo-focus-venafi-tpp"] = "true"
+	job.Labels["preset-venafi-tpp-credentials"] = "true"
+}
+
+func addVenafiBothLabels(job *Job) {
+	job.Labels["preset-ginkgo-focus-venafi"] = "true"
+
+	job.Labels["preset-venafi-cloud-credentials"] = "true"
+	job.Labels["preset-venafi-tpp-credentials"] = "true"
+}
+
+func addVenafiCloudLabels(job *Job) {
+	job.Labels["preset-ginkgo-focus-venafi-cloud"] = "true"
+	job.Labels["preset-venafi-cloud-credentials"] = "true"
+}
+
+func addBestPracticeInstallLabel(job *Job) {
+	job.Labels["preset-bestpractice-install"] = "true"
+}
+
+func addStandardE2ELabels(kubernetesVersion string) JobConfigurer {
+	return func(job *Job) {
+		addGinkgoSkipDefaultLabel(job)
+
+		majorVersion, minorVersion, err := splitKubernetesVersion(kubernetesVersion)
+		if err != nil {
+			// note: we panic here because this tool is developer-facing and because an
+			// error here suggests programmer error (e.g. a typo'd k8s version)
+			// adding 'return nil' for every configurer - most of which shouldn't fail in
+			// any reasonable scenario - seems far messier than a panic here
+			panic(err)
+		}
+
+		if majorVersion == 1 && minorVersion < 22 {
+			// SSA (server-side apply) is only fully supported in k8s 1.22+
+			job.Labels["preset-enable-all-feature-gates-disable-ssa"] = "true"
+			return
+		}
+
+		job.Labels["preset-enable-all-feature-gates"] = "true"
+	}
+}
+
+// addTestGridAnnotations inserts standard testgrid annotations for the job.
+// For a list of testgrid annotations, see:
+// https://github.com/GoogleCloudPlatform/testgrid/blob/444774c4b660dad5ab3c1f47e0579d37deb6b5b0/config.md#prow-job-configuration
+func addTestGridAnnotations(dashboardName string) JobConfigurer {
+	return func(job *Job) {
+		job.Annotations["testgrid-create-job-group"] = "true"
+		job.Annotations["testgrid-dashboards"] = dashboardName
+		job.Annotations["testgrid-alert-email"] = AlertEmailAddress
+	}
+}
+
+// addTestGridCustomFailuresToAlert changes the number of failures required before TestGrid
+// marks a job as "failed" (rather thank "flaky")
+func addTestGridCustomFailuresToAlert(failuresToAlert int) JobConfigurer {
+	return func(job *Job) {
+		job.Annotations["testgrid-num-failures-to-alert"] = fmt.Sprintf("%d", failuresToAlert)
+	}
+}
+
+// addTestGridStaleResultsAlert sets, in hours, the length of time before a job should be
+// considered stale. This guards against a job not running for whatever reason.
+func addTestGridStaleResultsAlert(hoursUntilStale int) JobConfigurer {
+	return func(job *Job) {
+		job.Annotations["testgrid-alert-stale-results-hours"] = fmt.Sprintf("%d", hoursUntilStale)
+	}
+}
+
+func addMaxConcurrency(maxConcurrency int) JobConfigurer {
+	return func(job *Job) {
+		job.MaxConcurrency = maxConcurrency
+	}
+}

--- a/config/prowgen/pkg/configurers_test.go
+++ b/config/prowgen/pkg/configurers_test.go
@@ -1,0 +1,96 @@
+// +skip_license_check
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pkg
+
+import (
+	"testing"
+)
+
+func Test_addStandardE2ELabels_NewKubernetes(t *testing.T) {
+	// on any version of k8s greater than or equal to 1.23 we should enable all feature gates
+	// and use SSA
+	for _, testVersion := range []string{"1.22", "1.23", "1.24", "2.1"} {
+		test := jobTemplate(
+			"test-test",
+			"some description",
+			addStandardE2ELabels(testVersion),
+		)
+
+		if borkedValue, ok := test.Labels["preset-enable-all-feature-gates-disable-ssa"]; ok {
+			t.Errorf("didn't expect 'preset-enable-all-feature-gates-disable-ssa' to be set for newer k8s version %q but it has value %s", testVersion, borkedValue)
+		}
+
+		gatesLabel, ok := test.Labels["preset-enable-all-feature-gates"]
+		if !ok {
+			t.Errorf("missing 'preset-enable-all-feature-gates' label after addStandardE2ELabels for newer k8s %s", testVersion)
+			continue
+		}
+
+		if gatesLabel != "true" {
+			t.Errorf("expected feature gates label to be 'true' but it was %q", gatesLabel)
+		}
+	}
+}
+
+func Test_addStandardE2ELabels_OldKubernetes(t *testing.T) {
+	// on any version of k8s greater than or equal to 1.23 we should enable all feature gates
+	// but disable SSA
+	for _, testVersion := range []string{"1.21", "1.20", "1.0"} {
+		test := jobTemplate(
+			"test-test",
+			"some description",
+			addStandardE2ELabels(testVersion),
+		)
+
+		if borkedValue, ok := test.Labels["preset-enable-all-feature-gates"]; ok {
+			t.Errorf("didn't expect 'preset-enable-all-feature-gates' to be set for older k8s version %q but it has value %s", testVersion, borkedValue)
+		}
+
+		gatesLabel, ok := test.Labels["preset-enable-all-feature-gates-disable-ssa"]
+		if !ok {
+			t.Errorf("missing 'preset-enable-all-feature-gates-disable-ssa' label after addStandardE2ELabels for older k8s version %s", testVersion)
+			continue
+		}
+
+		if gatesLabel != "true" {
+			t.Errorf("expected feature gates label to be 'true' but it was %q", gatesLabel)
+		}
+	}
+}
+
+func Test_addStandardE2ELabels_ProgrammerError(t *testing.T) {
+	k8sVersion := "1a.2a3a4a"
+	caughtPanic := false
+
+	defer func() {
+		if r := recover(); r != nil {
+			caughtPanic = true
+		}
+
+		if !caughtPanic {
+			t.Fatalf("expected a panic for addStandardE2ELabels with k8s version %q but didn't get one", k8sVersion)
+		}
+	}()
+
+	// programmer error with k8s version should panic
+	jobTemplate(
+		"test-test",
+		"some description",
+		addStandardE2ELabels(k8sVersion),
+	)
+}

--- a/config/prowgen/pkg/context.go
+++ b/config/prowgen/pkg/context.go
@@ -1,0 +1,174 @@
+// +skip_license_check
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pkg
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+)
+
+// ProwContext holds jobs and information required to configure jobs for a given release channel.
+type ProwContext struct {
+	// Branch is the name of the branch corresponding to the release channel modelled by this ProwContext.
+	// While it's possible to define a presubmit for multiple branches, this often doesn't correctly model
+	// how cert-manager uses prow in practice - usually, we want a different set of supported kubernetes
+	// versions for each major cert-manager release (and therefore branch), and in any case want a different
+	// dashboard for each supported release channel.
+	Branch string
+
+	// Image is the common test image used for running prow jobs.
+	Image string
+
+	// PresubmitDashboard, if set, will generate a presubmit TestGrid dashboard name based on the branch name
+	// for each presubmit job. If false, no presubmits will be added to a TestGrid dashboard.
+	PresubmitDashboard bool
+
+	// PeriodicDashboard, if set, will generate a periodic TestGrid dashboard name based on the branch name
+	// for each periodic job. If false, no periodics will be added to a TestGrid dashboard.
+	PeriodicDashboard bool
+
+	// Org is the GitHub organisation of the repository under test.
+	Org string
+
+	// Repo is the GitHub repository name of the repository under test.
+	Repo string
+
+	presubmits []*PresubmitJob
+	periodics  []*PeriodicJob
+
+	minutesCounter time.Time
+}
+
+// RequiredPresubmit adds a presubmit which is run by default and required to pass before a PR can be merged
+func (pc *ProwContext) RequiredPresubmit(job *Job) {
+	pc.addPresubmit(job, true, false, "")
+}
+
+// RequiredPresubmits adds a list of jobs to the context
+func (pc *ProwContext) RequiredPresubmits(jobs []*Job) {
+	for _, job := range jobs {
+		pc.addPresubmit(job, true, false, "")
+	}
+}
+
+// OptionalPresubmit adds a presubmit which is not run by default and is optional
+func (pc *ProwContext) OptionalPresubmit(job *Job) {
+	pc.addPresubmit(job, false, true, "")
+}
+
+// OptionalPresubmitIfChanged adds a presubmit which is not run by default and is optional unless a file has been
+// changed which matches changedFileRegex. In that situation, the job is always run.
+// See https://docs.prow.k8s.io/docs/jobs/#triggering-jobs-based-on-changes
+func (pc *ProwContext) OptionalPresubmitIfChanged(job *Job, changedFileRegex string) {
+	pc.addPresubmit(job, false, true, changedFileRegex)
+}
+
+func (pc *ProwContext) addPresubmit(job *Job, alwaysRun bool, optional bool, changedFileRegex string) {
+	job.Name = pc.presubmitJobName(job.Name)
+
+	if pc.PresubmitDashboard {
+		addTestGridAnnotations(pc.presubmitDashboardName())(job)
+	}
+
+	pc.presubmits = append(pc.presubmits, &PresubmitJob{
+		Job: *job,
+		// see the comment on ProwContext.Branch for why we only support a single branch here
+		Branches:     []string{pc.Branch},
+		AlwaysRun:    alwaysRun,
+		Optional:     optional,
+		RunIfChanged: changedFileRegex,
+	})
+}
+
+// Periodic adds periodic jobs which will run every `periodicityHours` hours, at some minute
+// within the hour, one job for each configured branch
+func (pc *ProwContext) Periodics(job *Job, periodicityHours int) {
+	originalName := job.Name
+
+	job.Name = pc.periodicJobName(originalName)
+
+	if pc.PeriodicDashboard {
+		addTestGridAnnotations(pc.periodicDashboardName())(job)
+	}
+
+	pc.periodics = append(pc.periodics, &PeriodicJob{
+		Job: *job,
+		ExtraRefs: []ExtraRef{
+			{
+				Org:     pc.Org,
+				Repo:    pc.Repo,
+				BaseRef: pc.Branch,
+			},
+		},
+		Interval: strconv.Itoa(periodicityHours) + "h",
+		// TODO: use Cron instead of Interval
+		// Cron: pc.cronSchedule(periodicityHours),
+	})
+}
+
+func (pc *ProwContext) JobFile() *JobFile {
+	// TODO: when using Cron instead of Interval for periodics, adjust all periodics
+	// here to spread them evenly throughout the hour
+
+	presubmitKey := fmt.Sprintf("%s/%s", pc.Org, pc.Repo)
+
+	return &JobFile{
+		Presubmits: map[string][]*PresubmitJob{
+			presubmitKey: pc.presubmits,
+		},
+		Periodics: pc.periodics,
+	}
+}
+
+// presubmitJobName returns a prow name for the given presubmit job. For example,
+// for the branch "release-1.0" and the test "foo", this would return "pull-cert-manager-release-1.0-foo"
+func (pc *ProwContext) presubmitJobName(name string) string {
+	return fmt.Sprintf("pull-%s-%s-%s", pc.Repo, pc.Branch, name)
+}
+
+// periodicJobName returns a prow name for the given periodic job. For example,
+// for the branch "release-1.0" and the test "foo", this would return "ci-cert-manager-release-1.0-foo"
+func (pc *ProwContext) periodicJobName(name string) string {
+	return fmt.Sprintf("ci-%s-%s-%s", pc.Repo, pc.Branch, name)
+}
+
+func (pc *ProwContext) presubmitDashboardName() string {
+	return fmt.Sprintf("%s-presubmits-%s", pc.Repo, pc.Branch)
+}
+
+func (pc *ProwContext) periodicDashboardName() string {
+	return fmt.Sprintf("%s-periodics-%s", pc.Repo, pc.Branch)
+}
+
+func (pc *ProwContext) cronSchedule(periodicityHours int) string {
+	minute := pc.minutesValue()
+
+	return fmt.Sprintf("*/%d %d * * *", minute, periodicityHours)
+}
+
+// minutesValue returns a minute value (0 - 59) at which a test should be run and then
+// increases the next value returned. This helps to prevent every test running at the same
+// minute within the hour causing a spiky distribution of tests.
+func (pc *ProwContext) minutesValue() int {
+	minuteVal := pc.minutesCounter.Minute()
+
+	pc.minutesCounter = pc.minutesCounter.Add(4 * time.Minute)
+
+	return minuteVal
+}

--- a/config/prowgen/pkg/generators.go
+++ b/config/prowgen/pkg/generators.go
@@ -1,0 +1,400 @@
+// +skip_license_check
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pkg
+
+import (
+	"fmt"
+	"strings"
+)
+
+// MakeTest generates a test which runs linting and verification targets as well as
+// unit and integration tests
+func MakeTest(ctx *ProwContext) *Job {
+	job := jobTemplate(
+		"make-test",
+		"Runs unit and integration tests and verification scripts",
+		addServiceAccountLabel,
+		addLocalCacheLabel,
+		addGoCacheLabel,
+		addMaxConcurrency(8),
+	)
+
+	makeJobs, cpuRequest := calculateMakeConcurrency("2000m")
+
+	job.Spec.Containers = []Container{
+		{
+			Image: ctx.Image,
+			Args: []string{
+				"runner",
+				"make",
+				makeJobs,
+				"vendor-go",
+				"ci-presubmit",
+				"test-ci",
+			},
+			Resources: ContainerResources{
+				Requests: ContainerResourceRequest{
+					CPU:    cpuRequest,
+					Memory: "4Gi",
+				},
+			},
+		},
+	}
+
+	return job
+}
+
+// ChartTest generates a test which lints helm charts. This is run inside a container
+// and so requires additional permissions.
+func ChartTest(ctx *ProwContext) *Job {
+	job := jobTemplate(
+		"chart",
+		"Verifies the Helm chart passes linting checks",
+		addServiceAccountLabel,
+		addDindLabel,
+		addLocalCacheLabel,
+		addGoCacheLabel,
+		addMaxConcurrency(8),
+	)
+
+	job.Spec.Containers = []Container{
+		{
+			Image: ctx.Image,
+			Args: []string{
+				"runner",
+				"make",
+				"vendor-go",
+				"verify-chart",
+			},
+			Resources: ContainerResources{
+				Requests: ContainerResourceRequest{
+					CPU:    "1",
+					Memory: "1Gi",
+				},
+			},
+			SecurityContext: &SecurityContext{
+				Privileged: true,
+			},
+		},
+	}
+
+	return job
+}
+
+// LicenseTest generates a test which validates the LICENSES file. Since the verify-licenses make target
+// depends on external services for license checking, running it on every PR would introduce the possibilities
+// for flakes if, say, a vanity import site such as gopkg.in was down.
+// We special case the license test so it only runs when go.mod has changed.
+func LicenseTest(ctx *ProwContext) *Job {
+	job := jobTemplate(
+		"license",
+		"Verifies LICENSES are up to date; only needs to be run if go.mod has changed",
+		addServiceAccountLabel,
+		addLocalCacheLabel,
+		addGoCacheLabel,
+		addMaxConcurrency(8),
+	)
+
+	job.Spec.Containers = []Container{
+		{
+			Image: ctx.Image,
+			Args: []string{
+				"runner",
+				"make",
+				"vendor-go",
+				"verify-licenses",
+			},
+			Resources: ContainerResources{
+				Requests: ContainerResourceRequest{
+					CPU:    "1",
+					Memory: "1Gi",
+				},
+			},
+		},
+	}
+
+	return job
+}
+
+// E2ETest generates a test which runs end-to-end tests with feature gates enabled. This
+// is run inside a container and requires additional permissions.
+func E2ETest(ctx *ProwContext, k8sVersion string) *Job {
+	// we don't want to use dots in names, so replace with dashes
+	nameVersion := strings.ReplaceAll(k8sVersion, ".", "-")
+
+	desc := fmt.Sprintf("Runs the end-to-end test suite against a Kubernetes v%s cluster", k8sVersion)
+
+	job := jobTemplate(
+		"e2e-v"+nameVersion,
+		desc,
+		addServiceAccountLabel,
+		addDindLabel,
+		addCloudflareCredentialsLabel,
+		addLocalCacheLabel,
+		addGoCacheLabel,
+		addStandardE2ELabels(k8sVersion),
+		addRetryFlakesLabel,
+		addMaxConcurrency(4),
+	)
+
+	makeJobs, cpuRequest := calculateMakeConcurrency("7000m")
+
+	k8sVersionArg := fmt.Sprintf("K8S_VERSION=%s", k8sVersion)
+
+	job.Spec.Containers = []Container{
+		{
+			Image: ctx.Image,
+			Args: []string{
+				"runner",
+				"make",
+				makeJobs,
+				"vendor-go",
+				"e2e-ci",
+				k8sVersionArg,
+			},
+			Resources: ContainerResources{
+				Requests: ContainerResourceRequest{
+					CPU:    cpuRequest,
+					Memory: "6Gi",
+				},
+			},
+			SecurityContext: &SecurityContext{
+				Privileged: true,
+				Capabilities: &SecurityContextCapabilities{
+					Add: []string{"SYS_ADMIN"},
+				},
+			},
+			Lifecycle: &Lifecycle{
+				PreStop: LifecycleHandler{
+					Exec: ExecAction{
+						Command: []string{
+							"/bin/sh",
+							"-c",
+							"make kind-logs",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return job
+}
+
+// E2ETestVenafiTPP generates a test which runs end-to-end tests only focusing on Venafi TPP.
+// This runs inside a container and so requires additional permissions.
+func E2ETestVenafiTPP(ctx *ProwContext, k8sVersion string) *Job {
+	job := E2ETest(ctx, k8sVersion)
+
+	job.Name = job.Name + "-issuers-venafi-tpp"
+	job.Annotations["description"] = "Runs the E2E tests with 'Venafi TPP' in name"
+
+	job.Labels = make(map[string]string)
+
+	addDindLabel(job)
+	addLocalCacheLabel(job)
+	addGoCacheLabel(job)
+	addRetryFlakesLabel(job)
+	addServiceAccountLabel(job)
+	addVenafiTPPLabels(job)
+
+	return job
+}
+
+// E2ETestVenafiCloud generates a test which runs end-to-end tests only focusing on Venafi Cloud.
+// This runs inside a container and so requires additional permissions.
+func E2ETestVenafiCloud(ctx *ProwContext, k8sVersion string) *Job {
+	job := E2ETest(ctx, k8sVersion)
+
+	job.Name = job.Name + "-issuers-venafi-cloud"
+	job.Annotations["description"] = "Runs the E2E tests with 'Venafi Cloud' in name"
+
+	job.Labels = make(map[string]string)
+
+	addDindLabel(job)
+	addLocalCacheLabel(job)
+	addGoCacheLabel(job)
+	addRetryFlakesLabel(job)
+	addServiceAccountLabel(job)
+	addVenafiCloudLabels(job)
+
+	return job
+}
+
+// E2ETestVenafiBoth generates a test which runs end-to-end tests focusing on
+// both Venafi TPP and Venafi Cloud.
+// This runs inside a container and so requires additional permissions.
+func E2ETestVenafiBoth(ctx *ProwContext, k8sVersion string) *Job {
+	job := E2ETest(ctx, k8sVersion)
+
+	job.Name = job.Name + "-issuers-venafi"
+	job.Annotations["description"] = "Runs Venafi (VaaS and TPP) e2e tests"
+
+	job.Labels = make(map[string]string)
+
+	addDindLabel(job)
+	addLocalCacheLabel(job)
+	addGoCacheLabel(job)
+	addRetryFlakesLabel(job)
+	addServiceAccountLabel(job)
+	addVenafiBothLabels(job)
+
+	return job
+}
+
+// E2ETestFeatureGatesDisabled generates a test which runs e2e tests with feature gates disabled
+func E2ETestFeatureGatesDisabled(ctx *ProwContext, k8sVersion string) *Job {
+	job := E2ETest(ctx, k8sVersion)
+
+	job.Name = job.Name + "-feature-gates-disabled"
+	job.Annotations["description"] = "Runs the E2E tests with all feature gates disabled"
+
+	job.Labels = make(map[string]string)
+
+	addCloudflareCredentialsLabel(job)
+	addDindLabel(job)
+	addDisableFeatureGatesLabel(job)
+	addGinkgoSkipDefaultLabel(job)
+	addLocalCacheLabel(job)
+	addGoCacheLabel(job)
+	addRetryFlakesLabel(job)
+	addServiceAccountLabel(job)
+
+	return job
+}
+
+// E2ETestWithBestPracticeInstall generates a test which runs e2e tests
+// with cert-manager installed in accordance with
+// https://cert-manager.io/docs/installation/best-practice/
+func E2ETestWithBestPracticeInstall(ctx *ProwContext, k8sVersion string) *Job {
+	job := E2ETest(ctx, k8sVersion)
+
+	job.Name = job.Name + "-bestpractice-install"
+	job.Annotations["description"] = "Runs the E2E tests with cert-manager installed in accordance with https://cert-manager.io/docs/installation/best-practice/"
+
+	job.Labels = make(map[string]string)
+
+	addCloudflareCredentialsLabel(job)
+	addDindLabel(job)
+	addDisableFeatureGatesLabel(job)
+	addGinkgoSkipDefaultLabel(job)
+	addLocalCacheLabel(job)
+	addGoCacheLabel(job)
+	addRetryFlakesLabel(job)
+	addServiceAccountLabel(job)
+	addBestPracticeInstallLabel(job)
+
+	return job
+}
+
+// UpgradeTest generates a test which tests an upgrade from the latest released version
+// of cert-manager to the version specified by the test ref / branch. This test runs
+// inside a container and so requires additional privileges.
+func UpgradeTest(ctx *ProwContext, k8sVersion string) *Job {
+	nameVersion := strings.ReplaceAll(k8sVersion, ".", "-")
+
+	job := jobTemplate(
+		"e2e-v"+nameVersion+"-upgrade",
+		"Runs cert-manager upgrade from latest published release",
+		addServiceAccountLabel,
+		addDindLabel,
+		addLocalCacheLabel,
+		addGoCacheLabel,
+		addMaxConcurrency(4),
+	)
+
+	k8sVersionArg := fmt.Sprintf("K8S_VERSION=%s", k8sVersion)
+
+	job.Spec.Containers = []Container{
+		{
+			Image: ctx.Image,
+			Args: []string{
+				"runner",
+				"make",
+				k8sVersionArg,
+				"vendor-go",
+				"test-upgrade",
+			},
+			Resources: ContainerResources{
+				Requests: ContainerResourceRequest{
+					CPU:    "3500m",
+					Memory: "6Gi",
+				},
+			},
+			SecurityContext: &SecurityContext{
+				Privileged: true,
+				Capabilities: &SecurityContextCapabilities{
+					Add: []string{"SYS_ADMIN"},
+				},
+			},
+		},
+	}
+
+	return job
+}
+
+// TrivyTest generates a test which runs a Trivy scan of a built container image which matches the given name.
+// Note that there's also a "make trivy-scan-all" target, but this will fail as soon as one of its dependencies fails,
+// so e.g. if there's a vuln in the "controller" container we might never scan "ctl" container.
+// Instead, we generate a test for each container so it's obvious which ones have failures and it's easier to get results
+// for each container
+func TrivyTest(ctx *ProwContext, containerName string) *Job {
+	containerName = strings.ToLower(containerName)
+
+	job := jobTemplate(
+		fmt.Sprintf("trivy-test-%s", containerName),
+		fmt.Sprintf("Runs a Trivy scan against the %s container", containerName),
+		addServiceAccountLabel,
+		addLocalCacheLabel,
+		addGoCacheLabel,
+		addDindLabel,
+		addMaxConcurrency(2),
+		// Need to ensure that trivy tests send a failure email as soon as they fail since
+		// they tend to be run relatively infrequently and a failure is important to address
+		addTestGridCustomFailuresToAlert(1),
+		// Ask TestGrid to alert us if the job hasn't run in the last 36 hours. Sets
+		// an upper limit on how regularly the job can be scheduled.
+		addTestGridStaleResultsAlert(36),
+	)
+
+	makeJobs, cpuRequest := calculateMakeConcurrency("1000m")
+
+	job.Spec.Containers = []Container{
+		{
+			Image: ctx.Image,
+			Args: []string{
+				"runner",
+				"make",
+				makeJobs,
+				"vendor-go",
+				fmt.Sprintf("trivy-scan-%s", containerName),
+			},
+			Resources: ContainerResources{
+				Requests: ContainerResourceRequest{
+					CPU:    cpuRequest,
+					Memory: "2Gi",
+				},
+			},
+			SecurityContext: &SecurityContext{
+				Privileged: true,
+			},
+		},
+	}
+
+	return job
+}

--- a/config/prowgen/pkg/globals.go
+++ b/config/prowgen/pkg/globals.go
@@ -1,0 +1,26 @@
+// +skip_license_check
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pkg
+
+const (
+	// CommonTestImage defines the common base image used across many prow jobs
+	CommonTestImage = "eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye"
+
+	// AlertEmailAddress is the address to which testgrid alerts should be sent
+	AlertEmailAddress = "cert-manager-dev-alerts@googlegroups.com"
+)

--- a/config/prowgen/pkg/types.go
+++ b/config/prowgen/pkg/types.go
@@ -1,0 +1,138 @@
+// +skip_license_check
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pkg
+
+// There are upstream definitions of these structs here:
+// https://github.com/kubernetes/test-infra/blob/857418c31f6963014ac8821c63e1053c2c0e7e88/prow/config/jobs.go
+
+// Rather than importing the prow struct definitions (and pulling in a bunch of dependencies)
+// we copy the structs + fields we actually use in practice here
+
+type JobFile struct {
+	Presubmits map[string][]*PresubmitJob `yaml:"presubmits"`
+	Periodics  []*PeriodicJob             `yaml:"periodics"`
+}
+
+type Job struct {
+	Name string `yaml:"name"`
+
+	MaxConcurrency int `yaml:"max_concurrency"`
+
+	Decorate bool `yaml:"decorate"`
+
+	Annotations map[string]string `yaml:"annotations"`
+
+	Labels map[string]string `yaml:"labels"`
+
+	Spec JobSpec `yaml:"spec"`
+}
+
+type JobSpec struct {
+	Containers []Container `yaml:"containers"`
+	DNSConfig  DNSConfig   `yaml:"dnsConfig"`
+}
+
+type Container struct {
+	Image string `yaml:"image"`
+
+	Args []string `yaml:"args"`
+
+	Resources ContainerResources `yaml:"resources"`
+
+	SecurityContext *SecurityContext `yaml:"securityContext,omitempty"`
+
+	Lifecycle *Lifecycle `yaml:"lifecycle,omitempty"`
+}
+
+type ContainerResources struct {
+	Requests ContainerResourceRequest `yaml:"requests"`
+}
+
+type ContainerResourceRequest struct {
+	CPU    string `yaml:"cpu"`
+	Memory string `yaml:"memory"`
+}
+
+type DNSConfig struct {
+	Options []DNSConfigOption `yaml:"options"`
+}
+
+type DNSConfigOption struct {
+	Name  string `yaml:"name"`
+	Value string `yaml:"value"`
+}
+
+func DefaultDNSConfig() DNSConfig {
+	return DNSConfig{
+		Options: []DNSConfigOption{
+			{
+				Name:  "ndots",
+				Value: "1",
+			},
+		},
+	}
+}
+
+type SecurityContext struct {
+	Privileged bool `yaml:"privileged"`
+
+	Capabilities *SecurityContextCapabilities `yaml:"capabilities,omitempty"`
+}
+
+type SecurityContextCapabilities struct {
+	Add []string `yaml:"add"`
+}
+
+type Lifecycle struct {
+	PreStop LifecycleHandler `yaml:"preStop"`
+}
+
+type LifecycleHandler struct {
+	Exec ExecAction `yaml:"exec"`
+}
+
+type ExecAction struct {
+	Command []string `yaml:"command"`
+}
+
+type PresubmitJob struct {
+	Job `yaml:",inline"`
+
+	Branches []string `yaml:"branches"`
+
+	AlwaysRun bool `yaml:"always_run"`
+	Optional  bool `yaml:"optional"`
+
+	RunIfChanged string `yaml:"run_if_changed,omitempty"`
+}
+
+type PeriodicJob struct {
+	Job `yaml:",inline"`
+
+	ExtraRefs []ExtraRef `yaml:"extra_refs"`
+
+	Cron     string `yaml:"cron,omitempty"`
+	Interval string `yaml:"interval,omitempty"`
+}
+
+type ExtraRef struct {
+	Org  string `yaml:"org"`
+	Repo string `yaml:"repo"`
+
+	BaseRef string `yaml:"base_ref"`
+}

--- a/config/prowgen/pkg/util.go
+++ b/config/prowgen/pkg/util.go
@@ -1,0 +1,80 @@
+// +skip_license_check
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pkg
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+)
+
+const (
+	milliCPUToCPU = 1000.0
+)
+
+func calculateMakeConcurrency(cpuRequest string) (string, string) {
+	if len(cpuRequest) == 0 {
+		panic("cannot determine value for NUM in make -j<NUM> without a configured CPU request")
+	}
+
+	cpuMultiplier := milliCPUToCPU
+
+	cpuRequest = strings.ToLower(cpuRequest)
+
+	originalCPURequest := cpuRequest
+
+	if strings.HasSuffix(cpuRequest, "m") {
+		cpuRequest = strings.TrimSuffix(cpuRequest, "m")
+		cpuMultiplier = 1.0
+	}
+
+	parsedCPUs, err := strconv.ParseFloat(cpuRequest, 64)
+	if err != nil {
+		panic(fmt.Errorf("CPU request %q wasn't a number: %w", originalCPURequest, err))
+	}
+
+	milliCPUs := parsedCPUs * cpuMultiplier
+
+	makeJobs := int(math.Floor(milliCPUs / milliCPUToCPU))
+
+	if makeJobs < 1 {
+		makeJobs = 1
+	}
+
+	return fmt.Sprintf("-j%d", makeJobs), originalCPURequest
+}
+
+func splitKubernetesVersion(version string) (int, int, error) {
+	versionParts := strings.Split(version, ".")
+	if len(versionParts) == 1 {
+		return 0, 0, fmt.Errorf("invalid version format %q; wanted at least two parts separated by a '.'", version)
+	}
+
+	majorPart, err := strconv.Atoi(versionParts[0])
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid major version %q: %w", versionParts[0], err)
+	}
+
+	minorPart, err := strconv.Atoi(versionParts[1])
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid minor version %q: %w", versionParts[1], err)
+	}
+
+	return majorPart, minorPart, nil
+}

--- a/config/prowgen/pkg/util_test.go
+++ b/config/prowgen/pkg/util_test.go
@@ -1,0 +1,209 @@
+// +skip_license_check
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pkg
+
+import "testing"
+
+func Test_calculateMakeConcurrency(t *testing.T) {
+	type testCase struct {
+		input              string
+		expectedMakeJobs   string
+		expectedCPURequest string
+	}
+
+	for _, test := range []testCase{
+		{
+			input: "3500m",
+
+			expectedMakeJobs:   "-j3",
+			expectedCPURequest: "3500m",
+		},
+		{
+			input: "5500M",
+
+			expectedMakeJobs:   "-j5",
+			expectedCPURequest: "5500m",
+		},
+		{
+			input: "55",
+
+			expectedMakeJobs:   "-j55",
+			expectedCPURequest: "55",
+		},
+		{
+			input: "55000m",
+
+			expectedMakeJobs:   "-j55",
+			expectedCPURequest: "55000m",
+		},
+		{
+			input: "500m",
+
+			expectedMakeJobs:   "-j1",
+			expectedCPURequest: "500m",
+		},
+		{
+			input: "0.5",
+
+			expectedMakeJobs:   "-j1",
+			expectedCPURequest: "0.5",
+		},
+	} {
+		gotMakeJobs, gotCPURequest := calculateMakeConcurrency(test.input)
+
+		if gotMakeJobs != test.expectedMakeJobs {
+			t.Errorf("make --jobs: expected %q but got %q", test.expectedMakeJobs, gotMakeJobs)
+		}
+
+		if gotCPURequest != test.expectedCPURequest {
+			t.Errorf("CPU request: expected %q but got %q", test.expectedCPURequest, gotCPURequest)
+		}
+	}
+}
+
+func Test_calculateMakeConcurrency_NoRequest_Failure(t *testing.T) {
+	caughtPanic := false
+
+	defer func() {
+		if r := recover(); r != nil {
+			caughtPanic = true
+		}
+
+		if !caughtPanic {
+			t.Fatalf("expected a panic for with no CPU request for calculateMakeConcurrency but didn't get one")
+		}
+	}()
+
+	calculateMakeConcurrency("")
+}
+
+func Test_calculateMakeConcurrency_InvalidRequestMillis_Failure(t *testing.T) {
+	caughtPanic := false
+
+	defer func() {
+		if r := recover(); r != nil {
+			caughtPanic = true
+		}
+
+		if !caughtPanic {
+			t.Fatalf("expected a panic for with no CPU request for calculateMakeConcurrency but didn't get one")
+		}
+	}()
+
+	calculateMakeConcurrency("100am")
+}
+
+func Test_calculateMakeConcurrency_InvalidRequestCPUs_Failure(t *testing.T) {
+	caughtPanic := false
+
+	defer func() {
+		if r := recover(); r != nil {
+			caughtPanic = true
+		}
+
+		if !caughtPanic {
+			t.Fatalf("expected a panic for with no CPU request for calculateMakeConcurrency but didn't get one")
+		}
+	}()
+
+	calculateMakeConcurrency("1a")
+}
+
+func Test_splitKubernetesVersion(t *testing.T) {
+	type testCase struct {
+		input string
+
+		expectedMajorVersion int
+		expectedMinorVersion int
+
+		expectError bool
+	}
+
+	for _, test := range []testCase{
+		{
+			input: "1.23",
+
+			expectedMajorVersion: 1,
+			expectedMinorVersion: 23,
+
+			expectError: false,
+		},
+		{
+			input: "1.23.1",
+
+			expectedMajorVersion: 1,
+			expectedMinorVersion: 23,
+
+			expectError: false,
+		},
+		{
+			input: "123",
+
+			expectedMajorVersion: 0,
+			expectedMinorVersion: 0,
+
+			expectError: true,
+		},
+		{
+			input: "2.24",
+
+			expectedMajorVersion: 2,
+			expectedMinorVersion: 24,
+
+			expectError: false,
+		},
+		{
+			input: "1a.24",
+
+			expectedMajorVersion: 0,
+			expectedMinorVersion: 0,
+
+			expectError: true,
+		},
+		{
+			input: "1.a24",
+
+			expectedMajorVersion: 0,
+			expectedMinorVersion: 0,
+
+			expectError: true,
+		},
+		{
+			input: "a1.a24",
+
+			expectedMajorVersion: 0,
+			expectedMinorVersion: 0,
+
+			expectError: true,
+		},
+	} {
+		gotMajor, gotMinor, err := splitKubernetesVersion(test.input)
+
+		if (err != nil) != test.expectError {
+			t.Errorf("expectError=%v, err=%v", test.expectError, err)
+		}
+
+		if gotMajor != test.expectedMajorVersion {
+			t.Errorf("got major version %q from %q, wanted %q", gotMajor, test.input, test.expectedMajorVersion)
+		}
+
+		if gotMinor != test.expectedMinorVersion {
+			t.Errorf("got minor version %q from %q, wanted %q", gotMinor, test.input, test.expectedMinorVersion)
+		}
+	}
+}

--- a/config/prowgen/prowspecs/specs.go
+++ b/config/prowgen/prowspecs/specs.go
@@ -1,0 +1,175 @@
+// +skip_license_check
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prowspecs
+
+import (
+	"fmt"
+	"strings"
+
+	"prowgen/pkg"
+)
+
+// knownBranches specifies a BranchSpec for each possible branch to test against
+// THIS IS WHAT YOU'RE MOST LIKELY TO NEED TO EDIT
+// The branches and kubernetes versions below are likely to need to be updated after each cert-manager release!
+
+// NB: There's at least one configurer (pkg/configurers.go) which will changes its operations
+// based on the k8s version it's being run against.
+
+var knownBranches map[string]BranchSpec = map[string]BranchSpec{
+	"release-1.10": {
+		prowContext: &pkg.ProwContext{
+			Branch: "release-1.10",
+
+			// Use latest image.
+			Image: pkg.CommonTestImage,
+
+			// NB: we don't use a presubmit dashboard outside of "master", currently
+			PresubmitDashboard: false,
+			PeriodicDashboard:  true,
+
+			Org:  "cert-manager",
+			Repo: "cert-manager",
+		},
+
+		primaryKubernetesVersion: "1.25",
+		otherKubernetesVersions:  []string{"1.20", "1.21", "1.22", "1.23", "1.24", "1.26"},
+	},
+	"release-1.11": {
+		prowContext: &pkg.ProwContext{
+			Branch: "release-1.11",
+
+			// Use latest image.
+			Image: pkg.CommonTestImage,
+
+			// NB: we don't use a presubmit dashboard outside of "master", currently
+			PresubmitDashboard: false,
+			PeriodicDashboard:  true,
+
+			Org:  "cert-manager",
+			Repo: "cert-manager",
+		},
+
+		primaryKubernetesVersion: "1.26",
+		otherKubernetesVersions:  []string{"1.21", "1.22", "1.23", "1.24", "1.25"},
+	},
+	"master": {
+		prowContext: &pkg.ProwContext{
+			Branch: "master",
+
+			// Use latest image.
+			Image: pkg.CommonTestImage,
+
+			PresubmitDashboard: true,
+			PeriodicDashboard:  true,
+
+			Org:  "cert-manager",
+			Repo: "cert-manager",
+		},
+
+		primaryKubernetesVersion: "1.26",
+		otherKubernetesVersions:  []string{"1.22", "1.23", "1.24", "1.25"},
+	},
+}
+
+// BranchSpec holds a specification of an entire test suite for a given branch, such as "master" or "release-1.9"
+// That includes:
+// - a ProwContext specifying things like the the repo, branch, dashboard names
+// - the primary Kubernetes version (which is the version whose tests are always run for presubmits, among other uses)
+// - the secondary Kubernetes versions, which are the rest of the supported versions for which tests should be generated
+type BranchSpec struct {
+	prowContext *pkg.ProwContext
+
+	primaryKubernetesVersion string
+	otherKubernetesVersions  []string
+}
+
+// GenerateJobFile will create a complete test file based on the BranchSpec. This
+// assumes that all tests for all branches should be the same.
+func (m *BranchSpec) GenerateJobFile() *pkg.JobFile {
+	m.prowContext.RequiredPresubmit(pkg.MakeTest(m.prowContext))
+	m.prowContext.RequiredPresubmit(pkg.ChartTest(m.prowContext))
+
+	for _, secondaryVersion := range m.otherKubernetesVersions {
+		m.prowContext.OptionalPresubmit(pkg.E2ETest(m.prowContext, secondaryVersion))
+	}
+
+	m.prowContext.RequiredPresubmit(pkg.E2ETest(m.prowContext, m.primaryKubernetesVersion))
+
+	m.prowContext.RequiredPresubmit(pkg.UpgradeTest(m.prowContext, m.primaryKubernetesVersion))
+
+	m.prowContext.OptionalPresubmitIfChanged(pkg.LicenseTest(m.prowContext), `go.mod`)
+
+	m.prowContext.OptionalPresubmit(pkg.E2ETestVenafiTPP(m.prowContext, m.primaryKubernetesVersion))
+	m.prowContext.OptionalPresubmit(pkg.E2ETestVenafiCloud(m.prowContext, m.primaryKubernetesVersion))
+	m.prowContext.OptionalPresubmit(pkg.E2ETestFeatureGatesDisabled(m.prowContext, m.primaryKubernetesVersion))
+	m.prowContext.OptionalPresubmit(pkg.E2ETestWithBestPracticeInstall(m.prowContext, m.primaryKubernetesVersion))
+
+	allKubernetesVersions := append(m.otherKubernetesVersions, m.primaryKubernetesVersion)
+
+	m.prowContext.Periodics(pkg.MakeTest(m.prowContext), 2)
+
+	// TODO: add chart periodic test?
+
+	for _, kubernetesVersion := range allKubernetesVersions {
+		m.prowContext.Periodics(pkg.E2ETest(m.prowContext, kubernetesVersion), 2)
+
+	}
+
+	m.prowContext.Periodics(pkg.E2ETestVenafiBoth(m.prowContext, m.primaryKubernetesVersion), 12)
+
+	m.prowContext.Periodics(pkg.UpgradeTest(m.prowContext, m.primaryKubernetesVersion), 8)
+
+	m.prowContext.Periodics(pkg.E2ETestWithBestPracticeInstall(m.prowContext, m.primaryKubernetesVersion), 24)
+
+	for _, kubernetesVersion := range allKubernetesVersions {
+		// TODO: roll this into above for loop; we have two for loops here to preserve the
+		// ordering of the tests in the output file, making it easier to review the
+		// differences between generated tests and existing handwritten tests
+		m.prowContext.Periodics(pkg.E2ETestFeatureGatesDisabled(m.prowContext, kubernetesVersion), 24)
+	}
+
+	for _, container := range []string{"controller", "acmesolver", "ctl", "cainjector", "webhook"} {
+		m.prowContext.Periodics(pkg.TrivyTest(m.prowContext, container), 24)
+	}
+
+	return m.prowContext.JobFile()
+}
+
+// KnownBranches returns a list of all branches which have been configured here
+func KnownBranches() []string {
+	var availableBranches []string
+
+	for branch, _ := range knownBranches {
+		availableBranches = append(availableBranches, branch)
+	}
+
+	return availableBranches
+}
+
+// SpecForBranch returns a spec for the named branch, if it exists
+func SpecForBranch(originalBranch string) (BranchSpec, error) {
+	branch := strings.ToLower(originalBranch)
+
+	spec, ok := knownBranches[branch]
+	if !ok {
+		return BranchSpec{}, fmt.Errorf("unknown branch %q; known branches are %q", originalBranch, KnownBranches())
+	}
+
+	return spec, nil
+}


### PR DESCRIPTION
This is the first step in the process of moving prowgen to cert-manager/release. The only changes that were made are filename changes & module changes.

The copy is based on https://github.com/cert-manager/release/commit/49b0c286b27ae0a37d656136afe18de2771318bd