### PR TITLE
Setup testing repo presubmits so prowgen is tested & go is available for the verify target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ verify-boilerplate:
 .PHONY: verify
 verify: verify-boilerplate
 
+.PHONY: test
+test:
+	cd ./config/prowgen/ && go test ./...
+
 # Run checkconfig locally to verify the Prow configuration, CI runs this
 # directly in the Prow cluster.
 local-checkconfig:

--- a/config/jobs/testing/testing-presubmits.yaml
+++ b/config/jobs/testing/testing-presubmits.yaml
@@ -29,7 +29,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20230407-da759c2-1.20.2
         args:
         - runner
         - make
@@ -40,6 +40,24 @@ presubmits:
             memory: 100Mi
     trigger: "(?m)^/test verify,?(\\s+|$)"
     rerun_command: "/test verify"
+
+  - name: pull-testing-test
+    always_run: true
+    max_concurrency: 4
+    decorate: true
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20230407-da759c2-1.20.2
+        args:
+        - runner
+        - make
+        - test
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+    trigger: "(?m)^/test test,?(\\s+|$)"
+    rerun_command: "/test test"
 
   - name: pull-testing-check-testgrid-config
     always_run: true


### PR DESCRIPTION
This PR runs the go tests before merging testing PRs.
Also, it prepares the make verify target with a golang installation so go can be used in a follow-up PR.

preparation for #879