### PR TITLE
Adds tests for release-1.12 and kube 1.27

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -61,13 +61,6 @@ branch-protection:
             # branch basis, since context names differ. Post release, the
             # release branches can be updated to allow for cherry picks to the
             # latest release.
-            release-1.9:
-              required_status_checks:
-                contexts:
-                - pull-cert-manager-release-1.9-chart
-                - pull-cert-manager-release-1.9-make-test
-                - pull-cert-manager-release-1.9-e2e-v1-24
-                - pull-cert-manager-release-1.9-e2e-v1-24-upgrade
             release-1.10:
               required_status_checks:
                 contexts:
@@ -82,13 +75,20 @@ branch-protection:
                 - pull-cert-manager-release-1.11-make-test
                 - pull-cert-manager-release-1.11-e2e-v1-26
                 - pull-cert-manager-release-1.11-e2e-v1-26-upgrade
+            release-1.12:
+              required_status_checks:
+                contexts:
+                - pull-cert-manager-release-1.12-chart
+                - pull-cert-manager-release-1.12-make-test
+                - pull-cert-manager-release-1.12-e2e-v1-27
+                - pull-cert-manager-release-1.12-e2e-v1-27-upgrade
             master:
               required_status_checks:
                 contexts:
                 - pull-cert-manager-master-chart
                 - pull-cert-manager-master-make-test
-                - pull-cert-manager-master-e2e-v1-26
-                - pull-cert-manager-master-e2e-v1-26-upgrade
+                - pull-cert-manager-master-e2e-v1-27
+                - pull-cert-manager-master-e2e-v1-27-upgrade
         website:
           required_status_checks:
             contexts:

--- a/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
+++ b/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
@@ -326,9 +326,60 @@ presubmits:
           value: "1"
     branches:
     - master
+    always_run: false
+    optional: true
+  - name: pull-cert-manager-master-e2e-v1-27
+    max_concurrency: 4
+    decorate: true
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.27 cluster
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-job-group: "true"
+      testgrid-dashboards: cert-manager-presubmits-master
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+      preset-retry-flakey-jobs: "true"
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+        args:
+        - runner
+        - make
+        - -j7
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.27
+        resources:
+          requests:
+            cpu: 7000m
+            memory: 6Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+    branches:
+    - master
     always_run: true
     optional: false
-  - name: pull-cert-manager-master-e2e-v1-26-upgrade
+  - name: pull-cert-manager-master-e2e-v1-27-upgrade
     max_concurrency: 4
     decorate: true
     annotations:
@@ -347,7 +398,7 @@ presubmits:
         args:
         - runner
         - make
-        - K8S_VERSION=1.26
+        - K8S_VERSION=1.27
         - vendor-go
         - test-upgrade
         resources:
@@ -401,7 +452,7 @@ presubmits:
     always_run: false
     optional: true
     run_if_changed: go.mod
-  - name: pull-cert-manager-master-e2e-v1-26-issuers-venafi-tpp
+  - name: pull-cert-manager-master-e2e-v1-27-issuers-venafi-tpp
     max_concurrency: 4
     decorate: true
     annotations:
@@ -426,7 +477,7 @@ presubmits:
         - -j7
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.26
+        - K8S_VERSION=1.27
         resources:
           requests:
             cpu: 7000m
@@ -451,7 +502,7 @@ presubmits:
     - master
     always_run: false
     optional: true
-  - name: pull-cert-manager-master-e2e-v1-26-issuers-venafi-cloud
+  - name: pull-cert-manager-master-e2e-v1-27-issuers-venafi-cloud
     max_concurrency: 4
     decorate: true
     annotations:
@@ -476,7 +527,7 @@ presubmits:
         - -j7
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.26
+        - K8S_VERSION=1.27
         resources:
           requests:
             cpu: 7000m
@@ -501,7 +552,7 @@ presubmits:
     - master
     always_run: false
     optional: true
-  - name: pull-cert-manager-master-e2e-v1-26-feature-gates-disabled
+  - name: pull-cert-manager-master-e2e-v1-27-feature-gates-disabled
     max_concurrency: 4
     decorate: true
     annotations:
@@ -527,7 +578,7 @@ presubmits:
         - -j7
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.26
+        - K8S_VERSION=1.27
         resources:
           requests:
             cpu: 7000m
@@ -552,7 +603,7 @@ presubmits:
     - master
     always_run: false
     optional: true
-  - name: pull-cert-manager-master-e2e-v1-26-bestpractice-install
+  - name: pull-cert-manager-master-e2e-v1-27-bestpractice-install
     max_concurrency: 4
     decorate: true
     annotations:
@@ -580,7 +631,7 @@ presubmits:
         - -j7
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.26
+        - K8S_VERSION=1.27
         resources:
           requests:
             cpu: 7000m
@@ -901,7 +952,59 @@ periodics:
     repo: cert-manager
     base_ref: master
   interval: 2h
-- name: ci-cert-manager-master-e2e-v1-26-issuers-venafi
+- name: ci-cert-manager-master-e2e-v1-27
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the end-to-end test suite against a Kubernetes v1.27 cluster
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-master
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.27
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: master
+  interval: 2h
+- name: ci-cert-manager-master-e2e-v1-27-issuers-venafi
   max_concurrency: 4
   decorate: true
   annotations:
@@ -927,7 +1030,7 @@ periodics:
       - -j7
       - vendor-go
       - e2e-ci
-      - K8S_VERSION=1.26
+      - K8S_VERSION=1.27
       resources:
         requests:
           cpu: 7000m
@@ -953,7 +1056,7 @@ periodics:
     repo: cert-manager
     base_ref: master
   interval: 12h
-- name: ci-cert-manager-master-e2e-v1-26-upgrade
+- name: ci-cert-manager-master-e2e-v1-27-upgrade
   max_concurrency: 4
   decorate: true
   annotations:
@@ -972,7 +1075,7 @@ periodics:
       args:
       - runner
       - make
-      - K8S_VERSION=1.26
+      - K8S_VERSION=1.27
       - vendor-go
       - test-upgrade
       resources:
@@ -993,7 +1096,7 @@ periodics:
     repo: cert-manager
     base_ref: master
   interval: 8h
-- name: ci-cert-manager-master-e2e-v1-26-bestpractice-install
+- name: ci-cert-manager-master-e2e-v1-27-bestpractice-install
   max_concurrency: 4
   decorate: true
   annotations:
@@ -1021,7 +1124,7 @@ periodics:
       - -j7
       - vendor-go
       - e2e-ci
-      - K8S_VERSION=1.26
+      - K8S_VERSION=1.27
       resources:
         requests:
           cpu: 7000m
@@ -1282,6 +1385,58 @@ periodics:
       - vendor-go
       - e2e-ci
       - K8S_VERSION=1.26
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: master
+  interval: 24h
+- name: ci-cert-manager-master-e2e-v1-27-feature-gates-disabled
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the E2E tests with all feature gates disabled
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-master
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-disable-all-alpha-beta-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.27
       resources:
         requests:
           cpu: 7000m

--- a/config/jobs/cert-manager/cert-manager/release-1.12/cert-manager-release-1.12.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.12/cert-manager-release-1.12.yaml
@@ -1,10 +1,10 @@
 # THIS FILE HAS BEEN AUTOMATICALLY GENERATED
-# Don't manually edit it; instead edit the "cmrel" tool which generated it
-# Generated with: cmrel generate-prow --branch * -o file
+# Don't manually edit it; instead edit the "prowgen" tool which generated it
+# Generated with: main prowgen --branch=release-1.12
 
 presubmits:
   cert-manager/cert-manager:
-  - name: pull-cert-manager-release-1.11-make-test
+  - name: pull-cert-manager-release-1.12-make-test
     max_concurrency: 8
     decorate: true
     annotations:
@@ -32,10 +32,10 @@ presubmits:
         - name: ndots
           value: "1"
     branches:
-    - release-1.11
+    - release-1.12
     always_run: true
     optional: false
-  - name: pull-cert-manager-release-1.11-chart
+  - name: pull-cert-manager-release-1.12-chart
     max_concurrency: 8
     decorate: true
     annotations:
@@ -64,58 +64,10 @@ presubmits:
         - name: ndots
           value: "1"
     branches:
-    - release-1.11
+    - release-1.12
     always_run: true
     optional: false
-  - name: pull-cert-manager-release-1.11-e2e-v1-21
-    max_concurrency: 4
-    decorate: true
-    annotations:
-      description: Runs the end-to-end test suite against a Kubernetes v1.21 cluster
-    labels:
-      preset-cloudflare-credentials: "true"
-      preset-dind-enabled: "true"
-      preset-enable-all-feature-gates-disable-ssa: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-go-cache: "true"
-      preset-local-cache: "true"
-      preset-retry-flakey-jobs: "true"
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
-        args:
-        - runner
-        - make
-        - -j3
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.21
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 6Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add:
-            - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-    branches:
-    - release-1.11
-    always_run: false
-    optional: true
-  - name: pull-cert-manager-release-1.11-e2e-v1-22
+  - name: pull-cert-manager-release-1.12-e2e-v1-22
     max_concurrency: 4
     decorate: true
     annotations:
@@ -135,13 +87,13 @@ presubmits:
         args:
         - runner
         - make
-        - -j3
+        - -j7
         - vendor-go
         - e2e-ci
         - K8S_VERSION=1.22
         resources:
           requests:
-            cpu: 3500m
+            cpu: 7000m
             memory: 6Gi
         securityContext:
           privileged: true
@@ -160,10 +112,10 @@ presubmits:
         - name: ndots
           value: "1"
     branches:
-    - release-1.11
+    - release-1.12
     always_run: false
     optional: true
-  - name: pull-cert-manager-release-1.11-e2e-v1-23
+  - name: pull-cert-manager-release-1.12-e2e-v1-23
     max_concurrency: 4
     decorate: true
     annotations:
@@ -183,13 +135,13 @@ presubmits:
         args:
         - runner
         - make
-        - -j3
+        - -j7
         - vendor-go
         - e2e-ci
         - K8S_VERSION=1.23
         resources:
           requests:
-            cpu: 3500m
+            cpu: 7000m
             memory: 6Gi
         securityContext:
           privileged: true
@@ -208,10 +160,10 @@ presubmits:
         - name: ndots
           value: "1"
     branches:
-    - release-1.11
+    - release-1.12
     always_run: false
     optional: true
-  - name: pull-cert-manager-release-1.11-e2e-v1-24
+  - name: pull-cert-manager-release-1.12-e2e-v1-24
     max_concurrency: 4
     decorate: true
     annotations:
@@ -231,13 +183,13 @@ presubmits:
         args:
         - runner
         - make
-        - -j3
+        - -j7
         - vendor-go
         - e2e-ci
         - K8S_VERSION=1.24
         resources:
           requests:
-            cpu: 3500m
+            cpu: 7000m
             memory: 6Gi
         securityContext:
           privileged: true
@@ -256,10 +208,10 @@ presubmits:
         - name: ndots
           value: "1"
     branches:
-    - release-1.11
+    - release-1.12
     always_run: false
     optional: true
-  - name: pull-cert-manager-release-1.11-e2e-v1-25
+  - name: pull-cert-manager-release-1.12-e2e-v1-25
     max_concurrency: 4
     decorate: true
     annotations:
@@ -279,7 +231,7 @@ presubmits:
         args:
         - runner
         - make
-        - -j3
+        - -j7
         - vendor-go
         - e2e-ci
         - K8S_VERSION=1.25
@@ -304,10 +256,58 @@ presubmits:
         - name: ndots
           value: "1"
     branches:
-    - release-1.11
+    - release-1.12
     always_run: false
     optional: true
-  - name: pull-cert-manager-release-1.11-e2e-v1-27
+  - name: pull-cert-manager-release-1.12-e2e-v1-26
+    max_concurrency: 4
+    decorate: true
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.26 cluster
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+      preset-retry-flakey-jobs: "true"
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+        args:
+        - runner
+        - make
+        - -j7
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.26
+        resources:
+          requests:
+            cpu: 7000m
+            memory: 6Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+    branches:
+    - release-1.12
+    always_run: false
+    optional: true
+  - name: pull-cert-manager-release-1.12-e2e-v1-27
     max_concurrency: 4
     decorate: true
     annotations:
@@ -352,58 +352,10 @@ presubmits:
         - name: ndots
           value: "1"
     branches:
-    - release-1.11
-    always_run: false
-    optional: true
-  - name: pull-cert-manager-release-1.11-e2e-v1-26
-    max_concurrency: 4
-    decorate: true
-    annotations:
-      description: Runs the end-to-end test suite against a Kubernetes v1.26 cluster
-    labels:
-      preset-cloudflare-credentials: "true"
-      preset-dind-enabled: "true"
-      preset-enable-all-feature-gates: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-go-cache: "true"
-      preset-local-cache: "true"
-      preset-retry-flakey-jobs: "true"
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
-        args:
-        - runner
-        - make
-        - -j3
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.26
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 6Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add:
-            - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
-      dnsConfig:
-        options:
-        - name: ndots
-          value: "1"
-    branches:
-    - release-1.11
+    - release-1.12
     always_run: true
     optional: false
-  - name: pull-cert-manager-release-1.11-e2e-v1-26-upgrade
+  - name: pull-cert-manager-release-1.12-e2e-v1-27-upgrade
     max_concurrency: 4
     decorate: true
     annotations:
@@ -419,7 +371,7 @@ presubmits:
         args:
         - runner
         - make
-        - K8S_VERSION=1.26
+        - K8S_VERSION=1.27
         - vendor-go
         - test-upgrade
         resources:
@@ -436,10 +388,10 @@ presubmits:
         - name: ndots
           value: "1"
     branches:
-    - release-1.11
+    - release-1.12
     always_run: true
     optional: false
-  - name: pull-cert-manager-release-1.11-license
+  - name: pull-cert-manager-release-1.12-license
     max_concurrency: 8
     decorate: true
     annotations:
@@ -466,11 +418,11 @@ presubmits:
         - name: ndots
           value: "1"
     branches:
-    - release-1.11
+    - release-1.12
     always_run: false
     optional: true
     run_if_changed: go.mod
-  - name: pull-cert-manager-release-1.11-e2e-v1-26-issuers-venafi-tpp
+  - name: pull-cert-manager-release-1.12-e2e-v1-27-issuers-venafi-tpp
     max_concurrency: 4
     decorate: true
     annotations:
@@ -489,13 +441,13 @@ presubmits:
         args:
         - runner
         - make
-        - -j3
+        - -j7
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.26
+        - K8S_VERSION=1.27
         resources:
           requests:
-            cpu: 3500m
+            cpu: 7000m
             memory: 6Gi
         securityContext:
           privileged: true
@@ -514,10 +466,10 @@ presubmits:
         - name: ndots
           value: "1"
     branches:
-    - release-1.11
+    - release-1.12
     always_run: false
     optional: true
-  - name: pull-cert-manager-release-1.11-e2e-v1-26-issuers-venafi-cloud
+  - name: pull-cert-manager-release-1.12-e2e-v1-27-issuers-venafi-cloud
     max_concurrency: 4
     decorate: true
     annotations:
@@ -536,13 +488,13 @@ presubmits:
         args:
         - runner
         - make
-        - -j3
+        - -j7
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.26
+        - K8S_VERSION=1.27
         resources:
           requests:
-            cpu: 3500m
+            cpu: 7000m
             memory: 6Gi
         securityContext:
           privileged: true
@@ -561,10 +513,10 @@ presubmits:
         - name: ndots
           value: "1"
     branches:
-    - release-1.11
+    - release-1.12
     always_run: false
     optional: true
-  - name: pull-cert-manager-release-1.11-e2e-v1-26-feature-gates-disabled
+  - name: pull-cert-manager-release-1.12-e2e-v1-27-feature-gates-disabled
     max_concurrency: 4
     decorate: true
     annotations:
@@ -584,13 +536,13 @@ presubmits:
         args:
         - runner
         - make
-        - -j3
+        - -j7
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.26
+        - K8S_VERSION=1.27
         resources:
           requests:
-            cpu: 3500m
+            cpu: 7000m
             memory: 6Gi
         securityContext:
           privileged: true
@@ -609,10 +561,10 @@ presubmits:
         - name: ndots
           value: "1"
     branches:
-    - release-1.11
+    - release-1.12
     always_run: false
     optional: true
-  - name: pull-cert-manager-release-1.11-e2e-v1-26-bestpractice-install
+  - name: pull-cert-manager-release-1.12-e2e-v1-27-bestpractice-install
     max_concurrency: 4
     decorate: true
     annotations:
@@ -634,13 +586,13 @@ presubmits:
         args:
         - runner
         - make
-        - -j3
+        - -j7
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.26
+        - K8S_VERSION=1.27
         resources:
           requests:
-            cpu: 3500m
+            cpu: 7000m
             memory: 6Gi
         securityContext:
           privileged: true
@@ -659,18 +611,18 @@ presubmits:
         - name: ndots
           value: "1"
     branches:
-    - release-1.11
+    - release-1.12
     always_run: false
     optional: true
 periodics:
-- name: ci-cert-manager-release-1.11-make-test
+- name: ci-cert-manager-release-1.12-make-test
   max_concurrency: 8
   decorate: true
   annotations:
     description: Runs unit and integration tests and verification scripts
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-release-1.11
+    testgrid-dashboards: cert-manager-periodics-release-1.12
   labels:
     preset-go-cache: "true"
     preset-local-cache: "true"
@@ -696,68 +648,16 @@ periodics:
   extra_refs:
   - org: cert-manager
     repo: cert-manager
-    base_ref: release-1.11
+    base_ref: release-1.12
   interval: 2h
-- name: ci-cert-manager-release-1.11-e2e-v1-21
-  max_concurrency: 4
-  decorate: true
-  annotations:
-    description: Runs the end-to-end test suite against a Kubernetes v1.21 cluster
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-release-1.11
-  labels:
-    preset-cloudflare-credentials: "true"
-    preset-dind-enabled: "true"
-    preset-enable-all-feature-gates-disable-ssa: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-go-cache: "true"
-    preset-local-cache: "true"
-    preset-retry-flakey-jobs: "true"
-    preset-service-account: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
-      args:
-      - runner
-      - make
-      - -j3
-      - vendor-go
-      - e2e-ci
-      - K8S_VERSION=1.21
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 6Gi
-      securityContext:
-        privileged: true
-        capabilities:
-          add:
-          - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: release-1.11
-  interval: 2h
-- name: ci-cert-manager-release-1.11-e2e-v1-22
+- name: ci-cert-manager-release-1.12-e2e-v1-22
   max_concurrency: 4
   decorate: true
   annotations:
     description: Runs the end-to-end test suite against a Kubernetes v1.22 cluster
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-release-1.11
+    testgrid-dashboards: cert-manager-periodics-release-1.12
   labels:
     preset-cloudflare-credentials: "true"
     preset-dind-enabled: "true"
@@ -773,13 +673,13 @@ periodics:
       args:
       - runner
       - make
-      - -j3
+      - -j7
       - vendor-go
       - e2e-ci
       - K8S_VERSION=1.22
       resources:
         requests:
-          cpu: 3500m
+          cpu: 7000m
           memory: 6Gi
       securityContext:
         privileged: true
@@ -800,16 +700,16 @@ periodics:
   extra_refs:
   - org: cert-manager
     repo: cert-manager
-    base_ref: release-1.11
+    base_ref: release-1.12
   interval: 2h
-- name: ci-cert-manager-release-1.11-e2e-v1-23
+- name: ci-cert-manager-release-1.12-e2e-v1-23
   max_concurrency: 4
   decorate: true
   annotations:
     description: Runs the end-to-end test suite against a Kubernetes v1.23 cluster
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-release-1.11
+    testgrid-dashboards: cert-manager-periodics-release-1.12
   labels:
     preset-cloudflare-credentials: "true"
     preset-dind-enabled: "true"
@@ -825,13 +725,13 @@ periodics:
       args:
       - runner
       - make
-      - -j3
+      - -j7
       - vendor-go
       - e2e-ci
       - K8S_VERSION=1.23
       resources:
         requests:
-          cpu: 3500m
+          cpu: 7000m
           memory: 6Gi
       securityContext:
         privileged: true
@@ -852,16 +752,16 @@ periodics:
   extra_refs:
   - org: cert-manager
     repo: cert-manager
-    base_ref: release-1.11
+    base_ref: release-1.12
   interval: 2h
-- name: ci-cert-manager-release-1.11-e2e-v1-24
+- name: ci-cert-manager-release-1.12-e2e-v1-24
   max_concurrency: 4
   decorate: true
   annotations:
     description: Runs the end-to-end test suite against a Kubernetes v1.24 cluster
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-release-1.11
+    testgrid-dashboards: cert-manager-periodics-release-1.12
   labels:
     preset-cloudflare-credentials: "true"
     preset-dind-enabled: "true"
@@ -877,13 +777,13 @@ periodics:
       args:
       - runner
       - make
-      - -j3
+      - -j7
       - vendor-go
       - e2e-ci
       - K8S_VERSION=1.24
       resources:
         requests:
-          cpu: 3500m
+          cpu: 7000m
           memory: 6Gi
       securityContext:
         privileged: true
@@ -904,16 +804,16 @@ periodics:
   extra_refs:
   - org: cert-manager
     repo: cert-manager
-    base_ref: release-1.11
+    base_ref: release-1.12
   interval: 2h
-- name: ci-cert-manager-release-1.11-e2e-v1-25
+- name: ci-cert-manager-release-1.12-e2e-v1-25
   max_concurrency: 4
   decorate: true
   annotations:
     description: Runs the end-to-end test suite against a Kubernetes v1.25 cluster
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-release-1.11
+    testgrid-dashboards: cert-manager-periodics-release-1.12
   labels:
     preset-cloudflare-credentials: "true"
     preset-dind-enabled: "true"
@@ -956,16 +856,68 @@ periodics:
   extra_refs:
   - org: cert-manager
     repo: cert-manager
-    base_ref: release-1.11
+    base_ref: release-1.12
   interval: 2h
-- name: ci-cert-manager-release-1.11-e2e-v1-27
+- name: ci-cert-manager-release-1.12-e2e-v1-26
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the end-to-end test suite against a Kubernetes v1.26 cluster
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.12
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.26
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.12
+  interval: 2h
+- name: ci-cert-manager-release-1.12-e2e-v1-27
   max_concurrency: 4
   decorate: true
   annotations:
     description: Runs the end-to-end test suite against a Kubernetes v1.27 cluster
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-release-1.11
+    testgrid-dashboards: cert-manager-periodics-release-1.12
   labels:
     preset-cloudflare-credentials: "true"
     preset-dind-enabled: "true"
@@ -1008,68 +960,16 @@ periodics:
   extra_refs:
   - org: cert-manager
     repo: cert-manager
-    base_ref: release-1.11
+    base_ref: release-1.12
   interval: 2h
-- name: ci-cert-manager-release-1.11-e2e-v1-26
-  max_concurrency: 4
-  decorate: true
-  annotations:
-    description: Runs the end-to-end test suite against a Kubernetes v1.26 cluster
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-release-1.11
-  labels:
-    preset-cloudflare-credentials: "true"
-    preset-dind-enabled: "true"
-    preset-enable-all-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-go-cache: "true"
-    preset-local-cache: "true"
-    preset-retry-flakey-jobs: "true"
-    preset-service-account: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
-      args:
-      - runner
-      - make
-      - -j3
-      - vendor-go
-      - e2e-ci
-      - K8S_VERSION=1.26
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 6Gi
-      securityContext:
-        privileged: true
-        capabilities:
-          add:
-          - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: release-1.11
-  interval: 2h
-- name: ci-cert-manager-release-1.11-e2e-v1-26-issuers-venafi
+- name: ci-cert-manager-release-1.12-e2e-v1-27-issuers-venafi
   max_concurrency: 4
   decorate: true
   annotations:
     description: Runs Venafi (VaaS and TPP) e2e tests
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-release-1.11
+    testgrid-dashboards: cert-manager-periodics-release-1.12
   labels:
     preset-dind-enabled: "true"
     preset-ginkgo-focus-venafi: "true"
@@ -1085,13 +985,13 @@ periodics:
       args:
       - runner
       - make
-      - -j3
+      - -j7
       - vendor-go
       - e2e-ci
-      - K8S_VERSION=1.26
+      - K8S_VERSION=1.27
       resources:
         requests:
-          cpu: 3500m
+          cpu: 7000m
           memory: 6Gi
       securityContext:
         privileged: true
@@ -1112,16 +1012,16 @@ periodics:
   extra_refs:
   - org: cert-manager
     repo: cert-manager
-    base_ref: release-1.11
+    base_ref: release-1.12
   interval: 12h
-- name: ci-cert-manager-release-1.11-e2e-v1-26-upgrade
+- name: ci-cert-manager-release-1.12-e2e-v1-27-upgrade
   max_concurrency: 4
   decorate: true
   annotations:
     description: Runs cert-manager upgrade from latest published release
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-release-1.11
+    testgrid-dashboards: cert-manager-periodics-release-1.12
   labels:
     preset-dind-enabled: "true"
     preset-go-cache: "true"
@@ -1133,7 +1033,7 @@ periodics:
       args:
       - runner
       - make
-      - K8S_VERSION=1.26
+      - K8S_VERSION=1.27
       - vendor-go
       - test-upgrade
       resources:
@@ -1152,9 +1052,9 @@ periodics:
   extra_refs:
   - org: cert-manager
     repo: cert-manager
-    base_ref: release-1.11
+    base_ref: release-1.12
   interval: 8h
-- name: ci-cert-manager-release-1.11-e2e-v1-26-bestpractice-install
+- name: ci-cert-manager-release-1.12-e2e-v1-27-bestpractice-install
   max_concurrency: 4
   decorate: true
   annotations:
@@ -1162,7 +1062,7 @@ periodics:
       https://cert-manager.io/docs/installation/best-practice/
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-release-1.11
+    testgrid-dashboards: cert-manager-periodics-release-1.12
   labels:
     preset-bestpractice-install: "true"
     preset-cloudflare-credentials: "true"
@@ -1179,13 +1079,13 @@ periodics:
       args:
       - runner
       - make
-      - -j3
+      - -j7
       - vendor-go
       - e2e-ci
-      - K8S_VERSION=1.26
+      - K8S_VERSION=1.27
       resources:
         requests:
-          cpu: 3500m
+          cpu: 7000m
           memory: 6Gi
       securityContext:
         privileged: true
@@ -1206,16 +1106,16 @@ periodics:
   extra_refs:
   - org: cert-manager
     repo: cert-manager
-    base_ref: release-1.11
+    base_ref: release-1.12
   interval: 24h
-- name: ci-cert-manager-release-1.11-e2e-v1-21-feature-gates-disabled
+- name: ci-cert-manager-release-1.12-e2e-v1-22-feature-gates-disabled
   max_concurrency: 4
   decorate: true
   annotations:
     description: Runs the E2E tests with all feature gates disabled
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-release-1.11
+    testgrid-dashboards: cert-manager-periodics-release-1.12
   labels:
     preset-cloudflare-credentials: "true"
     preset-dind-enabled: "true"
@@ -1231,65 +1131,13 @@ periodics:
       args:
       - runner
       - make
-      - -j3
-      - vendor-go
-      - e2e-ci
-      - K8S_VERSION=1.21
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 6Gi
-      securityContext:
-        privileged: true
-        capabilities:
-          add:
-          - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: release-1.11
-  interval: 24h
-- name: ci-cert-manager-release-1.11-e2e-v1-22-feature-gates-disabled
-  max_concurrency: 4
-  decorate: true
-  annotations:
-    description: Runs the E2E tests with all feature gates disabled
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-release-1.11
-  labels:
-    preset-cloudflare-credentials: "true"
-    preset-dind-enabled: "true"
-    preset-disable-all-alpha-beta-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-go-cache: "true"
-    preset-local-cache: "true"
-    preset-retry-flakey-jobs: "true"
-    preset-service-account: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
-      args:
-      - runner
-      - make
-      - -j3
+      - -j7
       - vendor-go
       - e2e-ci
       - K8S_VERSION=1.22
       resources:
         requests:
-          cpu: 3500m
+          cpu: 7000m
           memory: 6Gi
       securityContext:
         privileged: true
@@ -1310,16 +1158,16 @@ periodics:
   extra_refs:
   - org: cert-manager
     repo: cert-manager
-    base_ref: release-1.11
+    base_ref: release-1.12
   interval: 24h
-- name: ci-cert-manager-release-1.11-e2e-v1-23-feature-gates-disabled
+- name: ci-cert-manager-release-1.12-e2e-v1-23-feature-gates-disabled
   max_concurrency: 4
   decorate: true
   annotations:
     description: Runs the E2E tests with all feature gates disabled
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-release-1.11
+    testgrid-dashboards: cert-manager-periodics-release-1.12
   labels:
     preset-cloudflare-credentials: "true"
     preset-dind-enabled: "true"
@@ -1335,13 +1183,13 @@ periodics:
       args:
       - runner
       - make
-      - -j3
+      - -j7
       - vendor-go
       - e2e-ci
       - K8S_VERSION=1.23
       resources:
         requests:
-          cpu: 3500m
+          cpu: 7000m
           memory: 6Gi
       securityContext:
         privileged: true
@@ -1362,16 +1210,16 @@ periodics:
   extra_refs:
   - org: cert-manager
     repo: cert-manager
-    base_ref: release-1.11
+    base_ref: release-1.12
   interval: 24h
-- name: ci-cert-manager-release-1.11-e2e-v1-24-feature-gates-disabled
+- name: ci-cert-manager-release-1.12-e2e-v1-24-feature-gates-disabled
   max_concurrency: 4
   decorate: true
   annotations:
     description: Runs the E2E tests with all feature gates disabled
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-release-1.11
+    testgrid-dashboards: cert-manager-periodics-release-1.12
   labels:
     preset-cloudflare-credentials: "true"
     preset-dind-enabled: "true"
@@ -1387,13 +1235,13 @@ periodics:
       args:
       - runner
       - make
-      - -j3
+      - -j7
       - vendor-go
       - e2e-ci
       - K8S_VERSION=1.24
       resources:
         requests:
-          cpu: 3500m
+          cpu: 7000m
           memory: 6Gi
       securityContext:
         privileged: true
@@ -1414,16 +1262,16 @@ periodics:
   extra_refs:
   - org: cert-manager
     repo: cert-manager
-    base_ref: release-1.11
+    base_ref: release-1.12
   interval: 24h
-- name: ci-cert-manager-release-1.11-e2e-v1-25-feature-gates-disabled
+- name: ci-cert-manager-release-1.12-e2e-v1-25-feature-gates-disabled
   max_concurrency: 4
   decorate: true
   annotations:
     description: Runs the E2E tests with all feature gates disabled
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-release-1.11
+    testgrid-dashboards: cert-manager-periodics-release-1.12
   labels:
     preset-cloudflare-credentials: "true"
     preset-dind-enabled: "true"
@@ -1439,7 +1287,7 @@ periodics:
       args:
       - runner
       - make
-      - -j3
+      - -j7
       - vendor-go
       - e2e-ci
       - K8S_VERSION=1.25
@@ -1466,16 +1314,68 @@ periodics:
   extra_refs:
   - org: cert-manager
     repo: cert-manager
-    base_ref: release-1.11
+    base_ref: release-1.12
   interval: 24h
-- name: ci-cert-manager-release-1.11-e2e-v1-27-feature-gates-disabled
+- name: ci-cert-manager-release-1.12-e2e-v1-26-feature-gates-disabled
   max_concurrency: 4
   decorate: true
   annotations:
     description: Runs the E2E tests with all feature gates disabled
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-release-1.11
+    testgrid-dashboards: cert-manager-periodics-release-1.12
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-disable-all-alpha-beta-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.26
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.12
+  interval: 24h
+- name: ci-cert-manager-release-1.12-e2e-v1-27-feature-gates-disabled
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the E2E tests with all feature gates disabled
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.12
   labels:
     preset-cloudflare-credentials: "true"
     preset-dind-enabled: "true"
@@ -1518,61 +1418,9 @@ periodics:
   extra_refs:
   - org: cert-manager
     repo: cert-manager
-    base_ref: release-1.11
+    base_ref: release-1.12
   interval: 24h
-- name: ci-cert-manager-release-1.11-e2e-v1-26-feature-gates-disabled
-  max_concurrency: 4
-  decorate: true
-  annotations:
-    description: Runs the E2E tests with all feature gates disabled
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-release-1.11
-  labels:
-    preset-cloudflare-credentials: "true"
-    preset-dind-enabled: "true"
-    preset-disable-all-alpha-beta-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-go-cache: "true"
-    preset-local-cache: "true"
-    preset-retry-flakey-jobs: "true"
-    preset-service-account: "true"
-  spec:
-    containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
-      args:
-      - runner
-      - make
-      - -j3
-      - vendor-go
-      - e2e-ci
-      - K8S_VERSION=1.26
-      resources:
-        requests:
-          cpu: 3500m
-          memory: 6Gi
-      securityContext:
-        privileged: true
-        capabilities:
-          add:
-          - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
-    dnsConfig:
-      options:
-      - name: ndots
-        value: "1"
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: release-1.11
-  interval: 24h
-- name: ci-cert-manager-release-1.11-trivy-test-controller
+- name: ci-cert-manager-release-1.12-trivy-test-controller
   max_concurrency: 2
   decorate: true
   annotations:
@@ -1580,7 +1428,7 @@ periodics:
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     testgrid-alert-stale-results-hours: "36"
     testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-release-1.11
+    testgrid-dashboards: cert-manager-periodics-release-1.12
     testgrid-num-failures-to-alert: "1"
   labels:
     preset-dind-enabled: "true"
@@ -1609,9 +1457,9 @@ periodics:
   extra_refs:
   - org: cert-manager
     repo: cert-manager
-    base_ref: release-1.11
+    base_ref: release-1.12
   interval: 24h
-- name: ci-cert-manager-release-1.11-trivy-test-acmesolver
+- name: ci-cert-manager-release-1.12-trivy-test-acmesolver
   max_concurrency: 2
   decorate: true
   annotations:
@@ -1619,7 +1467,7 @@ periodics:
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     testgrid-alert-stale-results-hours: "36"
     testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-release-1.11
+    testgrid-dashboards: cert-manager-periodics-release-1.12
     testgrid-num-failures-to-alert: "1"
   labels:
     preset-dind-enabled: "true"
@@ -1648,9 +1496,9 @@ periodics:
   extra_refs:
   - org: cert-manager
     repo: cert-manager
-    base_ref: release-1.11
+    base_ref: release-1.12
   interval: 24h
-- name: ci-cert-manager-release-1.11-trivy-test-ctl
+- name: ci-cert-manager-release-1.12-trivy-test-ctl
   max_concurrency: 2
   decorate: true
   annotations:
@@ -1658,7 +1506,7 @@ periodics:
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     testgrid-alert-stale-results-hours: "36"
     testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-release-1.11
+    testgrid-dashboards: cert-manager-periodics-release-1.12
     testgrid-num-failures-to-alert: "1"
   labels:
     preset-dind-enabled: "true"
@@ -1687,9 +1535,9 @@ periodics:
   extra_refs:
   - org: cert-manager
     repo: cert-manager
-    base_ref: release-1.11
+    base_ref: release-1.12
   interval: 24h
-- name: ci-cert-manager-release-1.11-trivy-test-cainjector
+- name: ci-cert-manager-release-1.12-trivy-test-cainjector
   max_concurrency: 2
   decorate: true
   annotations:
@@ -1697,7 +1545,7 @@ periodics:
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     testgrid-alert-stale-results-hours: "36"
     testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-release-1.11
+    testgrid-dashboards: cert-manager-periodics-release-1.12
     testgrid-num-failures-to-alert: "1"
   labels:
     preset-dind-enabled: "true"
@@ -1726,9 +1574,9 @@ periodics:
   extra_refs:
   - org: cert-manager
     repo: cert-manager
-    base_ref: release-1.11
+    base_ref: release-1.12
   interval: 24h
-- name: ci-cert-manager-release-1.11-trivy-test-webhook
+- name: ci-cert-manager-release-1.12-trivy-test-webhook
   max_concurrency: 2
   decorate: true
   annotations:
@@ -1736,7 +1584,7 @@ periodics:
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     testgrid-alert-stale-results-hours: "36"
     testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-release-1.11
+    testgrid-dashboards: cert-manager-periodics-release-1.12
     testgrid-num-failures-to-alert: "1"
   labels:
     preset-dind-enabled: "true"
@@ -1765,5 +1613,6 @@ periodics:
   extra_refs:
   - org: cert-manager
     repo: cert-manager
-    base_ref: release-1.11
+    base_ref: release-1.12
   interval: 24h
+

--- a/config/prowgen/prowspecs/specs.go
+++ b/config/prowgen/prowspecs/specs.go
@@ -66,7 +66,25 @@ var knownBranches map[string]BranchSpec = map[string]BranchSpec{
 		},
 
 		primaryKubernetesVersion: "1.26",
-		otherKubernetesVersions:  []string{"1.21", "1.22", "1.23", "1.24", "1.25"},
+		otherKubernetesVersions:  []string{"1.21", "1.22", "1.23", "1.24", "1.25", "1.27"},
+	},
+	"release-1.12": {
+		prowContext: &pkg.ProwContext{
+			Branch: "release-1.12",
+
+			// Use latest image.
+			Image: pkg.CommonTestImage,
+
+			// NB: we don't use a presubmit dashboard outside of "master", currently
+			PresubmitDashboard: false,
+			PeriodicDashboard:  true,
+
+			Org:  "cert-manager",
+			Repo: "cert-manager",
+		},
+
+		primaryKubernetesVersion: "1.27",
+		otherKubernetesVersions:  []string{"1.22", "1.23", "1.24", "1.25", "1.26"},
 	},
 	"master": {
 		prowContext: &pkg.ProwContext{
@@ -82,8 +100,8 @@ var knownBranches map[string]BranchSpec = map[string]BranchSpec{
 			Repo: "cert-manager",
 		},
 
-		primaryKubernetesVersion: "1.26",
-		otherKubernetesVersions:  []string{"1.22", "1.23", "1.24", "1.25"},
+		primaryKubernetesVersion: "1.27",
+		otherKubernetesVersions:  []string{"1.22", "1.23", "1.24", "1.25", "1.26"},
 	},
 }
 

--- a/config/testgrid/dashboards.yaml
+++ b/config/testgrid/dashboards.yaml
@@ -5,6 +5,7 @@ dashboard_groups:
   - cert-manager-periodics-master
   - cert-manager-periodics-release-1.10
   - cert-manager-periodics-release-1.11
+  - cert-manager-periodics-release-1.12
   - cert-manager-presubmits-master
   - jetstack-testing-janitors
 
@@ -13,5 +14,6 @@ dashboards:
 - name: cert-manager-periodics-master
 - name: cert-manager-periodics-release-1.10
 - name: cert-manager-periodics-release-1.11
+- name: cert-manager-periodics-release-1.12
 - name: cert-manager-presubmits-master
 - name: jetstack-testing-janitors


### PR DESCRIPTION
This PR does the work required to add release-1.12 tests and test with kube 1.27:

- adds release-1.12 tests to prowjob codegen
- updates prowjob codegen config for master to test on 1.27 by default
- generates prowjob configs with the two changes listed above
- adds release-1.12 tests as required tests for cherry-picks against release-1.12 branch
- removes a couple out of date things like refs to release-1.9 tests