### PR TITLE
Bumps Go

### DIFF
--- a/config/jobs/cert-manager/approver-policy/cert-manager-approver-policy-presubmits.yaml
+++ b/config/jobs/cert-manager/approver-policy/cert-manager-approver-policy-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
       testgrid-create-test-group: 'false'
     spec:
       containers:
-      - image: golang:1.19
+      - image: golang:1.20
         args:
         - make
         - verify
@@ -26,7 +26,7 @@ presubmits:
       testgrid-create-test-group: 'false'
     spec:
       containers:
-      - image: golang:1.19
+      - image: golang:1.20
         args:
         - make
         - test

--- a/config/jobs/cert-manager/csi-driver/cert-manager-csi-driver-presubmits.yaml
+++ b/config/jobs/cert-manager/csi-driver/cert-manager-csi-driver-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
       testgrid-create-test-group: 'false'
     spec:
       containers:
-      - image: golang:1.18
+      - image: golang:1.20
         args:
         - make
         - verify

--- a/config/jobs/cert-manager/csi-lib/cert-manager-csi-lib-presubmits.yaml
+++ b/config/jobs/cert-manager/csi-lib/cert-manager-csi-lib-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: golang:1.19
+      - image: golang:1.20
         args:
         - ./hack/verify-all.sh
         resources:

--- a/config/jobs/cert-manager/istio-csr/cert-manager-istio-csr-presubmits.yaml
+++ b/config/jobs/cert-manager/istio-csr/cert-manager-istio-csr-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: golang:1.19
+      - image: golang:1.20
         args:
         - make
         - verify

--- a/config/jobs/cert-manager/webhook-example/cert-manager-webhook-example-presubmits.yaml
+++ b/config/jobs/cert-manager/webhook-example/cert-manager-webhook-example-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: golang:1.19-buster
+      - image: golang:1.20-buster
         args:
         - make
         - test


### PR DESCRIPTION
Bumps Go to 1.20 for all images used for tests of projects in cert-manager org.

It appears that kube 1.27 libs require Go 1.20 as a minimum, so we cannot test upgrades with 1.19 images, see i.e https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_webhook-example/50/pull-cert-manager-webhook-example-verify/1655980875042525185