### PR TITLE
Use Recreate as deployment strategy for ghproxy

### DIFF
--- a/prow/cluster/ghproxy.yaml
+++ b/prow/cluster/ghproxy.yaml
@@ -46,6 +46,12 @@ spec:
     matchLabels:
       app: ghproxy
   replicas: 1  # TODO(fejta): this should be HA
+
+  # @inteon: we set the strategy to Recreate, so the volume is
+  # unmounted before the new pod is created
+  strategy:
+    type: Recreate
+
   template:
     metadata:
       labels:


### PR DESCRIPTION
Since the PVC can only be mounted in 1 pod, the rolling update strategy resulted in a second pod that was not able to startup.
The `Recreate` strategy fixes this issue.