### PR TITLE
Use new signoff flag for autobumper

### DIFF
--- a/config/jobs/testing/testing-periodics-trusted.yaml
+++ b/config/jobs/testing/testing-periodics-trusted.yaml
@@ -120,3 +120,4 @@ periodics:
       - generic-autobumper
       args:
       - --config=config/autobump-config/testing-autobump-config.yaml
+      - --signoff

--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -93,10 +93,6 @@ require_matching_label:
   prs: true
   regexp: ^kind/
 
-dco:
-  jetstack:
-    trusted_apps: [ "jetstack-bot" ]
-
 plugins:
 
   jetstack:


### PR DESCRIPTION
The autobumper PRs did not have commits with signoff messages.
Previously, we tried to bypass the dco check for the jetstack-bot, but this did not work.
This PR instead uses the new --signoff flag to signoff all autobump commit messages.