### PR TITLE
Update required status checks to 1.28

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -80,8 +80,8 @@ branch-protection:
                 contexts:
                 - pull-cert-manager-master-chart
                 - pull-cert-manager-master-make-test
-                - pull-cert-manager-master-e2e-v1-27
-                - pull-cert-manager-master-e2e-v1-27-upgrade
+                - pull-cert-manager-master-e2e-v1-28
+                - pull-cert-manager-master-e2e-v1-28-upgrade
         website:
           required_status_checks:
             contexts:


### PR DESCRIPTION
missed this in https://github.com/jetstack/testing/pull/897