### PR TITLE
Disable automatic self-approval for PRs

### DIFF
--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -93,6 +93,10 @@ require_matching_label:
   prs: true
   regexp: ^kind/
 
+approve:
+- repos: ["cert-manager"] # repos can be specified as either org/repo or just org. So "cert-manager/cert-manager" is just the cert-manager repo, and "cert-manager" is "everything under the cert-manager org"
+  require_self_approval: true
+
 plugins:
 
   jetstack:


### PR DESCRIPTION
This was discussed in standup on 29/08/2023. This relates to https://github.com/cert-manager/cert-manager/pull/6260 and our efforts to define different roles within the org.

Since any org member can LGTM, having this enabled means that any approver (today, basically the maintainers) who raises a PR can have their PR merged by anyone else in the org dropping an `/lgtm`.

Instead, we ideally want a _different_ approver to have to approve a PR while encouraging drive-by `/lgtm`s from stakeholders. This still allows approvers to self-approve, which might be appropriate for e.g. fixing typos in READMEs or other trivial tasks, but shouldn't be the default. There doesn't seem to be an obvious way to disable the ability for these auto-approvals.