### PR TITLE
Remove trust-manager labels

### DIFF
--- a/config/labels.yaml
+++ b/config/labels.yaml
@@ -83,19 +83,6 @@ repos:
       target: both
       addedBy: prow
 
-  cert-manager/trust-manager:
-    labels:
-    - color: 0052cc
-      description: Indicates a PR modifies deployment configuration
-      name: area/deploy
-      target: both
-      addedBy: prow
-    - color: 0052cc
-      description: Indicates a PR modifies smoke testing code
-      name: area/testing
-      target: both
-      addedBy: prow
-
   jetstack/testing:
     labels:
     - color: 0052cc


### PR DESCRIPTION
This is an attempt to get the label colours set correctly