### PR TITLE
Drop separate licenses check on master

### DIFF
--- a/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
+++ b/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
@@ -285,40 +285,6 @@ presubmits:
     - master
     always_run: true
     optional: false
-  - name: pull-cert-manager-master-license
-    max_concurrency: 8
-    decorate: true
-    annotations:
-      description: Verifies LICENSES are up to date; only needs to be run if go.mod
-        has changed
-      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-      testgrid-create-job-group: "true"
-      testgrid-dashboards: cert-manager-presubmits-master
-    labels:
-      preset-go-cache: "true"
-      preset-local-cache: "true"
-    spec:
-      containers:
-      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20250327-af35b2b-bookworm
-        args:
-        - runner
-        - make
-        - vendor-go
-        - verify-licenses
-        resources:
-          requests:
-            cpu: "1"
-            memory: 1Gi
-      dnsPolicy: None
-      dnsConfig:
-        nameservers:
-        - 8.8.8.8
-        - 8.8.4.4
-    branches:
-    - master
-    always_run: false
-    optional: true
-    run_if_changed: go.mod
   - name: pull-cert-manager-master-e2e-v1-35-issuers-venafi-tpp
     max_concurrency: 4
     decorate: true

--- a/config/jobs/cert-manager/cert-manager/release-1.19/cert-manager-release-1.19.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.19/cert-manager-release-1.19.yaml
@@ -264,37 +264,6 @@ presubmits:
     - release-1.19
     always_run: true
     optional: false
-  - name: pull-cert-manager-release-1.19-license
-    max_concurrency: 8
-    decorate: true
-    annotations:
-      description: Verifies LICENSES are up to date; only needs to be run if go.mod
-        has changed
-    labels:
-      preset-go-cache: "true"
-      preset-local-cache: "true"
-    spec:
-      containers:
-      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20250327-af35b2b-bookworm
-        args:
-        - runner
-        - make
-        - vendor-go
-        - verify-licenses
-        resources:
-          requests:
-            cpu: "1"
-            memory: 1Gi
-      dnsPolicy: None
-      dnsConfig:
-        nameservers:
-        - 8.8.8.8
-        - 8.8.4.4
-    branches:
-    - release-1.19
-    always_run: false
-    optional: true
-    run_if_changed: go.mod
   - name: pull-cert-manager-release-1.19-e2e-v1-34-issuers-venafi-tpp
     max_concurrency: 4
     decorate: true

--- a/config/prowgen/prowspecs/specs.go
+++ b/config/prowgen/prowspecs/specs.go
@@ -53,6 +53,8 @@ var knownBranches map[string]BranchSpec = map[string]BranchSpec{
 
 		e2eCPURequest:    "7000m",
 		e2eMemoryRequest: "6Gi",
+
+		checkLicensesSeparately: true,
 	},
 	"release-1.19": {
 		prowContext: &pkg.ProwContext{
@@ -113,6 +115,9 @@ type BranchSpec struct {
 
 	// TODO: remove this field once we've migrated to the new set of container names
 	containerNames []string
+
+	// TODO: remove this field once we've migrated fully to the licenses makefile module
+	checkLicensesSeparately bool
 }
 
 // GenerateJobFile will create a complete test file based on the BranchSpec. This
@@ -129,7 +134,9 @@ func (m *BranchSpec) GenerateJobFile() *pkg.JobFile {
 
 	m.prowContext.RequiredPresubmit(pkg.UpgradeTest(m.prowContext, m.primaryKubernetesVersion))
 
-	m.prowContext.OptionalPresubmitIfChanged(pkg.LicenseTest(m.prowContext), `go.mod`)
+	if m.checkLicensesSeparately {
+		m.prowContext.OptionalPresubmitIfChanged(pkg.LicenseTest(m.prowContext), `go.mod`)
+	}
 
 	m.prowContext.OptionalPresubmit(pkg.E2ETestVenafiTPP(m.prowContext, m.primaryKubernetesVersion, m.e2eCPURequest, m.e2eMemoryRequest))
 	m.prowContext.OptionalPresubmit(pkg.E2ETestVenafiCloud(m.prowContext, m.primaryKubernetesVersion, m.e2eCPURequest, m.e2eMemoryRequest))


### PR DESCRIPTION
The licenses check is now included in the `pull-cert-manager-master-make-verify` check.