### PR TITLE
Add support for adding merge method label to PRs

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -219,7 +219,9 @@ presets:
 tide:
   pr_status_base_urls:
     '*': https://prow.infra.cert-manager.io/pr
-  squash_label: tide/squash
+  squash_label: tide/merge-method-squash
+  rebase_label: tide/merge-method-rebase
+  merge_label: tide/merge-method-merge
   queries:
   # Default tide config for all repos in the cert-manager org
   - orgs:

--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -95,6 +95,12 @@ approve:
 owners:
   skip_collaborators: ["cert-manager"] # all repos in the cert-manager org
 
+label:
+  additional_labels:
+    - tide/merge-method-merge
+    - tide/merge-method-rebase
+    - tide/merge-method-squash
+
 plugins:
 
   cert-manager:


### PR DESCRIPTION
I personally prefer single-commit PRs, especially for minor changes. It seems like Tide/Prow supports this, as I have [seen it in use](https://github.com/kubernetes-sigs/controller-runtime/issues?q=state%3Aclosed%20label%3Atide%2Fmerge-method-squash), but it's not enabled in our organization. To avoid asking contributors to rebase and squash their PR, I want to see if the change proposed in this PR can avoid [this error](https://github.com/cert-manager/istio-csr/pull/517#issuecomment-3258321319) and do the right thing.

I've compared our config with https://github.com/kubeedge/community-infra.

And I didn't want to use the "previous" label, ref. https://github.com/cert-manager/testing/blob/5296a458bfc2c344c6009443ee270d50d0e81761/config/labels.yaml#L380-L384