### PR TITLE
Add the 'cybr' label

### DIFF
--- a/config/labels.yaml
+++ b/config/labels.yaml
@@ -414,3 +414,8 @@ default:
     name: tide/squash
     target: pts
     addedBy: humans
+  - color: "006699"
+    description: "Used by CyberArk maintainers to provide line management with visibility into upcoming potential work."
+    name: cybr
+    target: both
+    addedBy: humans


### PR DESCRIPTION
Stop gap solution until we find a better way. For context, adding this label will ask https://github.com/maelvls/gh-to-jira to create a Jira ticket in the cert-manager team's backlog.