### PR TITLE
Disable DCO for Copilot-authored PRs

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -285,3 +285,16 @@ tide:
     - do-not-merge/invalid-owners-file
     - do-not-merge/work-in-progress
     - needs-rebase
+
+  - author: copilot-swe-agent[bot]
+    orgs:
+    - cert-manager
+    labels:
+    - skip-review
+    - "dco-signoff: yes"
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - needs-rebase


### PR DESCRIPTION
Hey,

It is now possible to let Copilot create PRs. It is especially useful for the website: it takes a few seconds to change things.

Only problem is that Copilot will not sign off its commits... and there is no point doing it because we can assume that any code written by an LLM is not a "person" in the legal sense and therefore cannot sign the Developer Certificate of Origin, or take legal responsibility for the contribution.

I'm not sure what that means... But my thinking is: let's not require DCO for AI-generated code.

The reason I'm using "copilot-swe-agent[bot]" as the author to be allowed is because that's the git user used by Copilot's agents to commit, e.g.

```
commit a78f72652ef987f41c7e898efebd241cc27883c7 (origin/copilot/promote-cainjector-merging-to-stable)
Author: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>
Date:   Fri Mar 6 22:22:53 2026 +0000

    cainjector: promote CAInjectorMerging feature gate to GA (v1.21)

    Signed-off-by: cert-manager-bot <bot@cert-manager.io>

    Co-authored-by: ThatsMrTalbot <15379715+ThatsMrTalbot@users.noreply.github.com>

commit 06b8355a9fcfd9fd6c2ec83db7bd23dc889b2e68
Author: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>
Date:   Fri Mar 6 22:17:38 2026 +0000

    Initial plan
```