### PR TITLE
Add Venafi NGTS e2e job and credentials preset

### DIFF
--- a/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
+++ b/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
@@ -371,6 +371,49 @@ presubmits:
     - master
     always_run: false
     optional: true
+  - name: pull-cert-manager-master-e2e-v1-35-issuers-venafi-ngts
+    max_concurrency: 4
+    decorate: true
+    annotations:
+      description: Runs the E2E tests with 'Venafi NGTS' in name
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-job-group: "true"
+      testgrid-dashboards: cert-manager-presubmits-master
+    labels:
+      preset-dind-enabled: "true"
+      preset-ginkgo-focus-venafi-ngts: "true"
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+      preset-retry-flakey-jobs: "true"
+      preset-venafi-ngts-credentials: "true"
+    spec:
+      containers:
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20260120-8648794-trixie
+        args:
+        - runner
+        - make
+        - -j7
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.35
+        resources:
+          requests:
+            cpu: 7000m
+            memory: 6Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+      dnsPolicy: None
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+        - 8.8.4.4
+    branches:
+    - master
+    always_run: false
+    optional: true
   - name: pull-cert-manager-master-e2e-v1-35-feature-gates-disabled
     max_concurrency: 4
     decorate: true

--- a/config/jobs/cert-manager/cert-manager/release-1.19/cert-manager-release-1.19.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.19/cert-manager-release-1.19.yaml
@@ -385,6 +385,46 @@ presubmits:
     - release-1.19
     always_run: false
     optional: true
+  - name: pull-cert-manager-release-1.19-e2e-v1-34-issuers-venafi-ngts
+    max_concurrency: 4
+    decorate: true
+    annotations:
+      description: Runs the E2E tests with 'Venafi NGTS' in name
+    labels:
+      preset-dind-enabled: "true"
+      preset-ginkgo-focus-venafi-ngts: "true"
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+      preset-retry-flakey-jobs: "true"
+      preset-venafi-ngts-credentials: "true"
+    spec:
+      containers:
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20260120-8648794-trixie
+        args:
+        - runner
+        - make
+        - -j7
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.34
+        resources:
+          requests:
+            cpu: 7000m
+            memory: 6Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+      dnsPolicy: None
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+        - 8.8.4.4
+    branches:
+    - release-1.19
+    always_run: false
+    optional: true
   - name: pull-cert-manager-release-1.19-e2e-v1-34-feature-gates-disabled
     max_concurrency: 4
     decorate: true

--- a/config/jobs/cert-manager/cert-manager/release-1.20/cert-manager-release-1.20.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.20/cert-manager-release-1.20.yaml
@@ -344,6 +344,46 @@ presubmits:
     - release-1.20
     always_run: false
     optional: true
+  - name: pull-cert-manager-release-1.20-e2e-v1-35-issuers-venafi-ngts
+    max_concurrency: 4
+    decorate: true
+    annotations:
+      description: Runs the E2E tests with 'Venafi NGTS' in name
+    labels:
+      preset-dind-enabled: "true"
+      preset-ginkgo-focus-venafi-ngts: "true"
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+      preset-retry-flakey-jobs: "true"
+      preset-venafi-ngts-credentials: "true"
+    spec:
+      containers:
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20260120-8648794-trixie
+        args:
+        - runner
+        - make
+        - -j7
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.35
+        resources:
+          requests:
+            cpu: 7000m
+            memory: 6Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+      dnsPolicy: None
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+        - 8.8.4.4
+    branches:
+    - release-1.20
+    always_run: false
+    optional: true
   - name: pull-cert-manager-release-1.20-e2e-v1-35-feature-gates-disabled
     max_concurrency: 4
     decorate: true

--- a/config/jobs/cert-manager/config.yaml
+++ b/config/jobs/cert-manager/config.yaml
@@ -64,6 +64,35 @@ presets:
         key: apitoken
 
 - labels:
+    preset-venafi-ngts-credentials: "true"
+  env:
+  - name: VENAFI_NGTS_ZONE
+    valueFrom:
+      secretKeyRef:
+        name: venafi-ngts
+        key: zone
+  - name: VENAFI_NGTS_TOKEN_ENDPOINT
+    valueFrom:
+      secretKeyRef:
+        name: venafi-ngts
+        key: token-endpoint
+  - name: VENAFI_NGTS_TSG_ID
+    valueFrom:
+      secretKeyRef:
+        name: venafi-ngts
+        key: tsg-id
+  - name: VENAFI_NGTS_CLIENT_ID
+    valueFrom:
+      secretKeyRef:
+        name: venafi-ngts
+        key: client-id
+  - name: VENAFI_NGTS_CLIENT_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: venafi-ngts
+        key: client-secret
+
+- labels:
     preset-retry-flakey-tests: "true"
   env:
   - name: FLAKE_ATTEMPTS
@@ -135,6 +164,12 @@ presets:
   env:
   - name: GINKGO_FOCUS
     value: "Venafi Cloud"
+
+- labels:
+    preset-ginkgo-focus-venafi-ngts: "true"
+  env:
+  - name: GINKGO_FOCUS
+    value: "Venafi NGTS"
 
 # This preset adds common configuration for all trivy jobs
 #

--- a/config/prowgen/pkg/configurers.go
+++ b/config/prowgen/pkg/configurers.go
@@ -101,6 +101,11 @@ func addVenafiCloudLabels(job *Job) {
 	job.Labels["preset-venafi-cloud-credentials"] = "true"
 }
 
+func addVenafiNGTSLabels(job *Job) {
+	job.Labels["preset-ginkgo-focus-venafi-ngts"] = "true"
+	job.Labels["preset-venafi-ngts-credentials"] = "true"
+}
+
 func addBestPracticeInstallLabel(job *Job) {
 	job.Labels["preset-bestpractice-install"] = "true"
 }

--- a/config/prowgen/pkg/generators.go
+++ b/config/prowgen/pkg/generators.go
@@ -216,6 +216,25 @@ func E2ETestVenafiCloud(ctx *ProwContext, k8sVersion string, cpuRequest, memoryR
 	return job
 }
 
+// E2ETestVenafiNGTS generates a test which runs end-to-end tests only focusing on Venafi NGTS.
+// This runs inside a container and so requires additional permissions.
+func E2ETestVenafiNGTS(ctx *ProwContext, k8sVersion string, cpuRequest, memoryRequest string) *Job {
+	job := E2ETest(ctx, k8sVersion, cpuRequest, memoryRequest)
+
+	job.Name = job.Name + "-issuers-venafi-ngts"
+	job.Annotations["description"] = "Runs the E2E tests with 'Venafi NGTS' in name"
+
+	job.Labels = make(map[string]string)
+
+	addDindLabel(job)
+	addLocalCacheLabel(job)
+	addGoCacheLabel(job)
+	addRetryFlakesLabel(job)
+	addVenafiNGTSLabels(job)
+
+	return job
+}
+
 // E2ETestVenafiBoth generates a test which runs end-to-end tests focusing on
 // both Venafi TPP and Venafi Cloud.
 // This runs inside a container and so requires additional permissions.

--- a/config/prowgen/prowspecs/specs.go
+++ b/config/prowgen/prowspecs/specs.go
@@ -138,6 +138,7 @@ func (m *BranchSpec) GenerateJobFile() *pkg.JobFile {
 
 	m.prowContext.OptionalPresubmit(pkg.E2ETestVenafiTPP(m.prowContext, m.primaryKubernetesVersion, m.e2eCPURequest, m.e2eMemoryRequest))
 	m.prowContext.OptionalPresubmit(pkg.E2ETestVenafiCloud(m.prowContext, m.primaryKubernetesVersion, m.e2eCPURequest, m.e2eMemoryRequest))
+	m.prowContext.OptionalPresubmit(pkg.E2ETestVenafiNGTS(m.prowContext, m.primaryKubernetesVersion, m.e2eCPURequest, m.e2eMemoryRequest))
 	m.prowContext.OptionalPresubmit(pkg.E2ETestFeatureGatesDisabled(m.prowContext, m.primaryKubernetesVersion, m.e2eCPURequest, m.e2eMemoryRequest))
 	m.prowContext.OptionalPresubmit(pkg.E2ETestWithBestPracticeInstall(m.prowContext, m.primaryKubernetesVersion, m.e2eCPURequest, m.e2eMemoryRequest))
 


### PR DESCRIPTION
cert-manager/cert-manager has added support for a new Venafi issuer backend called **NGTS** (Palo Alto Networks Next Generation Trust Services), which uses OAuth 2.0 Client Credentials. The e2e tests are already written and merged in cert-manager (`test/e2e/suite/issuers/venafi/ngts/` and `test/e2e/suite/conformance/certificates/venafingts/`) and skip automatically when the required env vars are absent.

This PR wires up the Prow configuration so the tests can be triggered and run.