### PR TITLE
GCS workload identity

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -19,7 +19,8 @@ plank:
       gcs_configuration:
         bucket: cert-manager-prow-artifacts
         path_strategy: explicit
-      gcs_credentials_secret: gcs-credentials
+      gcs_credentials_secret: "" # Use workload identity for uploading artifacts
+      default_service_account_name: prowjob-default
       resources:
         clonerefs:
           requests:

--- a/prow/Makefile
+++ b/prow/Makefile
@@ -31,6 +31,7 @@ KUBECTL_UNTRUSTED := kubectl --context=$(UNTRUSTED_CTX)
 help:
 	@echo "Main targets:"
 	@echo "  get-kubeconfig       - fetch kubeconfig for both clusters"
+	@echo "  create-cookie-secret - create cookie secret with random data"
 	@echo "  verify               - verify required secrets and resources exist"
 	@echo "  diff                 - diff all resources"
 	@echo "  deploy               - verify, deploy all, and restart deployments"
@@ -39,8 +40,13 @@ help:
 .PHONY: get-kubeconfig
 get-kubeconfig:
 	@echo "Fetching kubeconfig..."
-	@gcloud container clusters get-credentials $(TRUSTED_CLUSTER) --zone=$(ZONE) --project=$(TRUSTED_PROJECT)
 	@gcloud container clusters get-credentials $(UNTRUSTED_CLUSTER) --zone=$(ZONE) --project=$(UNTRUSTED_PROJECT)
+	@gcloud container clusters get-credentials $(TRUSTED_CLUSTER) --zone=$(ZONE) --project=$(TRUSTED_PROJECT)
+
+.PHONY: create-cookie-secret
+create-cookie-secret:
+	@echo "Creating cookie secret..."
+	@$(KUBECTL_TRUSTED) create secret generic cookie --from-literal=secret=$$(openssl rand -base64 32) --dry-run=client -o yaml | $(KUBECTL_TRUSTED) apply -f -
 
 .PHONY: bootstrap-config
 bootstrap-config:
@@ -56,20 +62,22 @@ verify:
 	@$(KUBECTL_TRUSTED) get ns default >/dev/null || (echo "ERROR: Cannot connect to trusted cluster" && exit 1)
 	@$(KUBECTL_UNTRUSTED) get ns default >/dev/null || (echo "ERROR: Cannot connect to untrusted cluster" && exit 1)
 	
-	@for secret in gcs-credentials cert-manager-bot-github-token hmac-token github-app-token; do \
+	@for secret in cert-manager-bot-github-token hmac-token github-app-token github-oauth-config; do \
 		$(KUBECTL_TRUSTED) get secret $$secret -n default >/dev/null || (echo "ERROR: $$secret not found" && exit 1); \
 	done
 	@for cm in config plugins job-config; do \
 		$(KUBECTL_TRUSTED) get cm $$cm -n default >/dev/null || (echo "ERROR: $$cm configmap not found" && exit 1); \
 	done
-	@if $(KUBECTL_TRUSTED) get ns test-pods >/dev/null 2>&1; then \
-		for secret in cloudflare-api-key:DNS01 venafi-tpp:TPP venafi-cloud:Cloud venafi-ngts:NGTS \
-			cert-manager-bot-ssh-keys cert-manager-bot-gcp-service-account; do \
-			name=$${secret%%:*}; desc=$${secret#*:}; \
-			$(KUBECTL_TRUSTED) get secret $$name -n test-pods >/dev/null 2>&1 || \
-				echo "WARNING: $$name not found ($$desc tests)"; \
-		done; \
-	fi
+	@for secret in cert-manager-bot-ssh-keys cert-manager-bot-gcp-service-account cert-manager-bot-github-token github-app-token; do \
+		$(KUBECTL_TRUSTED) get secret $$secret -n test-pods >/dev/null 2>&1 || \
+			echo "WARNING: $$secret not found"; \
+	done
+
+	@for secret in cloudflare-api-key venafi-tpp venafi-cloud venafi-ngts; do \
+		$(KUBECTL_UNTRUSTED) get secret $$secret -n test-pods >/dev/null 2>&1 || \
+			echo "WARNING: $$secret not found"; \
+	done
+	
 	@echo "✓ Prerequisites verified"
 
 .PHONY: diff
@@ -81,12 +89,11 @@ diff-prow:
 
 .PHONY: diff-test-pods
 diff-test-pods:
-	@$(KUBECTL_TRUSTED) diff -f ./test-pods/test-pods-resources.yaml 2>/dev/null || true
-	@$(KUBECTL_UNTRUSTED) diff -f ./test-pods/test-pods-resources.yaml 2>/dev/null || true
+	@$(KUBECTL_TRUSTED) diff -f ./test-pods/ 2>/dev/null || true
+	@$(KUBECTL_UNTRUSTED) diff -f ./test-pods/ 2>/dev/null || true
 
-.PHONY: diff-trusted-cluster
-diff-trusted-cluster:
-	@$(KUBECTL_TRUSTED) diff -f ./trusted_cluster/ 2>/dev/null || true
+	@$(KUBECTL_TRUSTED) diff -f ./test-pods/trusted_cluster/ 2>/dev/null || true
+	@$(KUBECTL_UNTRUSTED) diff -f ./test-pods/untrusted_cluster/ 2>/dev/null || true
 
 .PHONY: deploy
 deploy: verify deploy-prow deploy-test-pods deploy-trusted-cluster restart-deployments
@@ -100,13 +107,11 @@ deploy-prow:
 .PHONY: deploy-test-pods
 deploy-test-pods:
 	@echo "Deploying test-pods RBAC..."
-	@$(KUBECTL_TRUSTED) apply --server-side -f ./test-pods/test-pods-resources.yaml
-	@$(KUBECTL_UNTRUSTED) apply --server-side -f ./test-pods/test-pods-resources.yaml
+	@$(KUBECTL_TRUSTED) apply --server-side -f ./test-pods/
+	@$(KUBECTL_UNTRUSTED) apply --server-side -f ./test-pods/
 
-.PHONY: deploy-trusted-cluster
-deploy-trusted-cluster:
-	@echo "Deploying trusted_cluster resources..."
-	@$(KUBECTL_TRUSTED) apply --server-side -f ./trusted_cluster/
+	@$(KUBECTL_TRUSTED) apply --server-side -f ./test-pods/trusted_cluster/
+	@$(KUBECTL_UNTRUSTED) apply --server-side -f ./test-pods/untrusted_cluster/
 
 .PHONY: restart-deployments
 restart-deployments:

--- a/prow/cluster/crier_deployment.yaml
+++ b/prow/cluster/crier_deployment.yaml
@@ -44,7 +44,6 @@ spec:
         - --github-workers=10
         - --job-config-path=/etc/job-config
         - --kubernetes-blob-storage-workers=10
-        - --gcs-credentials-file=/etc/gcs-credentials/service-account.json
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
@@ -73,9 +72,6 @@ spec:
         - name: github-app-token
           mountPath: /etc/github
           readOnly: true
-        - name: gcs-credentials
-          mountPath: /etc/gcs-credentials
-          readOnly: true
       volumes:
       - name: config
         configMap:
@@ -86,9 +82,6 @@ spec:
       - name: github-app-token
         secret:
           secretName: github-app-token
-      - name: gcs-credentials
-        secret:
-          secretName: gcs-credentials
       - name: kubeconfig-prow-trusted
         configMap:
           defaultMode: 420

--- a/prow/test-pods/00_namespace.yaml
+++ b/prow/test-pods/00_namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-pods

--- a/prow/test-pods/01_control_plane_rbac.yaml
+++ b/prow/test-pods/01_control_plane_rbac.yaml
@@ -1,9 +1,3 @@
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: test-pods
----
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/prow/test-pods/trusted_cluster/02_prowjob_sa.yaml
+++ b/prow/test-pods/trusted_cluster/02_prowjob_sa.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: prowjob-default@cert-manager-tests-trusted.iam.gserviceaccount.com
+  name: prowjob-default
+  namespace: test-pods
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: testgrid-updater@cert-manager-tests-trusted.iam.gserviceaccount.com
+  name: testgrid-updater
+  namespace: test-pods

--- a/prow/test-pods/untrusted_cluster/02_prowjob_sa.yaml
+++ b/prow/test-pods/untrusted_cluster/02_prowjob_sa.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: prowjob-default@cert-manager-tests-untrusted.iam.gserviceaccount.com
+  name: prowjob-default
+  namespace: test-pods

--- a/prow/trusted_cluster/testgrid-updater-sa.yaml
+++ b/prow/trusted_cluster/testgrid-updater-sa.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  labels:
-    app.kubernetes.io/part-of: prow
-  annotations:
-    iam.gke.io/gcp-service-account: testgrid-updater@cert-manager-tests-trusted.iam.gserviceaccount.com
-  name: testgrid-updater
-  namespace: test-pods


### PR DESCRIPTION
Uses https://github.com/cert-manager/infrastructure/pull/80

Updates the prowjobs and crier to use workload identity to access GCS.