### PR TITLE
Add missing crier cluster RBAC

### DIFF
--- a/prow/test-pods/01_control_plane_rbac.yaml
+++ b/prow/test-pods/01_control_plane_rbac.yaml
@@ -118,3 +118,27 @@ roleRef:
 subjects:
   - kind: User
     name: prow-crier@cert-manager-tests-trusted.iam.gserviceaccount.com
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: crier
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "nodes"
+    verbs:
+      - "get"
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: crier
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: crier
+subjects:
+  - kind: User
+    name: prow-crier@cert-manager-tests-trusted.iam.gserviceaccount.com


### PR DESCRIPTION
The crier app nees some cluster RBAC. This PR adds the required RBAC.