### PR TITLE
Start using image-builder service account

### DIFF
--- a/config/jobs/testing/testing-postsubmits-trusted.yaml
+++ b/config/jobs/testing/testing-postsubmits-trusted.yaml
@@ -56,6 +56,7 @@ postsubmits:
       testgrid-disable-prowjob-analysis: "true"
       description: Build and push the 'make-dind' image
     spec:
+      serviceAccountName: image-builder
       containers:
       - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/image-builder:20250327-d147921-gcloud-516
         args:
@@ -91,6 +92,7 @@ postsubmits:
       testgrid-disable-prowjob-analysis: "true"
       description: Build and push the 'golang-dind' image
     spec:
+      serviceAccountName: image-builder
       containers:
       - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/image-builder:20250327-d147921-gcloud-516
         args:
@@ -126,6 +128,7 @@ postsubmits:
       testgrid-disable-prowjob-analysis: "true"
       description: Build and push the 'image-builder' image
     spec:
+      serviceAccountName: image-builder
       containers:
       - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/image-builder:20250327-d147921-gcloud-516
         args:
@@ -151,8 +154,6 @@ postsubmits:
     decorate: true
     labels:
       preset-dind-enabled: "true"
-      # Mount GCP SA creds and export GOOGLE_APPLICATION_CREDENTIALS env var
-      # pointing to the creds file.
       preset-deployer-service-account: "true"
     annotations:
       testgrid-create-test-group: 'true'
@@ -161,6 +162,7 @@ postsubmits:
       testgrid-disable-prowjob-analysis: "true"
       description: Build and push the 'kind' image
     spec:
+      serviceAccountName: image-builder
       containers:
       - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/golang-dind:20260120-31ee990-1.25
         args:
@@ -193,6 +195,7 @@ postsubmits:
       testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
       description: Build and push the 'golang-aws' image
     spec:
+      serviceAccountName: image-builder
       containers:
       - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/image-builder:20250327-d147921-gcloud-516
         args:
@@ -228,6 +231,7 @@ postsubmits:
       testgrid-disable-prowjob-analysis: "true"
       description: Build and push the 'nix-dind' image
     spec:
+      serviceAccountName: image-builder
       containers:
       - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/image-builder:20250327-d147921-gcloud-516
         args:

--- a/images/image-builder-script/builder.sh
+++ b/images/image-builder-script/builder.sh
@@ -28,17 +28,8 @@ if [ -z "${BUILD_DIR}" ]; then
 fi
 shift
 
-if [ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]; then
-    echo "GOOGLE_APPLICATION_CREDENTIALS set, using service account"
-
-    echo "Activating service account..."
-    gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
-
-    echo "Generating docker credentials..."
-    gcloud auth configure-docker europe-west1-docker.pkg.dev --quiet
-else
-    echo "WARNING: GOOGLE_APPLICATION_CREDENTIALS not set"
-fi
+echo "Generating docker credentials..."
+gcloud auth configure-docker europe-west1-docker.pkg.dev --quiet
 
 echo "Executing builder..."
 PUSHED_IMAGE=$(cd "$SCRIPT_DIR" && \

--- a/images/kind/build.sh
+++ b/images/kind/build.sh
@@ -43,9 +43,6 @@ echo "Building $image_tag..."
 kind build node-image \
 	--image ${image_tag}
 
-echo "Activating service account..."
-gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
-
 echo "Generating docker credentials..."
 gcloud auth configure-docker europe-west1-docker.pkg.dev --quiet
 

--- a/prow/Makefile
+++ b/prow/Makefile
@@ -68,7 +68,7 @@ verify:
 	@for cm in config plugins job-config; do \
 		$(KUBECTL_TRUSTED) get cm $$cm -n default >/dev/null || (echo "ERROR: $$cm configmap not found" && exit 1); \
 	done
-	@for secret in cert-manager-bot-ssh-keys cert-manager-bot-gcp-service-account cert-manager-bot-github-token github-app-token; do \
+	@for secret in cert-manager-bot-ssh-keys cert-manager-bot-github-token github-app-token; do \
 		$(KUBECTL_TRUSTED) get secret $$secret -n test-pods >/dev/null 2>&1 || \
 			echo "WARNING: $$secret not found"; \
 	done

--- a/prow/test-pods/trusted_cluster/02_prowjob_sa.yaml
+++ b/prow/test-pods/trusted_cluster/02_prowjob_sa.yaml
@@ -13,3 +13,11 @@ metadata:
     iam.gke.io/gcp-service-account: testgrid-updater@cert-manager-tests-trusted.iam.gserviceaccount.com
   name: testgrid-updater
   namespace: test-pods
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: image-builder@cert-manager-tests-trusted.iam.gserviceaccount.com
+  name: image-builder
+  namespace: test-pods


### PR DESCRIPTION
Add `image-builder` SA that we can use to push images to artifact registry.

Will need another PR to cleanup the old deployer-service-account secret.