### PR TITLE
Switch image builder to workload identity (part 2)

### DIFF
--- a/config/jobs/testing/testing-postsubmits-trusted.yaml
+++ b/config/jobs/testing/testing-postsubmits-trusted.yaml
@@ -46,7 +46,6 @@ postsubmits:
     decorate: true
     labels:
       preset-dind-enabled: "true"
-      preset-deployer-service-account: "true"
       preset-deployer-github-token: "true"
       preset-deployer-ssh-key: "true"
     annotations:
@@ -82,7 +81,6 @@ postsubmits:
     decorate: true
     labels:
       preset-dind-enabled: "true"
-      preset-deployer-service-account: "true"
       preset-deployer-github-token: "true"
       preset-deployer-ssh-key: "true"
     annotations:
@@ -118,7 +116,6 @@ postsubmits:
     decorate: true
     labels:
       preset-dind-enabled: "true"
-      preset-deployer-service-account: "true"
       preset-deployer-github-token: "true"
       preset-deployer-ssh-key: "true"
     annotations:
@@ -154,7 +151,6 @@ postsubmits:
     decorate: true
     labels:
       preset-dind-enabled: "true"
-      preset-deployer-service-account: "true"
     annotations:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: cert-manager-testing-janitors
@@ -186,7 +182,6 @@ postsubmits:
     decorate: true
     labels:
       preset-dind-enabled: "true"
-      preset-deployer-service-account: "true"
       preset-deployer-github-token: "true"
       preset-deployer-ssh-key: "true"
     annotations:
@@ -221,7 +216,6 @@ postsubmits:
     decorate: true
     labels:
       preset-dind-enabled: "true"
-      preset-deployer-service-account: "true"
       preset-deployer-github-token: "true"
       preset-deployer-ssh-key: "true"
     annotations:

--- a/config/jobs/testing/testing-presets-trusted.yaml
+++ b/config/jobs/testing/testing-presets-trusted.yaml
@@ -32,17 +32,3 @@ presets:
     secret:
       secretName: cert-manager-bot-ssh-keys
       defaultMode: 0400
-
-- labels:
-    preset-deployer-service-account: "true"
-  env:
-  - name: GOOGLE_APPLICATION_CREDENTIALS
-    value: /creds/service-account.json
-  volumeMounts:
-  - name: creds
-    mountPath: /creds
-    readOnly: true
-  volumes:
-  - name: creds
-    secret:
-      secretName: cert-manager-bot-gcp-service-account


### PR DESCRIPTION
With https://github.com/cert-manager/testing/pull/1188 merged and working, we can now remove the old secret and preset.