### PR TITLE
Fix builder image

### DIFF
--- a/images/image-builder/Dockerfile
+++ b/images/image-builder/Dockerfile
@@ -22,11 +22,11 @@ ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
 ENV PATH "$PATH:/opt/google-cloud-sdk/bin/"
 
 # Install google-cloud-cli
-RUN echo "deb http://packages.cloud.google.com/apt cloud-sdk-$(lsb_release -c -s) main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends \
-        google-cloud-cli=${CLOUD_SDK_VERSION}-0 && \
-    apt-get clean
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | \
+        tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+        curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
+        gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
+        apt-get update -y && \
+        apt-get install google-cloud-cli -y
 
 WORKDIR /workspace

--- a/images/image-builder/build.yaml
+++ b/images/image-builder/build.yaml
@@ -1,10 +1,10 @@
 name: image-builder # Name of the image to be built
 
 variants:
-  gcloud-516:
+  gcloud-569:
     arguments:
       BASE_IMAGE: "europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/golang-dind:20260526-40c7e99-1.26"
-      CLOUD_SDK_VERSION: "516.0.0"
+      CLOUD_SDK_VERSION: "569.0.0"
 
 # Image names to be tagged and pushed
 images:


### PR DESCRIPTION
Fixes error when building the builder image:
```
process "/bin/sh -c echo \"deb http://packages.cloud.google.com/apt  
  cloud-sdk-$(lsb_release -c -s) main\" > /etc/apt/sources.list.d/google-cloud-sdk.list &&     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg |   
  apt-key add - &&     apt-get update &&     apt-get install -y --no-install-recommends         google-cloud-cli=${CLOUD_SDK_VERSION}-0 &&     apt-get clean" 
   did not complete successfully: exit code: 127
```