### PR TITLE
Bump tested Istio version

### DIFF
--- a/config/jobs/cert-manager/istio-csr/cert-manager-istio-csr-presubmits.yaml
+++ b/config/jobs/cert-manager/istio-csr/cert-manager-istio-csr-presubmits.yaml
@@ -136,38 +136,6 @@ presubmits:
         - 8.8.8.8
         - 8.8.4.4
 
-  - name: pull-cert-manager-istio-csr-istio-v1-27
-    decorate: true
-    always_run: true
-    labels:
-      preset-go-cache: "true"
-      preset-local-cache: "true"
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20260527-d8a883d-trixie
-        args:
-        - runner
-        - make
-        - vendor-go
-        - test-e2e
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 6Gi
-        env:
-          - name: ISTIO_VERSION
-            value: "1.27.7"
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsPolicy: None
-      dnsConfig:
-        nameservers:
-        - 8.8.8.8
-        - 8.8.4.4
-
   - name: pull-cert-manager-istio-csr-istio-v1-28
     decorate: true
     always_run: true
@@ -189,7 +157,7 @@ presubmits:
             memory: 6Gi
         env:
           - name: ISTIO_VERSION
-            value: "1.28.4"
+            value: "1.28.7"
         securityContext:
           privileged: true
           capabilities:
@@ -221,7 +189,39 @@ presubmits:
             memory: 6Gi
         env:
           - name: ISTIO_VERSION
-            value: "1.29.0"
+            value: "1.29.3"
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+      dnsPolicy: None
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+        - 8.8.4.4
+
+  - name: pull-cert-manager-istio-csr-istio-v1-30
+    decorate: true
+    always_run: true
+    labels:
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20260527-d8a883d-trixie
+        args:
+        - runner
+        - make
+        - vendor-go
+        - test-e2e
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 6Gi
+        env:
+          - name: ISTIO_VERSION
+            value: "1.30.0"
         securityContext:
           privileged: true
           capabilities:


### PR DESCRIPTION
With reference to https://istio.io/latest/docs/releases/supported-releases/#support-status-of-istio-releases, I propose to remove testing of 1.27, add 1.30, and patch 1.28 and 1.29.