### PR TITLE
Kill processes that are left over

### DIFF
--- a/images/make-dind/runner
+++ b/images/make-dind/runner
@@ -221,7 +221,37 @@ trap 'kill -s TERM "$WRAPPED_COMMAND_PID" || true' TERM
 wait $WRAPPED_COMMAND_PID
 EXIT_VALUE=$?
 
-kill "$WATCHDOG_PID" 2>/dev/null || true
+# Reap any survivors from the wrapped command's and watchdog's process
+# groups. Both groups inherited this script's stdout/stderr, so a leftover
+# process (e.g. an envtest-spawned kube-apiserver, or the watchdog's
+# in-flight `sleep`) keeps the pipe open after this script exits, and
+# Prow's Wait() then blocks on the never-closing pipe until the 2h
+# timeout fires (manifesting as "Process did not finish before 2h0m0s
+# timeout" / "os: process already finished" in the entrypoint logs).
+# Signalling only the group leader (`kill $PID`) is not enough: the
+# leader may already be gone while children survive, and a `sleep` child
+# of the watchdog subshell doesn't receive a signal sent to the bash
+# subshell alone. `set -m` puts each backgrounded job in its own process
+# group, so `kill -- -PGID` reaches every descendant.
+#
+# Dump the process subtree rooted in the wrapped command's process group
+# so the CI log identifies what was leaked and how it was nested. mawk's
+# presence here means it hasn't seen EOF — i.e. some descendant of the
+# wrapped command (e.g. envtest's kube-apiserver/etcd) still holds the
+# FIFO write end. The watchdog's group is excluded: its `sleep` is
+# expected to be mid-sleep, not a leak.
+survivors=$(ps --no-headers --forest -eo pid,pgid,etime,args | \
+    awk -v w="$WRAPPED_COMMAND_PID" '$2 == w')
+if [[ -n "$survivors" ]]; then
+    echo "" >&2
+    echo "########################################################################################" >&2
+    echo "### Reap: test did not cleanly exit all processes in its process group (pgid=$WRAPPED_COMMAND_PID), will kill them" >&2
+    echo "### Columns: PID PGID ELAPSED COMMAND" >&2
+    echo "$survivors" >&2
+    echo "########################################################################################" >&2
+    echo "" >&2
+fi
+kill -KILL -- -"$WRAPPED_COMMAND_PID" -"$WATCHDOG_PID" 2>/dev/null || true
 wait "$WATCHDOG_PID" 2>/dev/null || true
 rm -f "$ACTIVITY_FILE"
 

--- a/images/make-dind/runner_test.sh
+++ b/images/make-dind/runner_test.sh
@@ -188,6 +188,41 @@ assert_signal_reaches_wrapped() {
     fi
 }
 
+# Verifies the runner's stdout closes promptly after the wrapped command
+# exits, even if a leaked descendant inherited the stdout pipe. Mirrors
+# what Prow sees on its end of the runner's stdout: prow's `Wait()` blocks
+# until every writer to the pipe is gone, so a leaked process (envtest's
+# kube-apiserver, the watchdog's in-flight `sleep`, etc.) would keep the
+# pipe open until Prow's 2h timeout fires. The pipeline-reader exits as
+# soon as it sees EOF, so a fast exit here proves the runner reaped all
+# writers before returning.
+test_pipe_closes_after_leaked_grandchild() {
+    local start elapsed
+    start=$(date +%s)
+
+    (
+        run_runner bash -c '
+            # nohup detaches from the controlling terminal; the spawned sleep
+            # inherits the wrapped command'\''s stdout/stderr, which is the
+            # mawk FIFO. Without the process-group reap, this sleep would
+            # outlive the runner and hold the pipe open.
+            nohup sleep 60 >&1 2>&1 &
+            echo "leaked grandchild pid=$!"
+        '
+    ) | (
+        while IFS= read -r _; do :; done
+    )
+
+    elapsed=$(( $(date +%s) - start ))
+    if (( elapsed < 10 )); then
+        pass "stdout pipe closes promptly after leaked grandchild (${elapsed}s)"
+    else
+        fail "stdout pipe still open ${elapsed}s after runner exit — a writer leaked"
+    fi
+
+    pkill -KILL -f "^sleep 60" 2>/dev/null || true
+}
+
 # Verifies the watchdog actually fires: it dumps the process tree to stderr
 # after $WATCHDOG_STALL_SECONDS of no output from the wrapped command. We
 # shrink the threshold to 2s and run a silent 5s sleep so the watchdog has
@@ -216,6 +251,7 @@ test_log_ordering
 test_output_is_streamed
 assert_signal_reaches_wrapped TERM
 assert_signal_reaches_wrapped INT
+test_pipe_closes_after_leaked_grandchild
 test_watchdog_fires_on_stall
 
 echo ""


### PR DESCRIPTION
If any commands are still running in the WRAPPED_COMMAND_PID process group, print them and kill them after.