### PR TITLE
Add NGTS credentials to periodic Venafi E2E job

### DIFF
--- a/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
+++ b/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
@@ -723,7 +723,7 @@ periodics:
   max_concurrency: 4
   decorate: true
   annotations:
-    description: Runs Venafi (VaaS and TPP) e2e tests
+    description: Runs Venafi (VaaS, TPP, and NGTS) e2e tests
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     testgrid-create-job-group: "true"
     testgrid-dashboards: cert-manager-periodics-master
@@ -734,6 +734,7 @@ periodics:
     preset-local-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-venafi-cloud-credentials: "true"
+    preset-venafi-ngts-credentials: "true"
     preset-venafi-tpp-credentials: "true"
   spec:
     containers:

--- a/config/jobs/cert-manager/cert-manager/release-1.19/cert-manager-release-1.19.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.19/cert-manager-release-1.19.yaml
@@ -773,7 +773,7 @@ periodics:
   max_concurrency: 4
   decorate: true
   annotations:
-    description: Runs Venafi (VaaS and TPP) e2e tests
+    description: Runs Venafi (VaaS, TPP, and NGTS) e2e tests
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     testgrid-create-job-group: "true"
     testgrid-dashboards: cert-manager-periodics-release-1.19
@@ -784,6 +784,7 @@ periodics:
     preset-local-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-venafi-cloud-credentials: "true"
+    preset-venafi-ngts-credentials: "true"
     preset-venafi-tpp-credentials: "true"
   spec:
     containers:

--- a/config/jobs/cert-manager/cert-manager/release-1.20/cert-manager-release-1.20.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.20/cert-manager-release-1.20.yaml
@@ -687,7 +687,7 @@ periodics:
   max_concurrency: 4
   decorate: true
   annotations:
-    description: Runs Venafi (VaaS and TPP) e2e tests
+    description: Runs Venafi (VaaS, TPP, and NGTS) e2e tests
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     testgrid-create-job-group: "true"
     testgrid-dashboards: cert-manager-periodics-release-1.20
@@ -698,6 +698,7 @@ periodics:
     preset-local-cache: "true"
     preset-retry-flakey-jobs: "true"
     preset-venafi-cloud-credentials: "true"
+    preset-venafi-ngts-credentials: "true"
     preset-venafi-tpp-credentials: "true"
   spec:
     containers:

--- a/config/prowgen/pkg/configurers.go
+++ b/config/prowgen/pkg/configurers.go
@@ -93,6 +93,7 @@ func addVenafiBothLabels(job *Job) {
 	job.Labels["preset-ginkgo-focus-venafi"] = "true"
 
 	job.Labels["preset-venafi-cloud-credentials"] = "true"
+	job.Labels["preset-venafi-ngts-credentials"] = "true"
 	job.Labels["preset-venafi-tpp-credentials"] = "true"
 }
 

--- a/config/prowgen/pkg/generators.go
+++ b/config/prowgen/pkg/generators.go
@@ -242,7 +242,7 @@ func E2ETestVenafiBoth(ctx *ProwContext, k8sVersion string, cpuRequest, memoryRe
 	job := E2ETest(ctx, k8sVersion, cpuRequest, memoryRequest)
 
 	job.Name = job.Name + "-issuers-venafi"
-	job.Annotations["description"] = "Runs Venafi (VaaS and TPP) e2e tests"
+	job.Annotations["description"] = "Runs Venafi (VaaS, TPP, and NGTS) e2e tests"
 
 	job.Labels = make(map[string]string)
 


### PR DESCRIPTION
## Summary

The NGTS E2E tests have never passed in CI. This PR fixes the periodic
job so that NGTS tests are no longer silently skipped.

- Adds `preset-venafi-ngts-credentials` to the periodic Venafi E2E job
  (`ci-cert-manager-master-e2e-v1-35-issuers-venafi`), which previously
  only had TPP and Cloud credential presets.

## Motivation

While investigating the Venafi TPP auth regression
(cert-manager/cert-manager#8843), I triggered the NGTS presubmit for
the first time and discovered two problems:

1. **Expired credentials**: The `venafi-ngts` secret contains credentials
   for `Felix-test-2@1271410543.iam.panserviceaccount.com`, which return
   `invalid_client` from the NGTS OAuth endpoint.

2. **Double-prefixed TSG ID**: The secret's `tsg-id` field was set to
   `tsg_id:1271410543`, but
   [`venaficlient.go`](https://github.com/cert-manager/cert-manager/blob/46c3921db60d078b9d95540220793240438482b1/pkg/issuer/venafi/client/venaficlient.go#L187)
   already prepends `tsg_id:` when building the OAuth scope, resulting in
   `tsg_id:tsg_id:1271410543`. The secret value must be the bare numeric
   TSG ID.

3. **Periodic job skips NGTS**: Without `preset-venafi-ngts-credentials`,
   the periodic job never supplies the NGTS env vars, so all NGTS tests
   skip with "Venafi NGTS TSGID must be set".

The NGTS presubmit was added in #1177 and the credentials were created
by @maelvls, but the test was never actually triggered to verify the
credentials worked. The corresponding cert-manager PR
(cert-manager/cert-manager#8779) was also merged without running the
NGTS presubmit.

## Cluster secret update

The `venafi-ngts` Kubernetes secret in the `test-pods` namespace of the
Prow untrusted cluster has been updated with new credentials on a new
TSG and a corrected TSG ID (bare numeric, no `tsg_id:` prefix).

The NGTS presubmit has been triggered on cert-manager/cert-manager#8843
to verify the new credentials work in CI.

## Test evidence

I verified locally that the new credentials work and the NGTS E2E test
passes:

```
VENAFI_NGTS_TSG_ID="1904192319" \
VENAFI_NGTS_CLIENT_ID="cert-manager-oss-e2e@1904192319.iam.panserviceaccount.com" \
VENAFI_NGTS_CLIENT_SECRET="<redacted>" \
GINKGO_FOCUS="Venafi NGTS Issuer.*should issue a certificate that defines a 2 distinct DNS Names" \
make e2e

Ran 1 of 980 Specs in 44.246 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 979 Skipped
```

*Generated with Claude (Opus 4.6)*