### PR TITLE
Fix cert-manager master required checks

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -100,8 +100,8 @@ branch-protection:
                 contexts:
                 - pull-cert-manager-master-make-verify
                 - pull-cert-manager-master-make-test
-                - pull-cert-manager-master-e2e-v1-35
-                - pull-cert-manager-master-e2e-v1-35-upgrade
+                - pull-cert-manager-master-e2e-v1-36
+                - pull-cert-manager-master-e2e-v1-36-upgrade
         website:
           required_status_checks:
             contexts:


### PR DESCRIPTION
TIL that I missed a few changes in https://github.com/cert-manager/testing/pull/1210. This is currently blocking all cert-manager PRs from being merged. 🙈 