### PR TITLE
fix: exclude CI/CD trust-boundary repos from skip-review Tide queries

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -263,6 +263,10 @@ tide:
   - author: github-actions[bot]
     orgs:
     - cert-manager
+    excludedRepos:
+    - cert-manager/testing        # CI/CD trust boundary: configures prow and trusted-cluster jobs
+    - cert-manager/infrastructure # CI/CD trust boundary: infrastructure configuration
+    - cert-manager/renovate-config # CI/CD trust boundary: shared Renovate preset applied org-wide
     labels:
     - skip-review
     - "dco-signoff: yes"
@@ -276,6 +280,10 @@ tide:
   - author: octo-sts[bot]
     orgs:
     - cert-manager
+    excludedRepos:
+    - cert-manager/testing        # CI/CD trust boundary: configures prow and trusted-cluster jobs
+    - cert-manager/infrastructure # CI/CD trust boundary: infrastructure configuration
+    - cert-manager/renovate-config # CI/CD trust boundary: shared Renovate preset applied org-wide
     labels:
     - skip-review
     - "dco-signoff: yes"
@@ -289,6 +297,10 @@ tide:
   - author: renovate[bot]
     orgs:
     - cert-manager
+    excludedRepos:
+    - cert-manager/testing        # CI/CD trust boundary: configures prow and trusted-cluster jobs
+    - cert-manager/infrastructure # CI/CD trust boundary: infrastructure configuration
+    - cert-manager/renovate-config # CI/CD trust boundary: shared Renovate preset applied org-wide
     labels:
     - skip-review
     - "dco-signoff: yes"


### PR DESCRIPTION
### Summary

  - The three bot Tide queries (github-actions[bot], octo-sts[bot], renovate[bot]) used orgs: [cert-manager] with no excludedRepos, making cert-manager/testing itself eligible for automatic no-review merges. A compromised bot identity could self-apply skip-review, merge a malicious config/jobs/** file, and have config-updater write it into the live job-config ConfigMap on prow-trusted — giving an attacker control of every secret in the trusted cluster with no maintainer notification.
  - Add excludedRepos: [cert-manager/testing, cert-manager/infrastructure, cert-manager/renovate-config] to all three bot Tide queries, scoping automatic merges away from repos that form the CI/CD trust boundary. This mirrors the existing pattern used by the default org query, which already excludes cert-manager/cert-manager.

### Testing

  - Ran checkconfig --strict (the same image used by the pull-testing-config presubmit) against both the pre-fix and post-fix config — both pass, confirming the fix introduces no structural regressions.
  - Ran a [Go scope validator ](https://github.com/user-attachments/files/29377915/main.go.zip) against both configs to confirm: (a) on master all three bot queries have excludedRepos: [] and cert-manager/testing is in scope; (b) on this branch all three queries exclude the three trust-boundary repos.