### PR TITLE
Remove unused Cloudflare e2e credentials

### DIFF
--- a/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
+++ b/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
@@ -79,7 +79,6 @@ presubmits:
       testgrid-create-job-group: "true"
       testgrid-dashboards: cert-manager-presubmits-master
     labels:
-      preset-cloudflare-credentials: "true"
       preset-dind-enabled: "true"
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
@@ -123,7 +122,6 @@ presubmits:
       testgrid-create-job-group: "true"
       testgrid-dashboards: cert-manager-presubmits-master
     labels:
-      preset-cloudflare-credentials: "true"
       preset-dind-enabled: "true"
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
@@ -167,7 +165,6 @@ presubmits:
       testgrid-create-job-group: "true"
       testgrid-dashboards: cert-manager-presubmits-master
     labels:
-      preset-cloudflare-credentials: "true"
       preset-dind-enabled: "true"
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
@@ -211,7 +208,6 @@ presubmits:
       testgrid-create-job-group: "true"
       testgrid-dashboards: cert-manager-presubmits-master
     labels:
-      preset-cloudflare-credentials: "true"
       preset-dind-enabled: "true"
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
@@ -423,7 +419,6 @@ presubmits:
       testgrid-create-job-group: "true"
       testgrid-dashboards: cert-manager-presubmits-master
     labels:
-      preset-cloudflare-credentials: "true"
       preset-dind-enabled: "true"
       preset-disable-all-alpha-beta-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
@@ -469,7 +464,6 @@ presubmits:
       testgrid-dashboards: cert-manager-presubmits-master
     labels:
       preset-bestpractice-install: "true"
-      preset-cloudflare-credentials: "true"
       preset-dind-enabled: "true"
       preset-disable-all-alpha-beta-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
@@ -548,7 +542,6 @@ periodics:
     testgrid-create-job-group: "true"
     testgrid-dashboards: cert-manager-periodics-master
   labels:
-    preset-cloudflare-credentials: "true"
     preset-dind-enabled: "true"
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
@@ -593,7 +586,6 @@ periodics:
     testgrid-create-job-group: "true"
     testgrid-dashboards: cert-manager-periodics-master
   labels:
-    preset-cloudflare-credentials: "true"
     preset-dind-enabled: "true"
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
@@ -638,7 +630,6 @@ periodics:
     testgrid-create-job-group: "true"
     testgrid-dashboards: cert-manager-periodics-master
   labels:
-    preset-cloudflare-credentials: "true"
     preset-dind-enabled: "true"
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
@@ -683,7 +674,6 @@ periodics:
     testgrid-create-job-group: "true"
     testgrid-dashboards: cert-manager-periodics-master
   labels:
-    preset-cloudflare-credentials: "true"
     preset-dind-enabled: "true"
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
@@ -816,7 +806,6 @@ periodics:
     testgrid-dashboards: cert-manager-periodics-master
   labels:
     preset-bestpractice-install: "true"
-    preset-cloudflare-credentials: "true"
     preset-dind-enabled: "true"
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
@@ -861,7 +850,6 @@ periodics:
     testgrid-create-job-group: "true"
     testgrid-dashboards: cert-manager-periodics-master
   labels:
-    preset-cloudflare-credentials: "true"
     preset-dind-enabled: "true"
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
@@ -906,7 +894,6 @@ periodics:
     testgrid-create-job-group: "true"
     testgrid-dashboards: cert-manager-periodics-master
   labels:
-    preset-cloudflare-credentials: "true"
     preset-dind-enabled: "true"
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
@@ -951,7 +938,6 @@ periodics:
     testgrid-create-job-group: "true"
     testgrid-dashboards: cert-manager-periodics-master
   labels:
-    preset-cloudflare-credentials: "true"
     preset-dind-enabled: "true"
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
@@ -996,7 +982,6 @@ periodics:
     testgrid-create-job-group: "true"
     testgrid-dashboards: cert-manager-periodics-master
   labels:
-    preset-cloudflare-credentials: "true"
     preset-dind-enabled: "true"
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-ginkgo-skip-default: "true"

--- a/config/jobs/cert-manager/cert-manager/release-1.20/cert-manager-release-1.20.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.20/cert-manager-release-1.20.yaml
@@ -70,7 +70,6 @@ presubmits:
     annotations:
       description: Runs the end-to-end test suite against a Kubernetes v1.32 cluster
     labels:
-      preset-cloudflare-credentials: "true"
       preset-dind-enabled: "true"
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
@@ -111,7 +110,6 @@ presubmits:
     annotations:
       description: Runs the end-to-end test suite against a Kubernetes v1.33 cluster
     labels:
-      preset-cloudflare-credentials: "true"
       preset-dind-enabled: "true"
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
@@ -152,7 +150,6 @@ presubmits:
     annotations:
       description: Runs the end-to-end test suite against a Kubernetes v1.34 cluster
     labels:
-      preset-cloudflare-credentials: "true"
       preset-dind-enabled: "true"
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
@@ -193,7 +190,6 @@ presubmits:
     annotations:
       description: Runs the end-to-end test suite against a Kubernetes v1.35 cluster
     labels:
-      preset-cloudflare-credentials: "true"
       preset-dind-enabled: "true"
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
@@ -390,7 +386,6 @@ presubmits:
     annotations:
       description: Runs the E2E tests with all feature gates disabled
     labels:
-      preset-cloudflare-credentials: "true"
       preset-dind-enabled: "true"
       preset-disable-all-alpha-beta-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
@@ -433,7 +428,6 @@ presubmits:
         https://cert-manager.io/docs/installation/best-practice/
     labels:
       preset-bestpractice-install: "true"
-      preset-cloudflare-credentials: "true"
       preset-dind-enabled: "true"
       preset-disable-all-alpha-beta-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
@@ -512,7 +506,6 @@ periodics:
     testgrid-create-job-group: "true"
     testgrid-dashboards: cert-manager-periodics-release-1.20
   labels:
-    preset-cloudflare-credentials: "true"
     preset-dind-enabled: "true"
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
@@ -557,7 +550,6 @@ periodics:
     testgrid-create-job-group: "true"
     testgrid-dashboards: cert-manager-periodics-release-1.20
   labels:
-    preset-cloudflare-credentials: "true"
     preset-dind-enabled: "true"
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
@@ -602,7 +594,6 @@ periodics:
     testgrid-create-job-group: "true"
     testgrid-dashboards: cert-manager-periodics-release-1.20
   labels:
-    preset-cloudflare-credentials: "true"
     preset-dind-enabled: "true"
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
@@ -647,7 +638,6 @@ periodics:
     testgrid-create-job-group: "true"
     testgrid-dashboards: cert-manager-periodics-release-1.20
   labels:
-    preset-cloudflare-credentials: "true"
     preset-dind-enabled: "true"
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
@@ -780,7 +770,6 @@ periodics:
     testgrid-dashboards: cert-manager-periodics-release-1.20
   labels:
     preset-bestpractice-install: "true"
-    preset-cloudflare-credentials: "true"
     preset-dind-enabled: "true"
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
@@ -825,7 +814,6 @@ periodics:
     testgrid-create-job-group: "true"
     testgrid-dashboards: cert-manager-periodics-release-1.20
   labels:
-    preset-cloudflare-credentials: "true"
     preset-dind-enabled: "true"
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
@@ -870,7 +858,6 @@ periodics:
     testgrid-create-job-group: "true"
     testgrid-dashboards: cert-manager-periodics-release-1.20
   labels:
-    preset-cloudflare-credentials: "true"
     preset-dind-enabled: "true"
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
@@ -915,7 +902,6 @@ periodics:
     testgrid-create-job-group: "true"
     testgrid-dashboards: cert-manager-periodics-release-1.20
   labels:
-    preset-cloudflare-credentials: "true"
     preset-dind-enabled: "true"
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
@@ -960,7 +946,6 @@ periodics:
     testgrid-create-job-group: "true"
     testgrid-dashboards: cert-manager-periodics-release-1.20
   labels:
-    preset-cloudflare-credentials: "true"
     preset-dind-enabled: "true"
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-ginkgo-skip-default: "true"

--- a/config/jobs/cert-manager/cert-manager/release-1.21/cert-manager-release-1.21.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.21/cert-manager-release-1.21.yaml
@@ -70,7 +70,6 @@ presubmits:
     annotations:
       description: Runs the end-to-end test suite against a Kubernetes v1.33 cluster
     labels:
-      preset-cloudflare-credentials: "true"
       preset-dind-enabled: "true"
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
@@ -111,7 +110,6 @@ presubmits:
     annotations:
       description: Runs the end-to-end test suite against a Kubernetes v1.34 cluster
     labels:
-      preset-cloudflare-credentials: "true"
       preset-dind-enabled: "true"
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
@@ -152,7 +150,6 @@ presubmits:
     annotations:
       description: Runs the end-to-end test suite against a Kubernetes v1.35 cluster
     labels:
-      preset-cloudflare-credentials: "true"
       preset-dind-enabled: "true"
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
@@ -193,7 +190,6 @@ presubmits:
     annotations:
       description: Runs the end-to-end test suite against a Kubernetes v1.36 cluster
     labels:
-      preset-cloudflare-credentials: "true"
       preset-dind-enabled: "true"
       preset-enable-all-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
@@ -390,7 +386,6 @@ presubmits:
     annotations:
       description: Runs the E2E tests with all feature gates disabled
     labels:
-      preset-cloudflare-credentials: "true"
       preset-dind-enabled: "true"
       preset-disable-all-alpha-beta-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
@@ -433,7 +428,6 @@ presubmits:
         https://cert-manager.io/docs/installation/best-practice/
     labels:
       preset-bestpractice-install: "true"
-      preset-cloudflare-credentials: "true"
       preset-dind-enabled: "true"
       preset-disable-all-alpha-beta-feature-gates: "true"
       preset-ginkgo-skip-default: "true"
@@ -512,7 +506,6 @@ periodics:
     testgrid-create-job-group: "true"
     testgrid-dashboards: cert-manager-periodics-release-1.21
   labels:
-    preset-cloudflare-credentials: "true"
     preset-dind-enabled: "true"
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
@@ -557,7 +550,6 @@ periodics:
     testgrid-create-job-group: "true"
     testgrid-dashboards: cert-manager-periodics-release-1.21
   labels:
-    preset-cloudflare-credentials: "true"
     preset-dind-enabled: "true"
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
@@ -602,7 +594,6 @@ periodics:
     testgrid-create-job-group: "true"
     testgrid-dashboards: cert-manager-periodics-release-1.21
   labels:
-    preset-cloudflare-credentials: "true"
     preset-dind-enabled: "true"
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
@@ -647,7 +638,6 @@ periodics:
     testgrid-create-job-group: "true"
     testgrid-dashboards: cert-manager-periodics-release-1.21
   labels:
-    preset-cloudflare-credentials: "true"
     preset-dind-enabled: "true"
     preset-enable-all-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
@@ -780,7 +770,6 @@ periodics:
     testgrid-dashboards: cert-manager-periodics-release-1.21
   labels:
     preset-bestpractice-install: "true"
-    preset-cloudflare-credentials: "true"
     preset-dind-enabled: "true"
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
@@ -825,7 +814,6 @@ periodics:
     testgrid-create-job-group: "true"
     testgrid-dashboards: cert-manager-periodics-release-1.21
   labels:
-    preset-cloudflare-credentials: "true"
     preset-dind-enabled: "true"
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
@@ -870,7 +858,6 @@ periodics:
     testgrid-create-job-group: "true"
     testgrid-dashboards: cert-manager-periodics-release-1.21
   labels:
-    preset-cloudflare-credentials: "true"
     preset-dind-enabled: "true"
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
@@ -915,7 +902,6 @@ periodics:
     testgrid-create-job-group: "true"
     testgrid-dashboards: cert-manager-periodics-release-1.21
   labels:
-    preset-cloudflare-credentials: "true"
     preset-dind-enabled: "true"
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-ginkgo-skip-default: "true"
@@ -960,7 +946,6 @@ periodics:
     testgrid-create-job-group: "true"
     testgrid-dashboards: cert-manager-periodics-release-1.21
   labels:
-    preset-cloudflare-credentials: "true"
     preset-dind-enabled: "true"
     preset-disable-all-alpha-beta-feature-gates: "true"
     preset-ginkgo-skip-default: "true"

--- a/config/jobs/cert-manager/config.yaml
+++ b/config/jobs/cert-manager/config.yaml
@@ -7,25 +7,6 @@ presets:
     value: TRUE
 
 - labels:
-    preset-cloudflare-credentials: "true"
-  env:
-  - name: CLOUDFLARE_E2E_API_TOKEN
-    valueFrom:
-      secretKeyRef:
-        name: cloudflare-api-key
-        key: api-token
-  - name: CLOUDFLARE_E2E_EMAIL
-    valueFrom:
-      secretKeyRef:
-        name: cloudflare-api-key
-        key: email
-  - name: CLOUDFLARE_E2E_DOMAIN
-    valueFrom:
-      secretKeyRef:
-        name: cloudflare-api-key
-        key: domain
-
-- labels:
     preset-venafi-tpp-credentials: "true"
   env:
   - name: VENAFI_TPP_URL

--- a/config/prowgen/pkg/configurers.go
+++ b/config/prowgen/pkg/configurers.go
@@ -68,10 +68,6 @@ func addDindLabel(job *Job) {
 	job.Labels["preset-dind-enabled"] = "true"
 }
 
-func addCloudflareCredentialsLabel(job *Job) {
-	job.Labels["preset-cloudflare-credentials"] = "true"
-}
-
 func addRetryFlakesLabel(job *Job) {
 	job.Labels["preset-retry-flakey-jobs"] = "true"
 }

--- a/config/prowgen/pkg/generators.go
+++ b/config/prowgen/pkg/generators.go
@@ -137,7 +137,6 @@ func E2ETest(ctx *ProwContext, k8sVersion string, cpuRequest, memoryRequest stri
 		"e2e-v"+nameVersion,
 		desc,
 		addDindLabel,
-		addCloudflareCredentialsLabel,
 		addLocalCacheLabel,
 		addGoCacheLabel,
 		addStandardE2ELabels(k8sVersion),
@@ -264,7 +263,6 @@ func E2ETestFeatureGatesDisabled(ctx *ProwContext, k8sVersion string, cpuRequest
 
 	job.Labels = make(map[string]string)
 
-	addCloudflareCredentialsLabel(job)
 	addDindLabel(job)
 	addDisableFeatureGatesLabel(job)
 	addGinkgoSkipDefaultLabel(job)
@@ -286,7 +284,6 @@ func E2ETestWithBestPracticeInstall(ctx *ProwContext, k8sVersion string, cpuRequ
 
 	job.Labels = make(map[string]string)
 
-	addCloudflareCredentialsLabel(job)
 	addDindLabel(job)
 	addDisableFeatureGatesLabel(job)
 	addGinkgoSkipDefaultLabel(job)


### PR DESCRIPTION
## What

Removes the `preset-cloudflare-credentials` preset and the prowgen wiring that attaches it to the e2e jobs.

## Why

The Cloudflare API credential is only consumed by the **"Public ACME Server"** conformance tests, and those are unconditionally skipped whenever the e2e suite runs against the in-cluster **pebble** ACME server — which is always the case in CI (`test/e2e/suite/conformance/certificates/tests.go` skips them with *"Not running public ACME tests against local cluster"*).

The effect is visible in any recent run. For example a passing `pull-cert-manager-master-e2e-v1-36`:

```
Ran 843 of 994 Specs
SUCCESS! -- 843 Passed | 0 Failed | 151 Skipped
```

The Cloudflare specs are among the 151 skipped, and the string `cloudflare` never appears in the log. The same is true for the periodics. So the credential provides **no test coverage in any job**, presubmit or periodic — it is dead weight that has been carried since the repo's first job-config import in 2018.

## Follow-up

The `cloudflare-api-key` Secret in the jobs' cluster is now unreferenced and can be deleted separately.

## Testing

`make verify-prowgen`, `make verify-boilerplate` and `checkconfig --strict` all pass.

*with claude opus-4.8*